### PR TITLE
Add the ReviewsListTable class

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -17,9 +17,11 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	public function prepare_items() {
 
-		$comments = get_comments( [
-			'post_type'  => 'product',
-		] );
+		$comments = get_comments(
+			[
+				'post_type'  => 'product',
+			]
+		);
 
 		update_comment_cache( $comments );
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Product > Reviews
+ */
+
+namespace Automattic\WooCommerce\Internal\Admin;
+
+use WP_List_Table;
+
+/**
+ * Handles the Product Reviews page.
+ */
+class ReviewsListTable extends WP_List_Table {
+
+}

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -12,4 +12,18 @@ use WP_List_Table;
  */
 class ReviewsListTable extends WP_List_Table {
 
+	/**
+	 * Prepare reviews for display
+	 */
+	public function prepare_items() {
+
+		$comments = get_comments( [
+			'post_type'  => 'product',
+		] );
+
+		update_comment_cache( $comments );
+
+		$this->items = $comments;
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin;
+
+use WC_Unit_Test_Case;
+
+/**
+ * Tests that product reviews page handler.
+ *
+ * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable
+ */
+class ReviewsListTableTest extends WC_Unit_Test_Case {
+
+}


### PR DESCRIPTION
## Summary

Adds a `ReviewsListTable` to handle the Product Reviews page output.

## Story: [MWC-5329](https://jira.godaddy.com/browse/MWC-5329)

## Details

For now the `prepare_items` method should be regarded as a stub. I realized that it would make it much easier to handle pagination and other elements once the product reviews page can be output in the WordPress admin. I have added [a new story](https://jira.godaddy.com/browse/MWC-5377) for this.

As mentioned in the Slack channel, I don't see a proper way to test `prepare_items` with "unit" tests for now, since all it does is calling internal WordPress functions, but there's no `WP_Mock` or `Mockery` available, and the tests seem supposed to run in a live WP instance. [See discussion](https://godaddy.slack.com/archives/C02PYQALB2Q/p1649733892107819?thread_ts=1649706830.857429&cid=C02PYQALB2Q).

## QA

- [x] Code review