### PR TITLE
Move Product Reviews to a Products > Reviews page

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/reviews/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/reviews/index.js
@@ -294,7 +294,7 @@ class ReviewsPanel extends Component {
 				{ renderedReviews }
 				<Link
 					href={ getAdminLink(
-						'edit-comments.php?comment_type=review'
+						'edit.php?post_type=product&page=product-reviews'
 					) }
 					onClick={ () => this.recordReviewEvent( 'reviews_manage' ) }
 					className="woocommerce-layout__activity-panel-outbound-link woocommerce-layout__activity-panel-empty"

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -169,11 +169,19 @@ class WC_Admin_Notices {
 				wp_die( esc_html__( 'Action failed. Please refresh the page and retry.', 'woocommerce' ) );
 			}
 
-			if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			$hide_notice = sanitize_text_field( wp_unslash( $_GET['wc-hide-notice'] ) ); // WPCS: input var ok, CSRF ok.
+
+			/**
+			 * Filter the capability required to dismiss a given notice.
+			 *
+			 * @param string $default_capability The default required capability.
+			 * @param string $hide_notice The notice ID.
+			 */
+			$required_capability = apply_filters( 'woocommerce_dismiss_notice_capability', 'manage_woocommerce', $hide_notice );
+
+			if ( ! current_user_can( $required_capability ) ) {
 				wp_die( esc_html__( 'You don&#8217;t have permission to do this.', 'woocommerce' ) );
 			}
-
-			$hide_notice = sanitize_text_field( wp_unslash( $_GET['wc-hide-notice'] ) ); // WPCS: input var ok, CSRF ok.
 
 			self::hide_notice( $hide_notice );
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -169,28 +169,28 @@ class WC_Admin_Notices {
 				wp_die( esc_html__( 'Action failed. Please refresh the page and retry.', 'woocommerce' ) );
 			}
 
-			$hide_notice = sanitize_text_field( wp_unslash( $_GET['wc-hide-notice'] ) ); // WPCS: input var ok, CSRF ok.
+			$notice_name = sanitize_text_field( wp_unslash( $_GET['wc-hide-notice'] ) ); // WPCS: input var ok, CSRF ok.
 
 			/**
 			 * Filter the capability required to dismiss a given notice.
 			 *
 			 * @param string $default_capability The default required capability.
-			 * @param string $hide_notice The notice ID.
+			 * @param string $notice_name The notice name.
 			 */
-			$required_capability = apply_filters( 'woocommerce_dismiss_notice_capability', 'manage_woocommerce', $hide_notice );
+			$required_capability = apply_filters( 'woocommerce_dismiss_notice_capability', 'manage_woocommerce', $notice_name );
 
 			if ( ! current_user_can( $required_capability ) ) {
 				wp_die( esc_html__( 'You don&#8217;t have permission to do this.', 'woocommerce' ) );
 			}
 
-			self::hide_notice( $hide_notice );
+			self::hide_notice( $notice_name );
 		}
 	}
 
 	/**
 	 * Hide a single notice.
 	 *
-	 * @param $name Notice name.
+	 * @param string $name Notice name.
 	 */
 	private static function hide_notice( $name ) {
 		self::remove_notice( $name );
@@ -500,9 +500,9 @@ class WC_Admin_Notices {
 	 */
 	public static function download_directories_sync_complete() {
 		$notice_dismissed = apply_filters(
-				'woocommerce_hide_download_directories_sync_complete',
-				get_user_meta( get_current_user_id(), 'download_directories_sync_complete', true )
-			);
+			'woocommerce_hide_download_directories_sync_complete',
+			get_user_meta( get_current_user_id(), 'download_directories_sync_complete', true )
+		);
 
 		if ( $notice_dismissed ) {
 			self::remove_notice( 'download_directories_sync_complete' );

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -29,6 +29,7 @@ function wc_get_screen_ids() {
 		'product_page_product_attributes',
 		'product_page_product_exporter',
 		'product_page_product_importer',
+		'product_page_product-reviews',
 		'edit-product',
 		'product',
 		'edit-shop_coupon',

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -36,7 +36,7 @@ class WC_Comments {
 		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_webhook_comments' ), 10, 1 );
 		add_filter( 'comment_feed_where', array( __CLASS__, 'exclude_webhook_comments_from_feed_where' ) );
 
-		// Secure product reviews.
+		// Exclude product reviews.
 		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_product_reviews' ), 10, 1 );
 
 		// Count comments.

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -244,7 +244,8 @@ class WC_Comments {
 					"
 					SELECT comment_approved, COUNT(*) AS num_comments
 					FROM {$wpdb->comments}
-					WHERE comment_type NOT IN ('action_log', 'order_note', 'webhook_delivery')
+					LEFT JOIN {$wpdb->posts} ON comment_post_ID = {$wpdb->posts}.ID
+					WHERE comment_type NOT IN ('action_log', 'order_note', 'webhook_delivery') AND {$wpdb->posts}.post_type NOT IN ('product')
 					GROUP BY comment_approved
 					",
 					ARRAY_A

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -241,7 +241,7 @@ class WC_Comments {
 	}
 
 	/**
-	 * Remove order notes and webhook delivery logs from wp_count_comments().
+	 * Remove order notes, webhook delivery logs, and product reviews from wp_count_comments().
 	 *
 	 * @since  2.2
 	 * @param  object $stats   Comment stats.

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -36,6 +36,9 @@ class WC_Comments {
 		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_webhook_comments' ), 10, 1 );
 		add_filter( 'comment_feed_where', array( __CLASS__, 'exclude_webhook_comments_from_feed_where' ) );
 
+		// Secure product reviews.
+		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_product_reviews' ), 10, 1 );
+
 		// Count comments.
 		add_filter( 'wp_count_comments', array( __CLASS__, 'wp_count_comments' ), 10, 2 );
 
@@ -72,6 +75,23 @@ class WC_Comments {
 			$open = false;
 		}
 		return $open;
+	}
+
+	/**
+	 * Removes product reviews from the edit-comments page to fix the "Mine" tab counter.
+	 *
+	 * @param  array $clauses A compacted array of comment query clauses.
+	 * @return array
+	 */
+	public static function exclude_product_reviews( $clauses ) {
+		global $wpdb, $current_screen;
+
+		if ( isset( $current_screen->base ) && 'edit-comments' === $current_screen->base ) {
+			$clauses['join']  .= " LEFT JOIN {$wpdb->posts} AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID ";
+			$clauses['where'] .= ( $clauses['where'] ? ' AND ' : '' ) . " wp_posts_to_exclude_reviews.post_type NOT IN ('product') ";
+		}
+
+		return $clauses;
 	}
 
 	/**

--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -7859,3 +7859,7 @@ table.bar_chart {
 		}
 	}
 }
+
+.product-reviews th.column-type {
+	width: 10%;
+}

--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -7871,10 +7871,17 @@ table.bar_chart {
 
 	@media screen and (max-width: 782px) {
 
-		.column-type,
-		.column-author,
-		.column-rating {
+		th.column-type,
+		td.column-type,
+		th.column-author,
+		td.column-author,
+		th.column-rating,
+		td.column-rating {
 			display: none !important;
+		}
+
+		.toggle-row {
+			top: 10px;
 		}
 	}
 }

--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -7860,6 +7860,12 @@ table.bar_chart {
 	}
 }
 
-.product-reviews th.column-type {
-	width: 10%;
+/**
+  * Product Reviews
+  */
+.wp-list-table.product-reviews {
+
+	th.column-type {
+		width: 10%;
+	}
 }

--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -7859,3 +7859,18 @@ table.bar_chart {
 		}
 	}
 }
+
+/**
+  * Product Reviews
+  */
+.wp-list-table.product-reviews {
+
+	@media screen and (max-width: 782px) {
+
+		.column-type,
+		.column-author,
+		.column-rating {
+			display: none !important;
+		}
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -11,7 +11,7 @@ namespace Automattic\WooCommerce\Internal\Admin;
 class Reviews {
 
 	/**
-	 * Admin page identifier.
+	 * Admin page identifier. (test with commit)
 	 */
 	const MENU_SLUG = 'product-reviews';
 

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -70,7 +70,7 @@ class Reviews {
 		 * @param string $capability The capability (defaults to `moderate_comments`).
 		 * @param string $context    The context for which the capability is needed.
 		 */
-		return apply_filters( 'woocommerce_view_product_reviews_page_capability', 'moderate_comments', $context );
+		return apply_filters( 'woocommerce_product_reviews_page_capability', 'moderate_comments', $context );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -68,7 +68,7 @@ class Reviews {
 		 *
 		 * @param string $capability The capability (defaults to `moderate_comments`).
 		 */
-		return apply_filters( 'woocommerce_manage_product_reviews_page_view_capability', 'moderate_comments' );
+		return apply_filters( 'woocommerce_view_product_reviews_page_capability', 'moderate_comments' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -57,6 +57,21 @@ class Reviews {
 	}
 
 	/**
+	 * Gets the required capability to access the reviews page and manage product reviews.
+	 *
+	 * @return string
+	 */
+	public static function get_capability() {
+
+		/**
+		 * Filters whether the current user can manage product reviews.
+		 *
+		 * @param string $capability The capability (defaults to `moderate_comments`).
+		 */
+		return apply_filters( 'woocommerce_manage_product_reviews_capability', 'moderate_comments' );
+	}
+
+	/**
 	 * Registers the Product Reviews submenu page.
 	 *
 	 * @return void
@@ -66,7 +81,7 @@ class Reviews {
 			'edit.php?post_type=product',
 			__( 'Reviews', 'woocommerce' ),
 			__( 'Reviews', 'woocommerce' ) . $this->get_pending_count_bubble(),
-			'moderate_comments',
+			static::get_capability(),
 			static::MENU_SLUG,
 			[ $this, 'render_reviews_list_table' ]
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -96,6 +96,18 @@ class Reviews {
 			$this->maybe_display_reviews_bulk_action_notice();
 		}
 	}
+
+	/**
+	 * May display the bulk action admin notice.
+	 *
+	 * @return void
+	 */
+	public function maybe_display_reviews_bulk_action_notice() {
+
+		$messages = $this->get_bulk_action_notice_messages();
+
+		echo ! empty( $messages ) ? '<div id="moderated" class="updated"><p>' . implode( "<br/>\n", $messages ) . '</p></div>' : '';  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
 	/**
 	 * Counts the number of pending product reviews/replies, and returns the notification bubble if there's more than zero.
 	 *

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -81,6 +81,7 @@ class Reviews {
 	 */
 	public function load_reviews_screen() {
 		$this->reviews_list_table = new ReviewsListTable( [ 'screen' => $this->reviews_page_hook ] );
+		$this->reviews_list_table->process_bulk_action();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -104,7 +104,7 @@ class Reviews {
 	 *
 	 * @return void
 	 */
-	public function maybe_display_reviews_bulk_action_notice() {
+	protected function maybe_display_reviews_bulk_action_notice() {
 
 		$messages = $this->get_bulk_action_notice_messages();
 

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -225,11 +225,9 @@ class Reviews {
 	 * @return string
 	 */
 	public function edit_review_parent_file( $parent_file ) {
-		global $submenu_file;
+		global $submenu_file, $current_screen;
 
-		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-
-		if ( $screen && 'comment' === $screen->id && isset( $_GET['c'] ) ) {
+		if ( isset( $current_screen->id, $_GET['c'] ) && 'comment' === $current_screen->id ) {
 
 			$comment_id = absint( $_GET['c'] );
 			$comment = get_comment( $comment_id );

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -42,6 +42,7 @@ class Reviews {
 	 * Constructor.
 	 */
 	public function __construct() {
+
 		add_action( 'admin_menu', [ $this, 'add_reviews_page' ] );
 
 		add_action( 'admin_notices', [ $this, 'display_notices' ] );
@@ -107,7 +108,7 @@ class Reviews {
 	public function is_reviews_page() : bool {
 		global $current_screen;
 
-		return isset( $current_screen->base ) && 'product_page_product-reviews' === $current_screen->base;
+		return isset( $current_screen->base ) && 'product_page_' . static::MENU_SLUG === $current_screen->base;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -158,6 +158,11 @@ class Reviews {
 			$messages[] = sprintf( _n( '%s comment restored from the Trash', '%s comments restored from the Trash', $untrashed, 'woocommerce' ), $untrashed );
 		}
 
+		if ( $deleted > 0 ) {
+			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
+			$messages[] = sprintf( _n( '%s comment permanently deleted', '%s comments permanently deleted', $deleted, 'woocommerce' ), $deleted );
+		}
+
 		return $messages;
 	}
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -48,7 +48,7 @@ class Reviews {
 	 *
 	 * @return Reviews instance
 	 */
-	public static function get_instance(): ?Reviews {
+	public static function get_instance() {
 		if ( null === self::$instance ) {
 			self::$instance = new self();
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -234,11 +234,11 @@ class Reviews {
 			$comment_id = absint( $_GET['c'] );
 			$comment = get_comment( $comment_id );
 
-			if ( $comment->comment_parent > 0 ) {
+			if ( isset( $comment->comment_parent ) && $comment->comment_parent > 0 ) {
 				$comment = get_comment( $comment->comment_parent );
 			}
 
-			if ( $comment && 'product' === get_post_type( $comment->comment_post_ID ) ) {
+			if ( isset( $comment->comment_post_ID ) && 'product' === get_post_type( $comment->comment_post_ID ) ) {
 				$parent_file  = 'edit.php?post_type=product';
 				$submenu_file = 'product-reviews'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			}

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -213,8 +213,8 @@ class Reviews {
 	public function handle_reply_to_review(): void {
 		check_ajax_referer( 'replyto-comment', '_ajax_nonce-replyto-comment' );
 
-		$reply_post_id = isset( $_POST['comment_post_ID'] ) ? (int) sanitize_text_field( wp_unslash( $_POST['comment_post_ID'] ) ) : 0;
-		$post          = get_post( $reply_post_id );
+		$comment_post_ID = isset( $_POST['comment_post_ID'] ) ? (int) sanitize_text_field( wp_unslash( $_POST['comment_post_ID'] ) ) : 0; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$post            = get_post( $comment_post_ID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 		if ( ! $post ) {
 			wp_die( -1 );
@@ -230,7 +230,7 @@ class Reviews {
 			return;
 		}
 
-		if ( ! current_user_can( 'edit_post', $reply_post_id ) ) {
+		if ( ! current_user_can( 'edit_post', $comment_post_ID ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 			wp_die( -1 );
 		}
 
@@ -277,13 +277,13 @@ class Reviews {
 		}
 
 		$comment_auto_approved = false;
-		$commentdata           = compact( 'reply_post_id', 'comment_author', 'comment_author_email', 'comment_author_url', 'comment_content', 'comment_type', 'comment_parent', 'user_ID' );
+		$commentdata           = compact( 'comment_post_ID', 'comment_author', 'comment_author_email', 'comment_author_url', 'comment_content', 'comment_type', 'comment_parent', 'user_ID' );
 
 		// Automatically approve parent comment.
 		if ( ! empty( $_POST['approve_parent'] ) ) {
 			$parent = get_comment( $comment_parent );
 
-			if ( $parent && '0' === $parent->comment_approved && $parent->comment_post_ID == $reply_post_id ) {
+			if ( $parent && '0' === $parent->comment_approved && $parent->comment_post_ID == $comment_post_ID ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 				if ( ! current_user_can( 'edit_comment', $parent->comment_ID ) ) {
 					wp_die( -1 );
 				}

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -262,7 +262,7 @@ class Reviews {
 			return $translation;
 		}
 
-		// Try to get comment from query params.
+		// Try to get comment from query params when not in context already.
 		if ( ! $comment && isset( $_GET['action'], $_GET['c'] ) && 'editcomment' === $_GET['action'] ) {
 			$comment_id = absint( $_GET['c'] );
 			$comment    = get_comment( $comment_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -147,6 +147,12 @@ class Reviews {
 			$messages[] = sprintf( _n( '%s comment restored from the spam', '%s comments restored from the spam', $unspammed, 'woocommerce' ), $unspammed );
 		}
 
+		if ( $trashed > 0 ) {
+			$ids = isset( $_REQUEST['ids'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ids'] ) ) : 0;
+			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
+			$messages[] = sprintf( _n( '%s comment moved to the Trash.', '%s comments moved to the Trash.', $trashed, 'woocommerce' ), $trashed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=untrash&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
+		}
+
 		return $messages;
 	}
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -153,6 +153,11 @@ class Reviews {
 			$messages[] = sprintf( _n( '%s comment moved to the Trash.', '%s comments moved to the Trash.', $trashed, 'woocommerce' ), $trashed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=untrash&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
 		}
 
+		if ( $untrashed > 0 ) {
+			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
+			$messages[] = sprintf( _n( '%s comment restored from the Trash', '%s comments restored from the Trash', $untrashed, 'woocommerce' ), $untrashed );
+		}
+
 		return $messages;
 	}
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -61,14 +61,14 @@ class Reviews {
 	 *
 	 * @return string
 	 */
-	public static function get_capability() {
+	public static function get_view_page_capability() {
 
 		/**
 		 * Filters whether the current user can manage product reviews.
 		 *
 		 * @param string $capability The capability (defaults to `moderate_comments`).
 		 */
-		return apply_filters( 'woocommerce_manage_product_reviews_capability', 'moderate_comments' );
+		return apply_filters( 'woocommerce_manage_product_reviews_page_view_capability', 'moderate_comments' );
 	}
 
 	/**
@@ -81,7 +81,7 @@ class Reviews {
 			'edit.php?post_type=product',
 			__( 'Reviews', 'woocommerce' ),
 			__( 'Reviews', 'woocommerce' ) . $this->get_pending_count_bubble(),
-			static::get_capability(),
+			static::get_view_page_capability(),
 			static::MENU_SLUG,
 			[ $this, 'render_reviews_list_table' ]
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -145,8 +145,15 @@ class Reviews {
 	}
 
 	/**
-	 * Ajax callback for editing a review. This is based on {@see wp_ajax_edit_comment()}, and is designed to run
-	 * before that callback so we can override the rendering for a review.
+	 * Ajax callback for editing a review.
+	 *
+	 * This functionality is taken from {@see wp_ajax_edit_comment()} and is largely copy and pasted. The only thing
+	 * we want to change is the review row HTML in the response. WordPress core uses a comment list table and we need
+	 * to use our own {@see ReviewsListTable} class to support our custom columns.
+	 *
+	 * This ajax callback is registered with a lower priority than WordPress core's so that our code can run
+	 * first. If the supplied comment ID is not a review or a reply to a review, then we `return` early from this method
+	 * to allow the WordPress core callback to take over.
 	 *
 	 * @return void
 	 */
@@ -205,8 +212,15 @@ class Reviews {
 	}
 
 	/**
-	 * Ajax callback for replying to a review inline. This is based on {@see wp_ajax_replyto_comment()}, and is designed
-	 * to run before that callback so we can override the rendering for a review reply.
+	 * Ajax callback for replying to a review inline.
+	 *
+	 * This functionality is taken from {@see wp_ajax_replyto_comment()} and is largely copy and pasted. The only thing
+	 * we want to change is the review row HTML in the response. WordPress core uses a comment list table and we need
+	 * to use our own {@see ReviewsListTable} class to support our custom columns.
+	 *
+	 * This ajax callback is registered with a lower priority than WordPress core's so that our code can run
+	 * first. If the supplied comment ID is not a review or a reply to a review, then we `return` early from this method
+	 * to allow the WordPress core callback to take over.
 	 *
 	 * @return void
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -116,7 +116,7 @@ class Reviews {
 	 *
 	 * @return array
 	 */
-	public function get_bulk_action_notice_messages() : array {
+	protected function get_bulk_action_notice_messages() : array {
 
 		$approved   = isset( $_REQUEST['approved'] ) ? (int) $_REQUEST['approved'] : 0;
 		$unapproved = isset( $_REQUEST['unapproved'] ) ? (int) $_REQUEST['unapproved'] : 0;
@@ -167,6 +167,7 @@ class Reviews {
 
 		return $messages;
 	}
+
 	/**
 	 * Counts the number of pending product reviews/replies, and returns the notification bubble if there's more than zero.
 	 *

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -76,7 +76,7 @@ class Reviews {
 	/**
 	 * Gets the required capability to access the reviews page and manage product reviews.
 	 *
-	 * @param string $context The context for which the capability is needed.
+	 * @param string $context The context for which the capability is needed.  (e.g. `view` or `moderate`)
 	 * @return string
 	 */
 	public static function get_capability( $context = 'view' ) {

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -59,16 +59,17 @@ class Reviews {
 	/**
 	 * Gets the required capability to access the reviews page and manage product reviews.
 	 *
+	 * @param string $context The context for which the capability is needed.
 	 * @return string
 	 */
-	public static function get_view_page_capability() {
+	public static function get_view_page_capability( $context = 'view' ) {
 
 		/**
 		 * Filters whether the current user can manage product reviews.
 		 *
 		 * @param string $capability The capability (defaults to `moderate_comments`).
 		 */
-		return apply_filters( 'woocommerce_view_product_reviews_page_capability', 'moderate_comments' );
+		return apply_filters( 'woocommerce_view_product_reviews_page_capability', 'moderate_comments', $context );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -116,6 +116,14 @@ class Reviews {
 	 */
 	public function get_bulk_action_notice_messages() : array {
 
+		$approved   = isset( $_REQUEST['approved'] ) ? (int) $_REQUEST['approved'] : 0;
+		$unapproved = isset( $_REQUEST['unapproved'] ) ? (int) $_REQUEST['unapproved'] : 0;
+		$deleted    = isset( $_REQUEST['deleted'] ) ? (int) $_REQUEST['deleted'] : 0;
+		$trashed    = isset( $_REQUEST['trashed'] ) ? (int) $_REQUEST['trashed'] : 0;
+		$untrashed  = isset( $_REQUEST['untrashed'] ) ? (int) $_REQUEST['untrashed'] : 0;
+		$spammed    = isset( $_REQUEST['spammed'] ) ? (int) $_REQUEST['spammed'] : 0;
+		$unspammed  = isset( $_REQUEST['unspammed'] ) ? (int) $_REQUEST['unspammed'] : 0;
+
 		$messages = [];
 
 		return $messages;

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -76,7 +76,7 @@ class Reviews {
 	/**
 	 * Gets the required capability to access the reviews page and manage product reviews.
 	 *
-	 * @param string $context The context for which the capability is needed.  (e.g. `view` or `moderate`)
+	 * @param string $context The context for which the capability is needed (e.g. `view` or `moderate`).
 	 * @return string
 	 */
 	public static function get_capability( $context = 'view' ) {
@@ -265,7 +265,7 @@ class Reviews {
 			$comment_author       = wp_slash( $user->display_name );
 			$comment_author_email = wp_slash( $user->user_email );
 			$comment_author_url   = wp_slash( $user->user_url );
-			// WordPress core already sanitizes `content` during the `pre_comment_content` hook, which is why it's not needed here.  {@see wp_filter_comment()} and {@see kses_init_filters()}
+			// WordPress core already sanitizes `content` during the `pre_comment_content` hook, which is why it's not needed here, {@see wp_filter_comment()} and {@see kses_init_filters()}.
 			$comment_content      = isset( $_POST['content'] ) ? wp_unslash( $_POST['content'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$comment_type         = isset( $_POST['comment_type'] ) ? sanitize_text_field( wp_unslash( $_POST['comment_type'] ) ) : 'comment';
 

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -65,13 +65,35 @@ class Reviews {
 		$this->reviews_page_hook = add_submenu_page(
 			'edit.php?post_type=product',
 			__( 'Reviews', 'woocommerce' ),
-			__( 'Reviews', 'woocommerce' ),
+			__( 'Reviews', 'woocommerce' ) . $this->get_pending_count_bubble(),
 			'moderate_comments',
 			static::MENU_SLUG,
 			[ $this, 'render_reviews_list_table' ]
 		);
 
 		add_action( "load-{$this->reviews_page_hook}", [ $this, 'load_reviews_screen' ] );
+	}
+
+	/**
+	 * Counts the number of pending product reviews/replies, and returns the notification bubble if there's more than zero.
+	 *
+	 * @return string Empty string if there are no pending reviews, or bubble HTML if there are.
+	 */
+	protected function get_pending_count_bubble() : string {
+		$count = (int) get_comments(
+			[
+				'type__in'  => [ 'review', 'comment' ],
+				'status'    => '0',
+				'post_type' => 'product',
+				'count'     => true,
+			]
+		);
+
+		if ( empty( $count ) ) {
+			return '';
+		}
+
+		return ' <span class="awaiting-mod count-' . esc_attr( $count ) . '"><span class="pending-count">' . esc_html( $count ) . '</span></span>';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -131,6 +131,11 @@ class Reviews {
 			$messages[] = sprintf( _n( '%s comment approved', '%s comments approved', $approved, 'woocommerce' ), $approved );
 		}
 
+		if ( $unapproved > 0 ) {
+			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
+			$messages[] = sprintf( _n( '%s comment unapproved', '%s comments unapproved', $unapproved, 'woocommerce' ), $unapproved );
+		}
+
 		return $messages;
 	}
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -41,6 +41,8 @@ class Reviews {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_reviews_page' ] );
+
+		add_action( 'admin_notices', [ $this, 'display_notices' ] );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\WooCommerce\Internal\Admin;
 
+use WP_Screen;
+
 /**
  * Handles backend logic for the Reviews component.
  */
@@ -37,7 +39,7 @@ class Reviews {
 	protected $reviews_list_table;
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_reviews_page' ] );
@@ -51,6 +53,7 @@ class Reviews {
 	 * @return Reviews instance
 	 */
 	public static function get_instance() {
+
 		if ( null === self::$instance ) {
 			self::$instance = new self();
 		}
@@ -81,6 +84,7 @@ class Reviews {
 	 * @return void
 	 */
 	public function add_reviews_page() {
+
 		$this->reviews_page_hook = add_submenu_page(
 			'edit.php?post_type=product',
 			__( 'Reviews', 'woocommerce' ),
@@ -95,6 +99,8 @@ class Reviews {
 
 	/**
 	 * Determines whether the current page is the reviews page.
+	 *
+	 * @global WP_Screen $current_screen
 	 *
 	 * @return bool
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -68,6 +68,7 @@ class Reviews {
 		 * Filters whether the current user can manage product reviews.
 		 *
 		 * @param string $capability The capability (defaults to `moderate_comments`).
+		 * @param string $context    The context for which the capability is needed.
 		 */
 		return apply_filters( 'woocommerce_view_product_reviews_page_capability', 'moderate_comments', $context );
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -270,13 +270,13 @@ class Reviews {
 
 		$is_reply = false;
 
-		if ( $comment && $comment->comment_parent > 0 ) {
+		if ( isset( $comment->comment_parent ) && $comment->comment_parent > 0 ) {
 			$is_reply = true;
 			$comment = get_comment( $comment->comment_parent ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
 		// Only replace the translated text if we are editing a comment left on a product (ie. a review).
-		if ( $comment && 'product' === get_post_type( $comment->comment_post_ID ) ) {
+		if ( isset( $comment->comment_parent ) && 'product' === get_post_type( $comment->comment_post_ID ) ) {
 			if ( 'Edit Comment' === $text ) {
 				$translation = $is_reply
 					? __( 'Edit Review Reply', 'woocommerce' )

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -41,6 +41,8 @@ class Reviews {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_reviews_page' ] );
+
+		add_action( 'init', [ $this, 'override_wp_count_comments' ] );
 	}
 
 	/**
@@ -89,6 +91,16 @@ class Reviews {
 		);
 
 		add_action( "load-{$this->reviews_page_hook}", [ $this, 'load_reviews_screen' ] );
+	}
+
+	/**
+	 * Overrides the WordPress comments count functions.
+	 *
+	 * This is necessary to prevent product reviews to be counted as regular post comments.
+	 */
+	public function override_wp_count_comments() {
+
+		add_filter( 'wp_count_comments', [ $this, 'count_comments' ], 10, 2 );
 	}
 
 	/**
@@ -160,6 +172,134 @@ class Reviews {
 		 * @param ReviewsListTable $reviews_list_table The reviews list table instance.
 		 */
 		echo apply_filters( 'woocommerce_product_reviews_list_table', ob_get_clean(), $this->reviews_list_table ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	/**
+	 * Retrieves the total comment counts for the whole site or a single post.
+	 *
+	 * This method overrides the default count_comments from WordPress to not consider product reviews as comments.
+	 *
+	 * @param array $count   This param is not used, but added given that count_comments is a callback to a filter.
+	 * @param int   $post_id Optional. Restrict the comment counts to the given post. Default 0, which indicates that
+	 *                       comment counts for the whole site will be retrieved.
+	 * @return stdClass {
+	 *     The number of comments keyed by their status.
+	 *
+	 *     @type int $approved       The number of approved comments.
+	 *     @type int $moderated      The number of comments awaiting moderation (a.k.a. pending).
+	 *     @type int $spam           The number of spam comments.
+	 *     @type int $trash          The number of trashed comments.
+	 *     @type int $post-trashed   The number of comments for posts that are in the trash.
+	 *     @type int $total_comments The total number of non-trashed comments, including spam.
+	 *     @type int $all            The total number of pending or approved comments.
+	 * }
+	 */
+	public function count_comments( $count, $post_id = 0 ) {
+
+		$post_id = (int) $post_id;
+
+		/**
+		 * Filters the comments count for a given post or the whole site.
+		 *
+		 * @param array|stdClass $count   An empty array or an object containing comment counts.
+		 * @param int            $post_id The post ID. Can be 0 to represent the whole site.
+		 */
+		$filtered = apply_filters( 'woocommerce_product_reviews_count_comments', array(), $post_id );
+		if ( ! empty( $filtered ) ) {
+			return $filtered;
+		}
+
+		$count = wp_cache_get( "comments-{$post_id}", 'counts' );
+		if ( false !== $count ) {
+			return $count;
+		}
+
+		$stats              = $this->get_comment_count( $post_id );
+		$stats['moderated'] = $stats['awaiting_moderation'];
+		unset( $stats['awaiting_moderation'] );
+
+		$stats_object = (object) $stats;
+		wp_cache_set( "comments-{$post_id}", $stats_object, 'counts' );
+
+		return $stats_object;
+	}
+
+	/**
+	 * Retrieves the total comment counts for the whole site or a single post.
+	 *
+	 * This method overrides the default get_comment_count from WordPress to not consider product reviews as comments.
+	 *
+	 * @param int $post_id Optional. Restrict the comment counts to the given post. Default 0, which indicates that
+	 *                     comment counts for the whole site will be retrieved.
+	 * @return int[] {
+	 *     The number of comments keyed by their status.
+	 *
+	 *     @type int $approved            The number of approved comments.
+	 *     @type int $awaiting_moderation The number of comments awaiting moderation (a.k.a. pending).
+	 *     @type int $spam                The number of spam comments.
+	 *     @type int $trash               The number of trashed comments.
+	 *     @type int $post-trashed        The number of comments for posts that are in the trash.
+	 *     @type int $total_comments      The total number of non-trashed comments, including spam.
+	 *     @type int $all                 The total number of pending or approved comments.
+	 * }
+	 */
+	protected function get_comment_count( $post_id = 0 ) {
+		global $wpdb;
+
+		$post_id = (int) $post_id;
+
+		$where = '';
+		if ( $post_id > 0 ) {
+			$where = $wpdb->prepare( $where . ' AND comment_post_ID = %d', $post_id ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		}
+
+		$sql = "
+			SELECT comment_approved, COUNT( * ) AS total
+			FROM {$wpdb->comments}
+			WHERE comment_type <> 'review' {$where}
+			GROUP BY comment_approved
+		";
+
+		$totals = (array) $wpdb->get_results( $wpdb->prepare( $sql ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		$comment_count = array(
+			'approved'            => 0,
+			'awaiting_moderation' => 0,
+			'spam'                => 0,
+			'trash'               => 0,
+			'post-trashed'        => 0,
+			'total_comments'      => 0,
+			'all'                 => 0,
+		);
+
+		foreach ( $totals as $row ) {
+			switch ( $row['comment_approved'] ) {
+				case 'trash':
+					$comment_count['trash'] = $row['total'];
+					break;
+				case 'post-trashed':
+					$comment_count['post-trashed'] = $row['total'];
+					break;
+				case 'spam':
+					$comment_count['spam']            = $row['total'];
+					$comment_count['total_comments'] += $row['total'];
+					break;
+				case '1':
+					$comment_count['approved']        = $row['total'];
+					$comment_count['total_comments'] += $row['total'];
+					$comment_count['all']            += $row['total'];
+					break;
+				case '0':
+					$comment_count['awaiting_moderation'] = $row['total'];
+					$comment_count['total_comments']     += $row['total'];
+					$comment_count['all']                += $row['total'];
+					break;
+				default:
+					break;
+			}
+		}
+
+		return array_map( 'intval', $comment_count );
 	}
 
 }

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -126,6 +126,11 @@ class Reviews {
 
 		$messages = [];
 
+		if ( $approved > 0 ) {
+			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
+			$messages[] = sprintf( _n( '%s comment approved', '%s comments approved', $approved, 'woocommerce' ), $approved );
+		}
+
 		return $messages;
 	}
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -247,6 +247,7 @@ class Reviews {
 			$comment_author       = wp_slash( $user->display_name );
 			$comment_author_email = wp_slash( $user->user_email );
 			$comment_author_url   = wp_slash( $user->user_url );
+			// WordPress core already sanitizes `content` during the `pre_comment_content` hook, which is why it's not needed here.
 			$comment_content      = isset( $_POST['content'] ) ? wp_unslash( $_POST['content'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$comment_type         = isset( $_POST['comment_type'] ) ? sanitize_text_field( wp_unslash( $_POST['comment_type'] ) ) : 'comment';
 

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -11,7 +11,7 @@ namespace Automattic\WooCommerce\Internal\Admin;
 class Reviews {
 
 	/**
-	 * Admin page identifier. (test with commit)
+	 * Admin page identifier.
 	 */
 	const MENU_SLUG = 'product-reviews';
 

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -108,6 +108,18 @@ class Reviews {
 
 		echo ! empty( $messages ) ? '<div id="moderated" class="updated"><p>' . implode( "<br/>\n", $messages ) . '</p></div>' : '';  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
+
+	/**
+	 * Gets the applicable bulk action admin notice messages.
+	 *
+	 * @return array
+	 */
+	public function get_bulk_action_notice_messages() : array {
+
+		$messages = [];
+
+		return $messages;
+	}
 	/**
 	 * Counts the number of pending product reviews/replies, and returns the notification bubble if there's more than zero.
 	 *

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -130,39 +130,39 @@ class Reviews {
 
 		if ( $approved > 0 ) {
 			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
-			$messages[] = sprintf( _n( '%s comment approved', '%s comments approved', $approved, 'woocommerce' ), $approved );
+			$messages[] = sprintf( _n( '%s review approved', '%s reviews approved', $approved, 'woocommerce' ), $approved );
 		}
 
 		if ( $unapproved > 0 ) {
 			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
-			$messages[] = sprintf( _n( '%s comment unapproved', '%s comments unapproved', $unapproved, 'woocommerce' ), $unapproved );
+			$messages[] = sprintf( _n( '%s review unapproved', '%s reviews unapproved', $unapproved, 'woocommerce' ), $unapproved );
 		}
 
 		if ( $spammed > 0 ) {
 			$ids = isset( $_REQUEST['ids'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ids'] ) ) : 0;
 			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
-			$messages[] = sprintf( _n( '%s comment marked as spam.', '%s comments marked as spam.', $spammed, 'woocommerce' ), $spammed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=unspam&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
+			$messages[] = sprintf( _n( '%s review marked as spam.', '%s reviews marked as spam.', $spammed, 'woocommerce' ), $spammed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=unspam&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
 		}
 
 		if ( $unspammed > 0 ) {
 			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
-			$messages[] = sprintf( _n( '%s comment restored from the spam', '%s comments restored from the spam', $unspammed, 'woocommerce' ), $unspammed );
+			$messages[] = sprintf( _n( '%s review restored from the spam', '%s reviews restored from the spam', $unspammed, 'woocommerce' ), $unspammed );
 		}
 
 		if ( $trashed > 0 ) {
 			$ids = isset( $_REQUEST['ids'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ids'] ) ) : 0;
 			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
-			$messages[] = sprintf( _n( '%s comment moved to the Trash.', '%s comments moved to the Trash.', $trashed, 'woocommerce' ), $trashed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=untrash&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
+			$messages[] = sprintf( _n( '%s review moved to the Trash.', '%s reviews moved to the Trash.', $trashed, 'woocommerce' ), $trashed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=untrash&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
 		}
 
 		if ( $untrashed > 0 ) {
 			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
-			$messages[] = sprintf( _n( '%s comment restored from the Trash', '%s comments restored from the Trash', $untrashed, 'woocommerce' ), $untrashed );
+			$messages[] = sprintf( _n( '%s review restored from the Trash', '%s reviews restored from the Trash', $untrashed, 'woocommerce' ), $untrashed );
 		}
 
 		if ( $deleted > 0 ) {
 			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
-			$messages[] = sprintf( _n( '%s comment permanently deleted', '%s comments permanently deleted', $deleted, 'woocommerce' ), $deleted );
+			$messages[] = sprintf( _n( '%s review permanently deleted', '%s reviews permanently deleted', $deleted, 'woocommerce' ), $deleted );
 		}
 
 		return $messages;

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -45,6 +45,8 @@ class Reviews {
 
 		add_action( 'admin_menu', [ $this, 'add_reviews_page' ] );
 
+		add_filter( 'parent_file', [ $this, 'edit_review_parent_file' ] );
+
 		add_action( 'admin_notices', [ $this, 'display_notices' ] );
 	}
 
@@ -212,6 +214,33 @@ class Reviews {
 		}
 
 		return ' <span class="awaiting-mod count-' . esc_attr( $count ) . '"><span class="pending-count">' . esc_html( $count ) . '</span></span>';
+	}
+
+	/**
+	 * Highlights Product -> Reviews admin menu item when editing a review or a reply to a review.
+	 *
+	 * @global string $submenu_file
+	 *
+	 * @param string $parent_file Parent menu item.
+	 * @return string
+	 */
+	public function edit_review_parent_file( $parent_file ) {
+		global $submenu_file;
+
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+		if ( $screen && 'comment' === $screen->id && isset( $_GET['c'] ) ) {
+
+			$comment_id = absint( $_GET['c'] );
+			$comment = get_comment( $comment_id );
+
+			if ( $comment && 'product' === get_post_type( $comment->comment_post_ID ) ) {
+				$parent_file  = 'edit.php?post_type=product';
+				$submenu_file = 'product-reviews'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			}
+		}
+
+		return $parent_file;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -47,7 +47,7 @@ class Reviews {
 
 		add_filter( 'parent_file', [ $this, 'edit_review_parent_file' ] );
 
-		add_filter( 'gettext', array( $this, 'filter_edit_comments_screen_translations' ), 10, 2 );
+		add_filter( 'gettext', [ $this, 'edit_comments_screen_text' ], 10, 2 );
 
 		add_action( 'admin_notices', [ $this, 'display_notices' ] );
 	}
@@ -250,7 +250,7 @@ class Reviews {
 	 * @param  string $text        Text to translate.
 	 * @return string              Translated text.
 	 */
-	public function filter_edit_comments_screen_translations( $translation, $text ) {
+	public function edit_comments_screen_text( $translation, $text ) {
 		global $comment;
 
 		// Bail out if not a text we should replace.
@@ -266,17 +266,14 @@ class Reviews {
 
 		// Only replace the translated text if we are editing a comment left on a product (ie. a review).
 		if ( $comment && 'product' === get_post_type( $comment->comment_post_ID ) ) {
-			switch ( $text ) {
-				case 'Edit Comment':
-					$translation = $comment->comment_parent > 0
-						? __( 'Edit Review Reply', 'woocommerce' )
-						: __( 'Edit Review', 'woocommerce' );
-					break;
-				case 'Moderate Comment':
-					$translation = $comment->comment_parent > 0
-						? __( 'Moderate Review Reply', 'woocommerce' )
-						: __( 'Moderate Review', 'woocommerce' );
-					break;
+			if ( 'Edit Comment' === $text ) {
+				$translation = $comment->comment_parent > 0
+					? __( 'Edit Review Reply', 'woocommerce' )
+					: __( 'Edit Review', 'woocommerce' );
+			} elseif ( 'Moderate Comment' === $text ) {
+				$translation = $comment->comment_parent > 0
+					? __( 'Moderate Review Reply', 'woocommerce' )
+					: __( 'Moderate Review', 'woocommerce' );
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -84,6 +84,18 @@ class Reviews {
 
 		return 'edit.php' === $pagenow && isset( $_GET['page'] ) && 'product-reviews' === $_GET['page'];
 	}
+
+	/**
+	 * Displays notices on the Reviews page.
+	 *
+	 * @return void
+	 */
+	public function display_notices() {
+
+		if ( $this->is_reviews_page() ) {
+			$this->maybe_display_reviews_bulk_action_notice();
+		}
+	}
 	/**
 	 * Counts the number of pending product reviews/replies, and returns the notification bubble if there's more than zero.
 	 *

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -82,9 +82,9 @@ class Reviews {
 	 * @return bool
 	 */
 	public function is_reviews_page() : bool {
-		global $pagenow;
+		global $current_screen;
 
-		return 'edit.php' === $pagenow && isset( $_GET['page'] ) && 'product-reviews' === $_GET['page'];
+		return isset( $current_screen->base ) && 'product_page_product-reviews' === $current_screen->base;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -43,6 +43,7 @@ class Reviews {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_reviews_page' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'load_javascript' ] );
 
 		add_action( 'admin_notices', [ $this, 'display_notices' ] );
 	}
@@ -108,6 +109,18 @@ class Reviews {
 		global $current_screen;
 
 		return isset( $current_screen->base ) && 'product_page_product-reviews' === $current_screen->base;
+	}
+
+	/**
+	 * Loads the JavaScript required for inline replies and quick edit.
+	 *
+	 * @return void
+	 */
+	public function load_javascript() : void {
+		if ( $this->is_reviews_page() ) {
+			wp_enqueue_script( 'admin-comments' );
+			enqueue_comment_hotkeys_js();
+		}
 	}
 
 	/**
@@ -252,6 +265,8 @@ class Reviews {
 			</form>
 		</div>
 		<?php
+		wp_comment_reply( '-1', true, 'detail' );
+		wp_comment_trashnotice();
 
 		/**
 		 * Filters the contents of the product reviews list table output.

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -234,6 +234,10 @@ class Reviews {
 			$comment_id = absint( $_GET['c'] );
 			$comment = get_comment( $comment_id );
 
+			if ( $comment->comment_parent > 0 ) {
+				$comment = get_comment( $comment->comment_parent );
+			}
+
 			if ( $comment && 'product' === get_post_type( $comment->comment_post_ID ) ) {
 				$parent_file  = 'edit.php?post_type=product';
 				$submenu_file = 'product-reviews'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -264,14 +268,21 @@ class Reviews {
 			$comment    = get_comment( $comment_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
+		$is_reply = false;
+
+		if ( $comment && $comment->comment_parent > 0 ) {
+			$is_reply = true;
+			$comment = get_comment( $comment->comment_parent ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+
 		// Only replace the translated text if we are editing a comment left on a product (ie. a review).
 		if ( $comment && 'product' === get_post_type( $comment->comment_post_ID ) ) {
 			if ( 'Edit Comment' === $text ) {
-				$translation = $comment->comment_parent > 0
+				$translation = $is_reply
 					? __( 'Edit Review Reply', 'woocommerce' )
 					: __( 'Edit Review', 'woocommerce' );
 			} elseif ( 'Moderate Comment' === $text ) {
-				$translation = $comment->comment_parent > 0
+				$translation = $is_reply
 					? __( 'Moderate Review Reply', 'woocommerce' )
 					: __( 'Moderate Review', 'woocommerce' );
 			}

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -110,6 +110,21 @@ class Reviews {
 	}
 
 	/**
+	 * Retrieves the URL to the product reviews page.
+	 *
+	 * @return string
+	 */
+	public static function get_reviews_page_url(): string {
+		return add_query_arg(
+			[
+				'post_type' => 'product',
+				'page'      => static::MENU_SLUG,
+			],
+			admin_url( 'edit.php' )
+		);
+	}
+
+	/**
 	 * Determines whether the current page is the reviews page.
 	 *
 	 * @global WP_Screen $current_screen

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -115,6 +115,8 @@ class Reviews {
 
 		$this->reviews_list_table->prepare_items();
 
+		ob_start();
+
 		?>
 		<div class="wrap">
 			<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
@@ -133,6 +135,14 @@ class Reviews {
 			</form>
 		</div>
 		<?php
+
+		/**
+		 * Filters the contents of the product reviews list table output.
+		 *
+		 * @param string           $output             The HTML output of the list table.
+		 * @param ReviewsListTable $reviews_list_table The reviews list table instance.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_list_table', ob_get_clean(), $this->reviews_list_table ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 }

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -62,7 +62,7 @@ class Reviews {
 	 * @param string $context The context for which the capability is needed.
 	 * @return string
 	 */
-	public static function get_view_page_capability( $context = 'view' ) {
+	public static function get_capability( $context = 'view' ) {
 
 		/**
 		 * Filters whether the current user can manage product reviews.
@@ -83,7 +83,7 @@ class Reviews {
 			'edit.php?post_type=product',
 			__( 'Reviews', 'woocommerce' ),
 			__( 'Reviews', 'woocommerce' ) . $this->get_pending_count_bubble(),
-			static::get_view_page_capability(),
+			static::get_capability(),
 			static::MENU_SLUG,
 			[ $this, 'render_reviews_list_table' ]
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -142,6 +142,11 @@ class Reviews {
 			$messages[] = sprintf( _n( '%s comment marked as spam.', '%s comments marked as spam.', $spammed, 'woocommerce' ), $spammed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=unspam&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
 		}
 
+		if ( $unspammed > 0 ) {
+			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
+			$messages[] = sprintf( _n( '%s comment restored from the spam', '%s comments restored from the spam', $unspammed, 'woocommerce' ), $unspammed );
+		}
+
 		return $messages;
 	}
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -75,6 +75,16 @@ class Reviews {
 	}
 
 	/**
+	 * Determines whether the current page is the reviews page.
+	 *
+	 * @return bool
+	 */
+	public function is_reviews_page() : bool {
+		global $pagenow;
+
+		return 'edit.php' === $pagenow && isset( $_GET['page'] ) && 'product-reviews' === $_GET['page'];
+	}
+	/**
 	 * Counts the number of pending product reviews/replies, and returns the notification bubble if there's more than zero.
 	 *
 	 * @return string Empty string if there are no pending reviews, or bubble HTML if there are.

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -582,7 +582,7 @@ class Reviews {
 				<input type="hidden" name="page" value="<?php echo esc_attr( $page ); ?>" />
 				<input type="hidden" name="post_type" value="product" />
 
-				<?php $this->reviews_list_table->search_box( __( 'Search reviews', 'woocommerce' ), 'reviews' ); ?>
+				<?php $this->reviews_list_table->search_box( __( 'Search Reviews', 'woocommerce' ), 'reviews' ); ?>
 
 				<?php $this->reviews_list_table->display(); ?>
 			</form>

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -276,7 +276,7 @@ class Reviews {
 		}
 
 		// Only replace the translated text if we are editing a comment left on a product (ie. a review).
-		if ( isset( $comment->comment_parent ) && 'product' === get_post_type( $comment->comment_post_ID ) ) {
+		if ( isset( $comment->comment_post_ID ) && 'product' === get_post_type( $comment->comment_post_ID ) ) {
 			if ( 'Edit Comment' === $text ) {
 				$translation = $is_reply
 					? __( 'Edit Review Reply', 'woocommerce' )

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -136,6 +136,12 @@ class Reviews {
 			$messages[] = sprintf( _n( '%s comment unapproved', '%s comments unapproved', $unapproved, 'woocommerce' ), $unapproved );
 		}
 
+		if ( $spammed > 0 ) {
+			$ids = isset( $_REQUEST['ids'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ids'] ) ) : 0;
+			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
+			$messages[] = sprintf( _n( '%s comment marked as spam.', '%s comments marked as spam.', $spammed, 'woocommerce' ), $spammed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=unspam&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
+		}
+
 		return $messages;
 	}
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -194,7 +194,7 @@ class Reviews {
 	 *     @type int $all            The total number of pending or approved comments.
 	 * }
 	 */
-	public function count_comments( $count, $post_id = 0 ) {
+	public function count_comments( $count = [], $post_id = 0 ) {
 
 		$post_id = (int) $post_id;
 

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -265,7 +265,7 @@ class Reviews {
 			$comment_author       = wp_slash( $user->display_name );
 			$comment_author_email = wp_slash( $user->user_email );
 			$comment_author_url   = wp_slash( $user->user_url );
-			// WordPress core already sanitizes `content` during the `pre_comment_content` hook, which is why it's not needed here.
+			// WordPress core already sanitizes `content` during the `pre_comment_content` hook, which is why it's not needed here.  {@see wp_filter_comment()} and {@see kses_init_filters()}
 			$comment_content      = isset( $_POST['content'] ) ? wp_unslash( $_POST['content'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$comment_type         = isset( $_POST['comment_type'] ) ? sanitize_text_field( wp_unslash( $_POST['comment_type'] ) ) : 'comment';
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -64,9 +64,7 @@ class ReviewsCommentsOverrides {
 			<p><?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?></p>
 			<p class="submit">
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a>
-				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button">
-					<?php esc_html_e( 'Dismiss', 'woocommerce' ); ?>
-				</a>
+				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
 			</p>
 		</div>
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -9,6 +9,8 @@ use WP_Comment_Query;
  */
 class ReviewsCommentsOverrides {
 
+	const REVIEWS_MOVED_NOTICE_ID = 'product_reviews_moved';
+
 	/**
 	 * Class instance.
 	 *
@@ -36,6 +38,11 @@ class ReviewsCommentsOverrides {
 			return;
 		}
 
+		// Do not display if the current user has dismissed this notice.
+		if ( get_user_meta( get_current_user_id(), 'dismissed_' . static::REVIEWS_MOVED_NOTICE_ID . '_notice', true ) ) {
+			return;
+		}
+
 		$this->display_reviews_moved_notice();
 	}
 
@@ -43,15 +50,10 @@ class ReviewsCommentsOverrides {
 	 * Renders an admin notice informing the user that reviews were moved to a new page.
 	 */
 	protected function display_reviews_moved_notice() {
-		$notice_name = 'product_reviews_moved';
-		if ( get_user_meta( get_current_user_id(), 'dismissed_' . $notice_name . '_notice', true ) ) {
-			return;
-		}
-
 		$dismiss_url = wp_nonce_url(
 			add_query_arg(
 				[
-					'wc-hide-notice' => urlencode( $notice_name ),
+					'wc-hide-notice' => urlencode( static::REVIEWS_MOVED_NOTICE_ID ),
 				]
 			),
 			'woocommerce_hide_notices_nonce',

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -57,12 +57,12 @@ class ReviewsCommentsOverrides {
 	 */
 	protected function should_display_reviews_moved_notice() : bool {
 		// Do not display if the user does not have the capability  to see the new page.
-		if ( ! current_user_can( Reviews::get_capability() ) ) {
+		if ( ! WC()->call_function( 'current_user_can', Reviews::get_capability() ) ) {
 			return false;
 		}
 
 		// Do not display if the current user has dismissed this notice.
-		if ( get_user_meta( get_current_user_id(), 'dismissed_' . static::REVIEWS_MOVED_NOTICE_ID . '_notice', true ) ) {
+		if ( WC()->call_function( 'get_user_meta', get_current_user_id(), 'dismissed_' . static::REVIEWS_MOVED_NOTICE_ID . '_notice', true ) ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -25,6 +25,8 @@ class ReviewsCommentsOverrides {
 
 		add_action( 'admin_notices', [ $this, 'display_notices' ] );
 
+		add_filter( 'woocommerce_dismiss_notice_capability', [ $this, 'get_dismiss_capability' ], 10, 2 );
+
 		add_filter( 'comments_list_table_query_args', [ $this, 'exclude_reviews_from_comments' ] );
 	}
 
@@ -94,6 +96,20 @@ class ReviewsCommentsOverrides {
 		</div>
 
 		<?php
+	}
+
+	/**
+	 * Gets the capability required to dismiss the notice.
+	 *
+	 * This is required so that users who do not have the manage_woocommerce capability (e.g. Editors) can still dismiss
+	 * the notice displayed in the Comments page.
+	 *
+	 * @param string $default_capability The default required capability.
+	 * @param string $notice_id The notice ID.
+	 * @return string
+	 */
+	public function get_dismiss_capability( string $default_capability, string $notice_id ) {
+		return self::REVIEWS_MOVED_NOTICE_ID === $notice_id ? Reviews::get_capability() : $default_capability;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -45,7 +45,7 @@ class ReviewsCommentsOverrides {
 	protected function display_reviews_moved_notice() {
 		?>
 
-		<div class="notice notice-info is-dismissible">
+		<div class="notice notice-info">
 			<p><strong><?php esc_html_e( 'Product reviews have moved!', 'woocommerce' ); ?></strong></p>
 			<p><?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?></p>
 			<p class="submit"><a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a></p>

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -38,12 +38,30 @@ class ReviewsCommentsOverrides {
 			return;
 		}
 
+		$this->maybe_display_reviews_moved_notice();
+	}
+
+	/**
+	 * May render an admin notice informing the user that reviews were moved to a new page.
+	 */
+	protected function maybe_display_reviews_moved_notice() {
+		if ( $this->should_display_reviews_moved_notice() ) {
+			$this->display_reviews_moved_notice();
+		}
+	}
+
+	/**
+	 * Checks if the admin notice informing the user that reviews were moved to a new page should be displayed.
+	 *
+	 * @return bool
+	 */
+	protected function should_display_reviews_moved_notice() : bool {
 		// Do not display if the current user has dismissed this notice.
 		if ( get_user_meta( get_current_user_id(), 'dismissed_' . static::REVIEWS_MOVED_NOTICE_ID . '_notice', true ) ) {
-			return;
+			return false;
 		}
 
-		$this->display_reviews_moved_notice();
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -90,7 +90,7 @@ class ReviewsCommentsOverrides {
 			<p class="submit">
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a>
 			</p>
-			<button type="button" class="notice-dismiss" onclick="window.location = '<?php echo esc_url( $dismiss_url ); ?>';"><span class="screen-reader-text">Dismiss this notice.</span></button>
+			<button type="button" class="notice-dismiss" onclick="window.location = '<?php echo esc_url( $dismiss_url ); ?>';"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'woocommerce' ); ?></span></button>
 		</div>
 
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -46,21 +46,9 @@ class ReviewsCommentsOverrides {
 		?>
 
 		<div class="notice notice-info is-dismissible">
-			<p>
-				<strong><?php esc_html_e( 'Product reviews have moved!', 'woocommerce' ); ?></strong>
-			</p>
-			<p>
-				<?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?>
-			</p>
-			<p class="submit">
-				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary">
-					<?php esc_html_e( 'Visit new location', 'woocommerce' ); ?>
-				</a>
-				<?php // @TODO: update the URL ?>
-				<a href="#" class="button-secondary">
-					<?php esc_html_e( 'Learn more about product reviews', 'woocommerce' ); ?>
-				</a>
-			</p>
+			<p><strong><?php esc_html_e( 'Product reviews have moved!', 'woocommerce' ); ?></strong></p>
+			<p><?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?></p>
+			<p class="submit"><a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a></p>
 		</div>
 
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -84,13 +84,13 @@ class ReviewsCommentsOverrides {
 		);
 		?>
 
-		<div class="notice notice-info">
+		<div class="notice notice-info is-dismissible">
 			<p><strong><?php esc_html_e( 'Product reviews have moved!', 'woocommerce' ); ?></strong></p>
 			<p><?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?></p>
 			<p class="submit">
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a>
-				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
 			</p>
+			<button type="button" class="notice-dismiss" onclick="window.location = '<?php echo esc_url( $dismiss_url ); ?>';"><span class="screen-reader-text">Dismiss this notice.</span></button>
 		</div>
 
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -43,12 +43,31 @@ class ReviewsCommentsOverrides {
 	 * Renders an admin notice informing the user that reviews were moved to a new page.
 	 */
 	protected function display_reviews_moved_notice() {
+		$notice_name = 'product_reviews_moved';
+		if ( get_user_meta( get_current_user_id(), 'dismissed_' . $notice_name . '_notice', true ) ) {
+			return;
+		}
+
+		$dismiss_url = wp_nonce_url(
+			add_query_arg(
+				[
+					'wc-hide-notice' => urlencode( $notice_name ),
+				]
+			),
+			'woocommerce_hide_notices_nonce',
+			'_wc_notice_nonce'
+		);
 		?>
 
 		<div class="notice notice-info">
 			<p><strong><?php esc_html_e( 'Product reviews have moved!', 'woocommerce' ); ?></strong></p>
 			<p><?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?></p>
-			<p class="submit"><a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a></p>
+			<p class="submit">
+				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a>
+				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button">
+					<?php esc_html_e( 'Dismiss', 'woocommerce' ); ?>
+				</a>
+			</p>
 		</div>
 
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -56,6 +56,11 @@ class ReviewsCommentsOverrides {
 	 * @return bool
 	 */
 	protected function should_display_reviews_moved_notice() : bool {
+		// Do not display if the user does not have the capability  to see the new page.
+		if ( ! current_user_can( Reviews::get_capability() ) ) {
+			return false;
+		}
+
 		// Do not display if the current user has dismissed this notice.
 		if ( get_user_meta( get_current_user_id(), 'dismissed_' . static::REVIEWS_MOVED_NOTICE_ID . '_notice', true ) ) {
 			return false;

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -105,11 +105,11 @@ class ReviewsCommentsOverrides {
 	 * the notice displayed in the Comments page.
 	 *
 	 * @param string $default_capability The default required capability.
-	 * @param string $notice_id The notice ID.
+	 * @param string $notice_name The notice name.
 	 * @return string
 	 */
-	public function get_dismiss_capability( string $default_capability, string $notice_id ) {
-		return self::REVIEWS_MOVED_NOTICE_ID === $notice_id ? Reviews::get_capability() : $default_capability;
+	public function get_dismiss_capability( string $default_capability, string $notice_name ) {
+		return self::REVIEWS_MOVED_NOTICE_ID === $notice_name ? Reviews::get_capability() : $default_capability;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -731,9 +731,7 @@ class ReviewsListTable extends WP_List_Table {
 			return;
 		}
 
-		$do_action = $this->current_action();
-
-		if ( $do_action ) {
+		if ( $this->current_action() ) {
 			check_admin_referer( 'bulk-product-reviews' );
 
 			$query_string = remove_query_arg( [ 'page', '_wpnonce' ], wp_unslash( ( $_SERVER['QUERY_STRING'] ?? '' ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -601,9 +601,11 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Renders the available status filters.
+	 * Returns the available status filters.
 	 *
 	 * @see WP_Comments_List_Table::get_views() for consistency.
+	 * @return array An associative array of fully-formed comment status links. Includes 'All', 'Pending',
+	 *               'Approved', 'Spam', and 'Trash'.
 	 */
 	protected function get_views() {
 		global $post_id, $comment_status, $comment_type;

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -35,7 +35,6 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param array|string $args Array or string of arguments.
 	 */
 	public function __construct( $args = [] ) {
-
 		parent::__construct( $args );
 
 		$this->current_user_can_moderate_reviews = current_user_can( 'moderate_comments' );

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -724,7 +724,7 @@ class ReviewsListTable extends WP_List_Table {
 			data-action="woocommerce_json_search_products"
 			data-allow_clear="true">
 			<?php if ( $current_product instanceof WC_Product ) : ?>
-				<option value="<?php echo esc_attr( $current_product ); ?>" selected="selected"><?php echo esc_html( $current_product->get_formatted_name() ); ?></option>
+				<option value="<?php echo esc_attr( $current_product->get_id() ); ?>" selected="selected"><?php echo esc_html( $current_product->get_formatted_name() ); ?></option>
 			<?php endif; ?>
 		</select>
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -110,7 +110,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Returns the number of items to show per page.
 	 *
-	 * @return int
+	 * @return int Customized per-page value if available, or 20 as the default.
 	 */
 	protected function get_per_page() : int {
 		return $this->get_items_per_page( 'edit_comments_per_page' );

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -621,11 +621,18 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param WP_Comment $item Review or reply being rendered.
 	 */
 	protected function column_type( $item ) {
-		echo esc_html(
-			'review' === $item->comment_type ?
-			'&#9734;&nbsp;' . __( 'Review', 'woocommerce' ) :
-			__( 'Reply', 'woocommerce' )
-		);
+
+		$type = 'review' === $item->comment_type
+			? '&#9734;&nbsp;' . __( 'Review', 'woocommerce' )
+			: __( 'Reply', 'woocommerce' );
+
+		/**
+		 * Filters the type column content.
+		 *
+		 * @param string     $type Type column content.
+		 * @param WP_Comment $item Review or reply being rendered.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_table_column_type', esc_html( $type ), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -379,6 +379,9 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param WP_Comment $item Review or reply being rendered.
 	 */
 	protected function column_cb( $item ) {
+
+		ob_start();
+
 		if ( $this->current_user_can_edit_review ) {
 			?>
 			<label class="screen-reader-text" for="cb-select-<?php echo esc_attr( $item->comment_ID ); ?>"><?php esc_html_e( 'Select review', 'woocommerce' ); ?></label>
@@ -390,6 +393,14 @@ class ReviewsListTable extends WP_List_Table {
 			/>
 			<?php
 		}
+
+		/**
+		 * Filters the content of the product review checkbox column.
+		 *
+		 * @param string     $content The content of the checkbox column.
+		 * @param WP_Comment $item    Review or reply being rendered.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_table_colum_cb', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -462,7 +462,7 @@ class ReviewsListTable extends WP_List_Table {
 
 		$i = 0;
 
-		foreach ( $actions as $action => $link ) {
+		foreach ( array_filter( $actions ) as $action => $link ) {
 			++$i;
 
 			if ( ( ( 'approve' === $action || 'unapprove' === $action ) && 2 === $i ) || 1 === $i ) {

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -168,7 +168,7 @@ class ReviewsListTable extends WP_List_Table {
 		 *
 		 * @param array $columns
 		 */
-		return apply_filters( 'woocommerce_product_review_table_columns', $columns );
+		return apply_filters( 'woocommerce_product_reviews_table_columns', $columns );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -87,6 +87,8 @@ class ReviewsListTable extends WP_List_Table {
 		$args = wp_parse_args( $this->get_filter_rating_arguments(), $args );
 		// Handle the review product filter.
 		$args = wp_parse_args( $this->get_filter_product_arguments(), $args );
+		// Include the review status arguments.
+		$args = wp_parse_args( $this->get_status_arguments(), $args );
 
 		$comments = get_comments( $args );
 
@@ -233,6 +235,23 @@ class ReviewsListTable extends WP_List_Table {
 
 		if ( $this->current_product_for_reviews instanceof WC_Product ) {
 			$args['post_id'] = $this->current_product_for_reviews->get_id();
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Gets the `status` argument based on the current request.
+	 *
+	 * @return array
+	 */
+	protected function get_status_arguments() : array {
+		$args = [];
+
+		global $comment_status;
+
+		if ( ! empty( $comment_status ) && 'all' !== $comment_status && array_key_exists( $comment_status, $this->get_status_filters() ) ) {
+			$args['status'] = $this->convert_status_to_query_value( $comment_status );
 		}
 
 		return $args;

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -705,7 +705,7 @@ class ReviewsListTable extends WP_List_Table {
 		 *
 		 * @param string $comment_id The review or reply ID as a numeric string.
 		 */
-		do_action( 'woocommerce_product_reviews_table_' . $column_name, $item );
+		do_action( 'woocommerce_product_reviews_table_column_' . $column_name, $item );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -148,6 +148,213 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Generate and display row actions links.
+	 *
+	 * @see WP_Comments_List_Table::handle_row_actions() for consistency.
+	 *
+	 * @global string $comment_status Status for the current listed comments.
+	 *
+	 * @param WP_Comment $review         The product review or reply in context.
+	 * @param string     $column_name    Current column name.
+	 * @param string     $primary_column Primary column name.
+	 * @return string
+	 */
+	protected function handle_row_actions( $review, $column_name, $primary_column ) {
+		global $comment_status;
+
+		if ( $primary_column !== $column_name || ! $this->current_user_can_edit_review ) {
+			return '';
+		}
+
+		$review_status = wp_get_comment_status( $review );
+
+		$del_nonce     = esc_html( '_wpnonce=' . wp_create_nonce( "delete-comment_$review->comment_ID" ) );
+		$approve_nonce = esc_html( '_wpnonce=' . wp_create_nonce( "approve-comment_$review->comment_ID" ) );
+
+		$url = "comment.php?c=$review->comment_ID";
+
+		$approve_url   = esc_url( $url . "&action=approvecomment&$approve_nonce" );
+		$unapprove_url = esc_url( $url . "&action=unapprovecomment&$approve_nonce" );
+		$spam_url      = esc_url( $url . "&action=spamcomment&$del_nonce" );
+		$unspam_url    = esc_url( $url . "&action=unspamcomment&$del_nonce" );
+		$trash_url     = esc_url( $url . "&action=trashcomment&$del_nonce" );
+		$untrash_url   = esc_url( $url . "&action=untrashcomment&$del_nonce" );
+		$delete_url    = esc_url( $url . "&action=deletecomment&$del_nonce" );
+
+		// Pre-ordered actions: Approve/Unapprove | Reply | Quick Edit | Edit | Spam/Unspam | Trash/Untrash/Delete Permanently.
+		$actions = [
+			'approve'   => '',
+			'unapprove' => '',
+			'reply'     => '',
+			'quickedit' => '',
+			'edit'      => '',
+			'spam'      => '',
+			'unspam'    => '',
+			'trash'     => '',
+			'untrash'   => '',
+			'delete'    => '',
+		];
+
+		if ( $comment_status && 'all' !== $comment_status ) {
+			if ( 'approved' === $review_status ) {
+				$actions['unapprove'] = sprintf(
+					'<a href="%s" data-wp-lists="%s" class="vim-u vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+					$unapprove_url,
+					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved",
+					esc_attr__( 'Unapprove this review', 'woocommerce' ),
+					__( 'Unapprove', 'woocommerce' )
+				);
+			} elseif ( 'unapproved' === $review_status ) {
+				$actions['approve'] = sprintf(
+					'<a href="%s" data-wp-lists="%s" class="vim-a vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+					$approve_url,
+					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved",
+					esc_attr__( 'Approve this review', 'woocommerce' ),
+					__( 'Approve', 'woocommerce' )
+				);
+			}
+		} else {
+			$actions['approve'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-a aria-button-if-js" aria-label="%s">%s</a>',
+				$approve_url,
+				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved",
+				esc_attr__( 'Approve this review', 'woocommerce' ),
+				__( 'Approve', 'woocommerce' )
+			);
+
+			$actions['unapprove'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-u aria-button-if-js" aria-label="%s">%s</a>',
+				$unapprove_url,
+				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved",
+				esc_attr__( 'Unapprove this review', 'woocommerce' ),
+				__( 'Unapprove', 'woocommerce' )
+			);
+		}
+
+		if ( 'spam' !== $review_status ) {
+			$actions['spam'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-s vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				$spam_url,
+				"delete:the-comment-list:comment-{$review->comment_ID}::spam=1",
+				esc_attr__( 'Mark this review as spam', 'woocommerce' ),
+				/* translators: "Mark as spam" link. */
+				_x( 'Spam', 'verb', 'woocommerce' )
+			);
+		} else {
+			$actions['unspam'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				$unspam_url,
+				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:unspam=1",
+				esc_attr__( 'Restore this review from the spam', 'woocommerce' ),
+				_x( 'Not Spam', 'review', 'woocommerce' )
+			);
+		}
+
+		if ( 'trash' === $review_status ) {
+			$actions['untrash'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				$untrash_url,
+				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:untrash=1",
+				esc_attr__( 'Restore this review from the Trash', 'woocommerce' ),
+				__( 'Restore', 'woocommerce' )
+			);
+		}
+
+		if ( 'spam' === $review_status || 'trash' === $review_status || ! EMPTY_TRASH_DAYS ) {
+			$actions['delete'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				$delete_url,
+				"delete:the-comment-list:comment-{$review->comment_ID}::delete=1",
+				esc_attr__( 'Delete this review permanently', 'woocommerce' ),
+				__( 'Delete Permanently', 'woocommerce' )
+			);
+		} else {
+			$actions['trash'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				$trash_url,
+				"delete:the-comment-list:comment-{$review->comment_ID}::trash=1",
+				esc_attr__( 'Move this review to the Trash', 'woocommerce' ),
+				_x( 'Trash', 'verb', 'woocommerce' )
+			);
+		}
+
+		if ( 'spam' !== $review_status && 'trash' !== $review_status ) {
+			$actions['edit'] = sprintf(
+				'<a href="%s" aria-label="%s">%s</a>',
+				"comment.php?action=editcomment&amp;c={$review->comment_ID}",
+				esc_attr__( 'Edit this review', 'woocommerce' ),
+				__( 'Edit', 'woocommerce' )
+			);
+
+			$format = '<button type="button" data-comment-id="%d" data-post-id="%d" data-action="%s" class="%s button-link" aria-expanded="false" aria-label="%s">%s</button>';
+
+			$actions['quickedit'] = sprintf(
+				$format,
+				$review->comment_ID,
+				$review->comment_post_ID,
+				'edit',
+				'vim-q comment-inline',
+				esc_attr__( 'Quick edit this review inline', 'woocommerce' ),
+				__( 'Quick&nbsp;Edit', 'woocommerce' )
+			);
+
+			$actions['reply'] = sprintf(
+				$format,
+				$review->comment_ID,
+				$review->comment_post_ID,
+				'replyto',
+				'vim-r comment-inline',
+				esc_attr__( 'Reply to this review', 'woocommerce' ),
+				__( 'Reply', 'woocommerce' )
+			);
+		}
+
+		/** This filter is documented in wp-admin/includes/dashboard.php */
+		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $review );
+
+		$always_visible = false;
+
+		$mode = get_user_setting( 'posts_list_mode', 'list' );
+
+		if ( 'excerpt' === $mode ) {
+			$always_visible = true;
+		}
+
+		$output = '<div class="' . ( $always_visible ? 'row-actions visible' : 'row-actions' ) . '">';
+
+		$i = 0;
+
+		foreach ( $actions as $action => $link ) {
+			++$i;
+
+			if ( ( ( 'approve' === $action || 'unapprove' === $action ) && 2 === $i ) || 1 === $i ) {
+				$sep = '';
+			} else {
+				$sep = ' | ';
+			}
+
+			// Reply and quickedit need a hide-if-no-js span when not added with Ajax.
+			if ( ( 'reply' === $action || 'quickedit' === $action ) && ! wp_doing_ajax() ) {
+				$action .= ' hide-if-no-js';
+			} elseif ( ( 'untrash' === $action && 'trash' === $review_status ) || ( 'unspam' === $action && 'spam' === $review_status ) ) {
+				if ( '1' === get_comment_meta( $review->comment_ID, '_wp_trash_meta_status', true ) ) {
+					$action .= ' approve';
+				} else {
+					$action .= ' unapprove';
+				}
+			}
+
+			$output .= "<span class='$action'>$sep$link</span>";
+		}
+
+		$output .= '</div>';
+
+		$output .= '<button type="button" class="toggle-row"><span class="screen-reader-text">' . __( 'Show more details', 'woocommerce' ) . '</span></button>';
+
+		return $output;
+	}
+
+	/**
 	 * Returns the columns for the table.
 	 *
 	 * @return array Table columns and their headings.

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -290,7 +290,12 @@ class ReviewsListTable extends WP_List_Table {
 		$del_nonce     = esc_html( '_wpnonce=' . wp_create_nonce( "delete-comment_$review->comment_ID" ) );
 		$approve_nonce = esc_html( '_wpnonce=' . wp_create_nonce( "approve-comment_$review->comment_ID" ) );
 
-		$url = "comment.php?c=$review->comment_ID";
+		$url = add_query_arg(
+			[
+				'c' => urlencode( $review->comment_ID ),
+			],
+			admin_url( 'comment.php' )
+		);
 
 		$approve_url   = $url . "&action=approvecomment&$approve_nonce";
 		$unapprove_url = $url . "&action=unapprovecomment&$approve_nonce";

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -34,7 +34,7 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @var int
 	 */
-	private $current_rating = 0;
+	private $current_reviews_rating = 0;
 
 	/**
 	 * Constructor.
@@ -54,7 +54,7 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	public function prepare_items() {
 
-		$this->current_rating = isset( $_REQUEST['review_rating'] ) ? absint( $_REQUEST['review_rating'] ) : 0;
+		$this->current_reviews_rating = isset( $_REQUEST['review_rating'] ) ? absint( $_REQUEST['review_rating'] ) : 0;
 
 		$this->set_review_status();
 		$this->set_review_type();
@@ -192,18 +192,18 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @return array
 	 */
-	public function get_filter_rating_arguments() : array {
+	protected function get_filter_rating_arguments() : array {
 
 		$args = [];
 
-		if ( empty( $this->current_rating ) ) {
+		if ( empty( $this->current_reviews_rating ) ) {
 			return $args;
 		}
 
 		$args['meta_query'] = [
 			[
 				'key'     => 'rating',
-				'value'   => (int) $this->current_rating,
+				'value'   => (int) $this->current_reviews_rating,
 				'compare' => '=',
 				'type'    => 'NUMERIC',
 			],
@@ -646,7 +646,7 @@ class ReviewsListTable extends WP_List_Table {
 			ob_start();
 
 			$this->review_type_dropdown( $comment_type );
-			$this->review_rating_dropdown( $this->current_rating );
+			$this->review_rating_dropdown( $this->current_reviews_rating );
 
 			$output = ob_get_clean();
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -1385,8 +1385,9 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Displays a review count bubble. Based on {@see WP_List_Table::comments_bubble()}, but overridden so we can
-	 * customize the URL and some of the language.
+	 * Displays a review count bubble.
+	 *
+	 * Based on {@see WP_List_Table::comments_bubble()}, but overridden, so we can customize the URL and text output.
 	 *
 	 * @param int $post_id          The product ID.
 	 * @param int $pending_comments Number of pending reviews.
@@ -1398,19 +1399,19 @@ class ReviewsListTable extends WP_List_Table {
 		$pending_reviews_number  = number_format_i18n( $pending_comments );
 
 		$approved_only_phrase = sprintf(
-		/* translators: %s: Number of reviews. */
+			/* translators: %s: Number of reviews. */
 			_n( '%s review', '%s reviews', $approved_review_count, 'woocommerce' ),
 			$approved_reviews_number
 		);
 
 		$approved_phrase = sprintf(
-		/* translators: %s: Number of reviews. */
+			/* translators: %s: Number of reviews. */
 			_n( '%s approved review', '%s approved reviews', $approved_review_count, 'woocommerce' ),
 			$approved_reviews_number
 		);
 
 		$pending_phrase = sprintf(
-		/* translators: %s: Number of reviews. */
+			/* translators: %s: Number of reviews. */
 			_n( '%s pending review', '%s pending reviews', $pending_comments, 'woocommerce' ),
 			$pending_reviews_number
 		);

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -344,6 +344,32 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Returns the base URL for a view, excluding the status (that should be appended).
+	 *
+	 * @param string $comment_type Comment type filter.
+	 * @param int    $post_id      Current post ID.
+	 * @return string
+	 */
+	protected function get_view_url( $comment_type, $post_id ) : string {
+		$link = add_query_arg(
+			[
+				'post_type' => 'product',
+				'page'      => Reviews::MENU_SLUG,
+			],
+			admin_url( 'edit.php' )
+		);
+
+		if ( ! empty( $comment_type ) && 'all' !== $comment_type ) {
+			$link = add_query_arg( 'comment_type', urlencode( $comment_type ), $link );
+		}
+		if ( ! empty( $post_id ) ) {
+			$link = add_query_arg( 'p', absint( $post_id ), $link );
+		}
+
+		return $link;
+	}
+
+	/**
 	 * Renders the available status filters.
 	 *
 	 * @see WP_Comments_List_Table::get_views() for consistency.
@@ -359,20 +385,7 @@ class ReviewsListTable extends WP_List_Table {
 			unset( $status_labels['trash'] );
 		}
 
-		$link = add_query_arg(
-			[
-				'post_type' => 'product',
-				'page'      => Reviews::MENU_SLUG,
-			],
-			admin_url( 'edit.php' )
-		);
-
-		if ( ! empty( $comment_type ) && 'all' !== $comment_type ) {
-			$link = add_query_arg( 'comment_type', urlencode( $comment_type ), $link );
-		}
-		if ( ! empty( $post_id ) ) {
-			$link = add_query_arg( 'p', absint( $post_id ), $link );
-		}
+		$link = $this->get_view_url( $comment_type, $post_id );
 
 		foreach ( $status_labels as $status => $label ) {
 			$current_link_attributes = '';

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -636,19 +636,32 @@ class ReviewsListTable extends WP_List_Table {
 	protected function column_rating( $item ) {
 		$rating = get_comment_meta( $item->comment_ID, 'rating', true );
 
+		ob_start();
+
 		if ( ! empty( $rating ) && is_numeric( $rating ) ) {
 			$rating = (int) $rating;
+
 			$accessibility_label = sprintf(
 				/* translators: 1: number representing a rating */
 				__( '%1$s out of 5', 'woocommerce' ),
 				$rating
 			);
+
 			$stars = str_repeat( '&#9733;', $rating );
 			$stars .= str_repeat( '&#9734;', 5 - $rating );
+
 			?>
 			<span aria-label="<?php echo esc_attr( $accessibility_label ); ?>"><?php echo esc_html( $stars ); ?></span>
 			<?php
 		}
+
+		/**
+		 * Filters the review rating column content.
+		 *
+		 * @param string     $content Review rating column content.
+		 * @param WP_Comment $item    Review or reply being rendered.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_table_column_rating', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -660,12 +673,12 @@ class ReviewsListTable extends WP_List_Table {
 	protected function column_default( $item, $column_name ) {
 		/**
 		 * Fires when the default column output is displayed for a single row.
+		 *
 		 * This action can be used to render custom columns that have been added.
 		 *
-		 * @param string $column_name The custom column's name.
-		 * @param string $comment_id  The review ID as a numeric string.
+		 * @param string $comment_id The review or reply ID as a numeric string.
 		 */
-		do_action( 'woocommerce_product_reviews_table_custom_column', $column_name, $item->comment_ID );
+		do_action( 'woocommerce_product_reviews_table_' . $column_name, $item );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -305,11 +305,41 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	protected function get_status_filters() : array {
 		return [
-			'all'       => _x( 'All', 'product reviews', 'woocommerce' ),
-			'moderated' => _x( 'Pending', 'product reviews', 'woocommerce' ),
-			'approved'  => _x( 'Approved', 'product reviews', 'woocommerce' ),
-			'spam'      => _x( 'Spam', 'product reviews', 'woocommerce' ),
-			'trash'     => _x( 'Trash', 'product reviews', 'woocommerce' ),
+			/* translators: %s: Number of reviews. */
+			'all'       => _nx_noop(
+				'All <span class="count">(%s)</span>',
+				'All <span class="count">(%s)</span>',
+				'product reviews',
+				'woocommerce'
+			),
+			/* translators: %s: Number of reviews. */
+			'moderated' => _nx_noop(
+				'Pending <span class="count">(%s)</span>',
+				'Pending <span class="count">(%s)</span>',
+				'product reviews',
+				'woocommerce'
+			),
+			/* translators: %s: Number of reviews. */
+			'approved'  => _nx_noop(
+				'Approved <span class="count">(%s)</span>',
+				'Approved <span class="count">(%s)</span>',
+				'product reviews',
+				'woocommerce'
+			),
+			/* translators: %s: Number of reviews. */
+			'spam'      => _nx_noop(
+				'Spam <span class="count">(%s)</span>',
+				'Spam <span class="count">(%s)</span>',
+				'product reviews',
+				'woocommerce'
+			),
+			/* translators: %s: Number of reviews. */
+			'trash'     => _nx_noop(
+				'Trash <span class="count">(%s)</span>',
+				'Trash <span class="count">(%s)</span>',
+				'product reviews',
+				'woocommerce'
+			),
 		];
 	}
 
@@ -323,10 +353,10 @@ class ReviewsListTable extends WP_List_Table {
 
 		$status_links = [];
 
-		$status_link_labels = $this->get_status_filters();
+		$status_labels = $this->get_status_filters();
 
 		if ( ! EMPTY_TRASH_DAYS ) {
-			unset( $status_link_labels['trash'] );
+			unset( $status_labels['trash'] );
 		}
 
 		$link = add_query_arg(
@@ -340,27 +370,28 @@ class ReviewsListTable extends WP_List_Table {
 		if ( ! empty( $comment_type ) && 'all' !== $comment_type ) {
 			$link = add_query_arg( 'comment_type', urlencode( $comment_type ), $link );
 		}
+		if ( ! empty( $post_id ) ) {
+			$link = add_query_arg( 'p', absint( $post_id ), $link );
+		}
 
-		foreach ( $status_link_labels as $status => $label ) {
+		foreach ( $status_labels as $status => $label ) {
 			$current_link_attributes = '';
 
 			if ( $status === $comment_status ) {
 				$current_link_attributes = ' class="current" aria-current="page"';
 			}
 
-			$link = add_query_arg( 'comment_status', $status, $link );
+			$link = add_query_arg( 'comment_status', urlencode( $status ), $link );
 
-			if ( $post_id ) {
-				$link = add_query_arg( 'p', absint( $post_id ), $link );
-			}
+			$number_reviews_for_status = $this->get_review_count( $status, (int) $post_id );
 
 			$count_html = sprintf(
-				'<span class="count">(<span class="%s-count">%s</span>)</span>',
+				'<span class="%s-count">%s</span>',
 				( 'moderated' === $status ) ? 'pending' : $status,
-				number_format_i18n( $this->get_review_count( $status, (int) $post_id ) )
+				number_format_i18n( $number_reviews_for_status )
 			);
 
-			$status_links[ $status ] = '<a href="' . esc_url( $link ) . '"' . $current_link_attributes . '>' . $label . ' ' . $count_html . '</a>';
+			$status_links[ $status ] = '<a href="' . esc_url( $link ) . '"' . $current_link_attributes . '>' . sprintf( translate_nooped_plural( $label, $number_reviews_for_status ), $count_html ) . '</a>';
 		}
 
 		/** This filter is documented in wp-admin/includes/class-wp-comments-list-table.php */

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -602,7 +602,7 @@ class ReviewsListTable extends WP_List_Table {
 	public function get_columns() {
 		$columns = [
 			'cb'       => '<input type="checkbox" />',
-			'type'     => _x( 'Type', 'review type', 'woocommerce' ),
+			'type'     => _x( 'Type', 'review type', 'woocommerce' ) . '<style>.column-type { width: 10%; }</style>',
 			'author'   => __( 'Author', 'woocommerce' ),
 			'rating'   => __( 'Rating', 'woocommerce' ),
 			'comment'  => _x( 'Review', 'column name', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -394,13 +394,7 @@ class ReviewsListTable extends WP_List_Table {
 			<?php
 		}
 
-		/**
-		 * Filters the content of the product review checkbox column.
-		 *
-		 * @param string     $content The content of the checkbox column.
-		 * @param WP_Comment $item    Review or reply being rendered.
-		 */
-		echo apply_filters( 'woocommerce_product_reviews_table_colum_cb', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->filter_column_output( 'cb', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -428,13 +422,7 @@ class ReviewsListTable extends WP_List_Table {
 			'</div>'
 		);
 
-		/**
-		 * Filters the review content column.
-		 *
-		 * @param string     $content Review or reply content.
-		 * @param WP_Comment $item    Review or reply being rendered.
-		 */
-		echo apply_filters( 'woocommerce_product_reviews_table_column_comment', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->filter_column_output( 'comment', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -526,13 +514,7 @@ class ReviewsListTable extends WP_List_Table {
 
 		endif;
 
-		/**
-		 * Filters the product review author column content.
-		 *
-		 * @param string     $content The content of the column.
-		 * @param WP_Comment $item    The review or reply being rendered.
-		 */
-		echo apply_filters( 'woocommerce_product_reviews_table_column_author', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->filter_column_output( 'author', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -608,13 +590,7 @@ class ReviewsListTable extends WP_List_Table {
 		</div>
 		<?php
 
-		/**
-		 * Filters the product review date column content.
-		 *
-		 * @param string     $content The review date column content.
-		 * @param WP_Comment $item    The review or reply being rendered.
-		 */
-		echo apply_filters( 'woocommerce_product_reviews_table_column_date', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->filter_column_output( 'date', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -622,9 +598,10 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @see WP_Comments_List_Table::column_response() for consistency.
 	 *
+	 * @param WP_Comment $item Review or reply being rendered.
 	 * @return void
 	 */
-	protected function column_response() {
+	protected function column_response( $item ) {
 		$product_post = get_post();
 
 		ob_start();
@@ -658,13 +635,7 @@ class ReviewsListTable extends WP_List_Table {
 
 		endif;
 
-		/**
-		 * Filters the product review response column content.
-		 *
-		 * @param string     $content The response column content.
-		 * @param WP_Comment $item    The review or reply being rendered.
-		 */
-		echo apply_filters( 'woocommerce_product_reviews_table_column_response', ob_get_clean(), get_comment() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->filter_column_output( 'response', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -678,13 +649,7 @@ class ReviewsListTable extends WP_List_Table {
 			? '&#9734;&nbsp;' . __( 'Review', 'woocommerce' )
 			: __( 'Reply', 'woocommerce' );
 
-		/**
-		 * Filters the type column content.
-		 *
-		 * @param string     $type Type column content.
-		 * @param WP_Comment $item Review or reply being rendered.
-		 */
-		echo apply_filters( 'woocommerce_product_reviews_table_column_type', esc_html( $type ), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->filter_column_output( 'type', esc_html( $type ), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -714,13 +679,7 @@ class ReviewsListTable extends WP_List_Table {
 			<?php
 		}
 
-		/**
-		 * Filters the product review rating column content.
-		 *
-		 * @param string     $content Review rating column content.
-		 * @param WP_Comment $item    Review or reply being rendered.
-		 */
-		echo apply_filters( 'woocommerce_product_reviews_table_column_rating', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->filter_column_output( 'rating', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -730,14 +689,38 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param string     $column_name Name of the column being rendered.
 	 */
 	protected function column_default( $item, $column_name ) {
+
+		ob_start();
+
 		/**
 		 * Fires when the default column output is displayed for a single row.
 		 *
 		 * This action can be used to render custom columns that have been added.
 		 *
-		 * @param string $comment_id The review or reply ID as a numeric string.
+		 * @param WP_Comment $item The review or reply being rendered.
 		 */
 		do_action( 'woocommerce_product_reviews_table_column_' . $column_name, $item );
+
+		echo $this->filter_column_output( $column_name, ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	/**
+	 * Runs a filter hook for a given column content.
+	 *
+	 * @param string     $column_name The column being output.
+	 * @param string     $output      The output content (may include HTML).
+	 * @param WP_Comment $item        The review or reply being rendered.
+	 * @return string
+	 */
+	protected function filter_column_output( $column_name, $output, $item ) {
+
+		/**
+		 * Filters the output of a column.
+		 *
+		 * @param string     $output The column output.
+		 * @param WP_Comment $item   The product review being rendered.
+		 */
+		return apply_filters( 'woocommerce_product_reviews_table_column_' . $column_name, $output, $item );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -646,7 +646,7 @@ class ReviewsListTable extends WP_List_Table {
 	protected function review_type_dropdown( $item_type ) {
 
 		$item_types = [
-			'all'     => __( 'All', 'woocommerce' ),
+			'all'     => __( 'All types', 'woocommerce' ),
 			'comment' => __( 'Replies', 'woocommerce' ),
 			'review'  => __( 'Reviews', 'woocommerce' ),
 		];

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -725,7 +725,7 @@ class ReviewsListTable extends WP_List_Table {
 					? $label
 					: sprintf(
 						/* translators: %s: Star rating. */
-						__( '%s-star reviews', 'woocommerce' ),
+						__( '%s-star rating', 'woocommerce' ),
 						$rating
 					);
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -60,7 +60,7 @@ class ReviewsListTable extends WP_List_Table {
 			)
 		);
 
-		$this->current_user_can_moderate_reviews = current_user_can( Reviews::get_view_page_capability() );
+		$this->current_user_can_moderate_reviews = current_user_can( Reviews::get_view_page_capability( 'moderate' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -602,7 +602,7 @@ class ReviewsListTable extends WP_List_Table {
 	public function get_columns() {
 		$columns = [
 			'cb'       => '<input type="checkbox" />',
-			'type'     => _x( 'Type', 'review type', 'woocommerce' ) . '<style>.column-type { width: 10%; }</style>',
+			'type'     => _x( 'Type', 'review type', 'woocommerce' ),
 			'author'   => __( 'Author', 'woocommerce' ),
 			'rating'   => __( 'Rating', 'woocommerce' ),
 			'comment'  => _x( 'Review', 'column name', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -556,6 +556,8 @@ class ReviewsListTable extends WP_List_Table {
 			get_comment_date( __( 'g:i a', 'woocommerce' ), $item )
 		);
 
+		ob_start();
+
 		?>
 		<div class="submitted-on">
 			<?php
@@ -573,6 +575,14 @@ class ReviewsListTable extends WP_List_Table {
 			?>
 		</div>
 		<?php
+
+		/**
+		 * Filters the product review date column content.
+		 *
+		 * @param string     $content The review date column content.
+		 * @param WP_Comment $item    The review or reply being rendered.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_table_column_date', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -585,34 +595,44 @@ class ReviewsListTable extends WP_List_Table {
 	protected function column_response() {
 		$product_post = get_post();
 
-		if ( ! $product_post ) {
-			return;
-		}
+		ob_start();
 
-		?>
-		<div class="response-links">
-			<?php
-
-			if ( current_user_can( 'edit_product', $product_post->ID ) ) :
-				$post_link  = "<a href='" . esc_url( get_edit_post_link( $product_post->ID ) ) . "' class='comments-edit-item-link'>";
-				$post_link .= esc_html( get_the_title( $product_post->ID ) ) . '</a>';
-			else :
-				$post_link = esc_html( get_the_title( $product_post->ID ) );
-			endif;
-
-			echo $post_link; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-
-			$post_type_object = get_post_type_object( $product_post->post_type );
+		if ( $product_post ) :
 
 			?>
-			<a href="<?php echo esc_url( get_permalink( $product_post->ID ) ); ?>" class="comments-view-item-link">
-				<?php echo esc_html( $post_type_object->labels->view_item ); ?>
-			</a>
-			<span class="post-com-count-wrapper post-com-count-<?php echo esc_attr( $product_post->ID ); ?>">
-				<?php $this->comments_bubble( $product_post->ID, get_pending_comments_num( $product_post->ID ) ); ?>
-			</span>
-		</div>
-		<?php
+			<div class="response-links">
+				<?php
+
+				if ( current_user_can( 'edit_product', $product_post->ID ) ) :
+					$post_link  = "<a href='" . esc_url( get_edit_post_link( $product_post->ID ) ) . "' class='comments-edit-item-link'>";
+					$post_link .= esc_html( get_the_title( $product_post->ID ) ) . '</a>';
+				else :
+					$post_link = esc_html( get_the_title( $product_post->ID ) );
+				endif;
+
+				echo $post_link; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+				$post_type_object = get_post_type_object( $product_post->post_type );
+
+				?>
+				<a href="<?php echo esc_url( get_permalink( $product_post->ID ) ); ?>" class="comments-view-item-link">
+					<?php echo esc_html( $post_type_object->labels->view_item ); ?>
+				</a>
+				<span class="post-com-count-wrapper post-com-count-<?php echo esc_attr( $product_post->ID ); ?>">
+					<?php $this->comments_bubble( $product_post->ID, get_pending_comments_num( $product_post->ID ) ); ?>
+				</span>
+			</div>
+			<?php
+
+		endif;
+
+		/**
+		 * Filters the product review response column content.
+		 *
+		 * @param string     $content The response column content.
+		 * @param WP_Comment $item    The review or reply being rendered.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_table_column_response', ob_get_clean(), get_comment() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -663,7 +683,7 @@ class ReviewsListTable extends WP_List_Table {
 		}
 
 		/**
-		 * Filters the review rating column content.
+		 * Filters the product review rating column content.
 		 *
 		 * @param string     $content Review rating column content.
 		 * @param WP_Comment $item    Review or reply being rendered.

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -181,7 +181,6 @@ class ReviewsListTable extends WP_List_Table {
 		$untrash_url   = esc_url( $url . "&action=untrashcomment&$del_nonce" );
 		$delete_url    = esc_url( $url . "&action=deletecomment&$del_nonce" );
 
-		// Pre-ordered actions: Approve/Unapprove | Reply | Quick Edit | Edit | Spam/Unspam | Trash/Untrash/Delete Permanently.
 		$actions = [
 			'approve'   => '',
 			'unapprove' => '',
@@ -312,13 +311,7 @@ class ReviewsListTable extends WP_List_Table {
 		/** This filter is documented in wp-admin/includes/dashboard.php */
 		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $review );
 
-		$always_visible = false;
-
-		$mode = get_user_setting( 'posts_list_mode', 'list' );
-
-		if ( 'excerpt' === $mode ) {
-			$always_visible = true;
-		}
+		$always_visible = 'excerpt' === get_user_setting( 'posts_list_mode', 'list' );
 
 		$output = '<div class="' . ( $always_visible ? 'row-actions visible' : 'row-actions' ) . '">';
 
@@ -333,7 +326,6 @@ class ReviewsListTable extends WP_List_Table {
 				$sep = ' | ';
 			}
 
-			// Reply and quickedit need a hide-if-no-js span when not added with Ajax.
 			if ( ( 'reply' === $action || 'quickedit' === $action ) && ! wp_doing_ajax() ) {
 				$action .= ' hide-if-no-js';
 			} elseif ( ( 'untrash' === $action && 'trash' === $review_status ) || ( 'unspam' === $action && 'spam' === $review_status ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -320,7 +320,7 @@ class ReviewsListTable extends WP_List_Table {
 					$unapprove_url,
 					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved",
 					esc_attr__( 'Unapprove this review', 'woocommerce' ),
-					__( 'Unapprove', 'woocommerce' )
+					esc_html__( 'Unapprove', 'woocommerce' )
 				);
 			} elseif ( 'unapproved' === $review_status ) {
 				$actions['approve'] = sprintf(
@@ -328,7 +328,7 @@ class ReviewsListTable extends WP_List_Table {
 					$approve_url,
 					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved",
 					esc_attr__( 'Approve this review', 'woocommerce' ),
-					__( 'Approve', 'woocommerce' )
+					esc_html__( 'Approve', 'woocommerce' )
 				);
 			}
 		} else {
@@ -337,7 +337,7 @@ class ReviewsListTable extends WP_List_Table {
 				$approve_url,
 				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved",
 				esc_attr__( 'Approve this review', 'woocommerce' ),
-				__( 'Approve', 'woocommerce' )
+				esc_html__( 'Approve', 'woocommerce' )
 			);
 
 			$actions['unapprove'] = sprintf(
@@ -345,7 +345,7 @@ class ReviewsListTable extends WP_List_Table {
 				$unapprove_url,
 				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved",
 				esc_attr__( 'Unapprove this review', 'woocommerce' ),
-				__( 'Unapprove', 'woocommerce' )
+				esc_html__( 'Unapprove', 'woocommerce' )
 			);
 		}
 
@@ -356,7 +356,7 @@ class ReviewsListTable extends WP_List_Table {
 				"delete:the-comment-list:comment-{$review->comment_ID}::spam=1",
 				esc_attr__( 'Mark this review as spam', 'woocommerce' ),
 				/* translators: "Mark as spam" link. */
-				_x( 'Spam', 'verb', 'woocommerce' )
+				esc_html_x( 'Spam', 'verb', 'woocommerce' )
 			);
 		} else {
 			$actions['unspam'] = sprintf(
@@ -364,7 +364,7 @@ class ReviewsListTable extends WP_List_Table {
 				$unspam_url,
 				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:unspam=1",
 				esc_attr__( 'Restore this review from the spam', 'woocommerce' ),
-				_x( 'Not Spam', 'review', 'woocommerce' )
+				esc_html_x( 'Not Spam', 'review', 'woocommerce' )
 			);
 		}
 
@@ -374,7 +374,7 @@ class ReviewsListTable extends WP_List_Table {
 				$untrash_url,
 				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:untrash=1",
 				esc_attr__( 'Restore this review from the Trash', 'woocommerce' ),
-				__( 'Restore', 'woocommerce' )
+				esc_html__( 'Restore', 'woocommerce' )
 			);
 		}
 
@@ -384,7 +384,7 @@ class ReviewsListTable extends WP_List_Table {
 				$delete_url,
 				"delete:the-comment-list:comment-{$review->comment_ID}::delete=1",
 				esc_attr__( 'Delete this review permanently', 'woocommerce' ),
-				__( 'Delete Permanently', 'woocommerce' )
+				esc_html__( 'Delete Permanently', 'woocommerce' )
 			);
 		} else {
 			$actions['trash'] = sprintf(
@@ -392,7 +392,7 @@ class ReviewsListTable extends WP_List_Table {
 				$trash_url,
 				"delete:the-comment-list:comment-{$review->comment_ID}::trash=1",
 				esc_attr__( 'Move this review to the Trash', 'woocommerce' ),
-				_x( 'Trash', 'verb', 'woocommerce' )
+				esc_html_x( 'Trash', 'verb', 'woocommerce' )
 			);
 		}
 
@@ -401,29 +401,29 @@ class ReviewsListTable extends WP_List_Table {
 				'<a href="%s" aria-label="%s">%s</a>',
 				"comment.php?action=editcomment&amp;c={$review->comment_ID}",
 				esc_attr__( 'Edit this review', 'woocommerce' ),
-				__( 'Edit', 'woocommerce' )
+				esc_html__( 'Edit', 'woocommerce' )
 			);
 
 			$format = '<button type="button" data-comment-id="%d" data-post-id="%d" data-action="%s" class="%s button-link" aria-expanded="false" aria-label="%s">%s</button>';
 
 			$actions['quickedit'] = sprintf(
 				$format,
-				$review->comment_ID,
-				$review->comment_post_ID,
+				esc_attr( $review->comment_ID ),
+				esc_attr( $review->comment_post_ID ),
 				'edit',
 				'vim-q comment-inline',
 				esc_attr__( 'Quick edit this review inline', 'woocommerce' ),
-				__( 'Quick&nbsp;Edit', 'woocommerce' )
+				esc_html__( 'Quick Edit', 'woocommerce' )
 			);
 
 			$actions['reply'] = sprintf(
 				$format,
-				$review->comment_ID,
-				$review->comment_post_ID,
+				esc_attr( $review->comment_ID ),
+				esc_attr( $review->comment_post_ID ),
 				'replyto',
 				'vim-r comment-inline',
 				esc_attr__( 'Reply to this review', 'woocommerce' ),
-				__( 'Reply', 'woocommerce' )
+				esc_html__( 'Reply', 'woocommerce' )
 			);
 		}
 
@@ -460,7 +460,7 @@ class ReviewsListTable extends WP_List_Table {
 
 		$output .= '</div>';
 
-		$output .= '<button type="button" class="toggle-row"><span class="screen-reader-text">' . __( 'Show more details', 'woocommerce' ) . '</span></button>';
+		$output .= '<button type="button" class="toggle-row"><span class="screen-reader-text">' . esc_html__( 'Show more details', 'woocommerce' ) . '</span></button>';
 
 		return $output;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -646,8 +646,7 @@ class ReviewsListTable extends WP_List_Table {
 			ob_start();
 
 			$this->review_type_dropdown( $comment_type );
-
-			$this->rating_dropdown( $this->current_rating );
+			$this->review_rating_dropdown( $this->current_rating );
 
 			$output = ob_get_clean();
 
@@ -705,7 +704,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param int $current_rating Rating to display reviews for.
 	 * @return void
 	 */
-	public function rating_dropdown( $current_rating ) {
+	public function review_rating_dropdown( $current_rating ) {
 
 		$rating_options = [
 			'0' => __( 'All ratings', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -318,7 +318,7 @@ class ReviewsListTable extends WP_List_Table {
 				$actions['unapprove'] = sprintf(
 					'<a href="%s" data-wp-lists="%s" class="vim-u vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 					esc_url( $unapprove_url ),
-					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved",
+					esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved" ),
 					esc_attr__( 'Unapprove this review', 'woocommerce' ),
 					esc_html__( 'Unapprove', 'woocommerce' )
 				);
@@ -326,7 +326,7 @@ class ReviewsListTable extends WP_List_Table {
 				$actions['approve'] = sprintf(
 					'<a href="%s" data-wp-lists="%s" class="vim-a vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 					esc_url( $approve_url ),
-					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved",
+					esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved" ),
 					esc_attr__( 'Approve this review', 'woocommerce' ),
 					esc_html__( 'Approve', 'woocommerce' )
 				);
@@ -335,7 +335,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['approve'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-a aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $approve_url ),
-				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved",
+				esc_attr( "dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved" ),
 				esc_attr__( 'Approve this review', 'woocommerce' ),
 				esc_html__( 'Approve', 'woocommerce' )
 			);
@@ -343,7 +343,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['unapprove'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-u aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $unapprove_url ),
-				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved",
+				esc_attr( "dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved" ),
 				esc_attr__( 'Unapprove this review', 'woocommerce' ),
 				esc_html__( 'Unapprove', 'woocommerce' )
 			);
@@ -353,7 +353,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['spam'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-s vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $spam_url ),
-				"delete:the-comment-list:comment-{$review->comment_ID}::spam=1",
+				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}::spam=1" ),
 				esc_attr__( 'Mark this review as spam', 'woocommerce' ),
 				/* translators: "Mark as spam" link. */
 				esc_html_x( 'Spam', 'verb', 'woocommerce' )
@@ -362,7 +362,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['unspam'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $unspam_url ),
-				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:unspam=1",
+				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:66cc66:unspam=1" ),
 				esc_attr__( 'Restore this review from the spam', 'woocommerce' ),
 				esc_html_x( 'Not Spam', 'review', 'woocommerce' )
 			);
@@ -372,7 +372,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['untrash'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $untrash_url ),
-				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:untrash=1",
+				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:66cc66:untrash=1" ),
 				esc_attr__( 'Restore this review from the Trash', 'woocommerce' ),
 				esc_html__( 'Restore', 'woocommerce' )
 			);
@@ -382,7 +382,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['delete'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $delete_url ),
-				"delete:the-comment-list:comment-{$review->comment_ID}::delete=1",
+				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}::delete=1" ),
 				esc_attr__( 'Delete this review permanently', 'woocommerce' ),
 				esc_html__( 'Delete Permanently', 'woocommerce' )
 			);
@@ -390,7 +390,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['trash'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $trash_url ),
-				"delete:the-comment-list:comment-{$review->comment_ID}::trash=1",
+				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}::trash=1" ),
 				esc_attr__( 'Move this review to the Trash', 'woocommerce' ),
 				esc_html_x( 'Trash', 'verb', 'woocommerce' )
 			);
@@ -399,7 +399,15 @@ class ReviewsListTable extends WP_List_Table {
 		if ( 'spam' !== $review_status && 'trash' !== $review_status ) {
 			$actions['edit'] = sprintf(
 				'<a href="%s" aria-label="%s">%s</a>',
-				esc_url( "comment.php?action=editcomment&amp;c={$review->comment_ID}" ),
+				esc_url(
+					add_query_arg(
+						[
+							'action' => 'editcomment',
+							'c'      => urlencode( $review->comment_ID ),
+						],
+						admin_url( 'comment.php' )
+					)
+				),
 				esc_attr__( 'Edit this review', 'woocommerce' ),
 				esc_html__( 'Edit', 'woocommerce' )
 			);

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -459,6 +459,8 @@ class ReviewsListTable extends WP_List_Table {
 			$author_avatar = '';
 		}
 
+		ob_start();
+
 		echo '<strong>' . $author_avatar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		comment_author();
 		echo '</strong><br>';
@@ -501,6 +503,14 @@ class ReviewsListTable extends WP_List_Table {
 			<?php
 
 		endif;
+
+		/**
+		 * Filters the product review author column content.
+		 *
+		 * @param string     $content The content of the column.
+		 * @param WP_Comment $item    The review or reply being rendered.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_table_column_author', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -153,7 +153,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @return array Table columns and their headings.
 	 */
 	public function get_columns() {
-		return [
+		$columns = [
 			'cb'       => '<input type="checkbox" />',
 			'type'     => _x( 'Type', 'review type', 'woocommerce' ),
 			'author'   => __( 'Author', 'woocommerce' ),
@@ -162,6 +162,13 @@ class ReviewsListTable extends WP_List_Table {
 			'response' => __( 'Product', 'woocommerce' ),
 			'date'     => _x( 'Submitted on', 'column name', 'woocommerce' ),
 		];
+
+		/**
+		 * Filters the table columns.
+		 *
+		 * @param array $columns
+		 */
+		return apply_filters( 'woocommerce_product_review_table_columns', $columns );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -813,13 +813,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @return string
 	 */
 	protected function get_view_url( string $comment_type, int $post_id ) : string {
-		$link = add_query_arg(
-			[
-				'post_type' => 'product',
-				'page'      => Reviews::MENU_SLUG,
-			],
-			admin_url( 'edit.php' )
-		);
+		$link = Reviews::get_reviews_page_url();
 
 		if ( ! empty( $comment_type ) && 'all' !== $comment_type ) {
 			$link = add_query_arg( 'comment_type', urlencode( $comment_type ), $link );
@@ -1388,6 +1382,99 @@ class ReviewsListTable extends WP_List_Table {
 			<?php endif; ?>
 		</select>
 		<?php
+	}
+
+	/**
+	 * Displays a review count bubble. Based on {@see WP_List_Table::comments_bubble()}, but overridden so we can
+	 * customize the URL and some of the language.
+	 *
+	 * @param int $post_id          The product ID.
+	 * @param int $pending_comments Number of pending reviews.
+	 */
+	protected function comments_bubble( $post_id, $pending_comments ) {
+		$approved_review_count = get_comments_number();
+
+		$approved_reviews_number = number_format_i18n( $approved_review_count );
+		$pending_reviews_number  = number_format_i18n( $pending_comments );
+
+		$approved_only_phrase = sprintf(
+		/* translators: %s: Number of reviews. */
+			_n( '%s review', '%s reviews', $approved_review_count, 'woocommerce' ),
+			$approved_reviews_number
+		);
+
+		$approved_phrase = sprintf(
+		/* translators: %s: Number of reviews. */
+			_n( '%s approved review', '%s approved reviews', $approved_review_count, 'woocommerce' ),
+			$approved_reviews_number
+		);
+
+		$pending_phrase = sprintf(
+		/* translators: %s: Number of reviews. */
+			_n( '%s pending review', '%s pending reviews', $pending_comments, 'woocommerce' ),
+			$pending_reviews_number
+		);
+
+		if ( ! $approved_review_count && ! $pending_comments ) {
+			// No reviews at all.
+			printf(
+				'<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">%s</span>',
+				esc_html__( 'No reviews', 'woocommerce' )
+			);
+		} elseif ( $approved_review_count && 'trash' === get_post_status( $post_id ) ) {
+			// Don't link the comment bubble for a trashed product.
+			printf(
+				'<span class="post-com-count post-com-count-approved"><span class="comment-count-approved" aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></span>',
+				esc_html( $approved_reviews_number ),
+				$pending_comments ? esc_html( $approved_phrase ) : esc_html( $approved_only_phrase )
+			);
+		} elseif ( $approved_review_count ) {
+			// Link the comment bubble to approved reviews.
+			printf(
+				'<a href="%s" class="post-com-count post-com-count-approved"><span class="comment-count-approved" aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></a>',
+				esc_url(
+					add_query_arg(
+						[
+							'product_id'     => urlencode( $post_id ),
+							'comment_status' => 'approved',
+						],
+						Reviews::get_reviews_page_url()
+					)
+				),
+				esc_html( $approved_reviews_number ),
+				$pending_comments ? esc_html( $approved_phrase ) : esc_html( $approved_only_phrase )
+			);
+		} else {
+			// Don't link the comment bubble when there are no approved reviews.
+			printf(
+				'<span class="post-com-count post-com-count-no-comments"><span class="comment-count comment-count-no-comments" aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></span>',
+				esc_html( $approved_reviews_number ),
+				$pending_comments ? esc_html__( 'No approved reviews', 'woocommerce' ) : esc_html__( 'No reviews', 'woocommerce' )
+			);
+		}
+
+		if ( $pending_comments ) {
+			printf(
+				'<a href="%s" class="post-com-count post-com-count-pending"><span class="comment-count-pending" aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></a>',
+				esc_url(
+					add_query_arg(
+						[
+							'product_id'     => urlencode( $post_id ),
+							'comment_status' => 'moderated',
+						],
+						Reviews::get_reviews_page_url()
+					)
+				),
+				esc_html( $pending_reviews_number ),
+				esc_html( $pending_phrase )
+			);
+		} else {
+			printf(
+				'<span class="post-com-count post-com-count-pending post-com-count-no-pending"><span class="comment-count comment-count-no-pending" aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></span>',
+				esc_html( $pending_reviews_number ),
+				$approved_review_count ? esc_html__( 'No pending reviews', 'woocommerce' ) : esc_html__( 'No reviews', 'woocommerce' )
+			);
+		}
 	}
 
 }

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -60,7 +60,7 @@ class ReviewsListTable extends WP_List_Table {
 			)
 		);
 
-		$this->current_user_can_moderate_reviews = current_user_can( 'moderate_comments' );
+		$this->current_user_can_moderate_reviews = current_user_can( Reviews::get_view_page_capability() );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -60,7 +60,7 @@ class ReviewsListTable extends WP_List_Table {
 			)
 		);
 
-		$this->current_user_can_moderate_reviews = current_user_can( Reviews::get_view_page_capability( 'moderate' ) );
+		$this->current_user_can_moderate_reviews = current_user_can( Reviews::get_capability( 'moderate' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -322,6 +322,211 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Generate and display row actions links.
+	 *
+	 * @see WP_Comments_List_Table::handle_row_actions() for consistency.
+	 *
+	 * @global string $comment_status Status for the current listed comments.
+	 *
+	 * @param WP_Comment $item        The product review or reply in context.
+	 * @param string     $column_name Current column name.
+	 * @param string     $primary     Primary column name.
+	 * @return string
+	 */
+	protected function handle_row_actions( $item, $column_name, $primary ) {
+		global $comment_status;
+
+		if ( $primary !== $column_name || ! $this->current_user_can_edit_review ) {
+			return '';
+		}
+
+		$review_status = wp_get_comment_status( $item );
+
+		$url = add_query_arg(
+			[
+				'c' => urlencode( $item->comment_ID ),
+			],
+			admin_url( 'comment.php' )
+		);
+
+		$approve_url   = wp_nonce_url( add_query_arg( 'action', 'approvecomment', $url ), "approve-comment_$item->comment_ID" );
+		$unapprove_url = wp_nonce_url( add_query_arg( 'action', 'unapprovecomment', $url ), "approve-comment_$item->comment_ID" );
+		$spam_url      = wp_nonce_url( add_query_arg( 'action', 'spamcomment', $url ), "delete-comment_$item->comment_ID" );
+		$unspam_url    = wp_nonce_url( add_query_arg( 'action', 'unspamcomment', $url ), "delete-comment_$item->comment_ID" );
+		$trash_url     = wp_nonce_url( add_query_arg( 'action', 'trashcomment', $url ), "delete-comment_$item->comment_ID" );
+		$untrash_url   = wp_nonce_url( add_query_arg( 'action', 'untrashcomment', $url ), "delete-comment_$item->comment_ID" );
+		$delete_url    = wp_nonce_url( add_query_arg( 'action', 'deletecomment', $url ), "delete-comment_$item->comment_ID" );
+
+		$actions = [
+			'approve'   => '',
+			'unapprove' => '',
+			'reply'     => '',
+			'quickedit' => '',
+			'edit'      => '',
+			'spam'      => '',
+			'unspam'    => '',
+			'trash'     => '',
+			'untrash'   => '',
+			'delete'    => '',
+		];
+
+		if ( $comment_status && 'all' !== $comment_status ) {
+			if ( 'approved' === $review_status ) {
+				$actions['unapprove'] = sprintf(
+					'<a href="%s" data-wp-lists="%s" class="vim-u vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+					esc_url( $unapprove_url ),
+					esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved" ),
+					esc_attr__( 'Unapprove this review', 'woocommerce' ),
+					esc_html__( 'Unapprove', 'woocommerce' )
+				);
+			} elseif ( 'unapproved' === $review_status ) {
+				$actions['approve'] = sprintf(
+					'<a href="%s" data-wp-lists="%s" class="vim-a vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+					esc_url( $approve_url ),
+					esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved" ),
+					esc_attr__( 'Approve this review', 'woocommerce' ),
+					esc_html__( 'Approve', 'woocommerce' )
+				);
+			}
+		} else {
+			$actions['approve'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-a aria-button-if-js" aria-label="%s">%s</a>',
+				esc_url( $approve_url ),
+				esc_attr( "dim:the-comment-list:comment-{$item->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved" ),
+				esc_attr__( 'Approve this review', 'woocommerce' ),
+				esc_html__( 'Approve', 'woocommerce' )
+			);
+
+			$actions['unapprove'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-u aria-button-if-js" aria-label="%s">%s</a>',
+				esc_url( $unapprove_url ),
+				esc_attr( "dim:the-comment-list:comment-{$item->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved" ),
+				esc_attr__( 'Unapprove this review', 'woocommerce' ),
+				esc_html__( 'Unapprove', 'woocommerce' )
+			);
+		}
+
+		if ( 'spam' !== $review_status ) {
+			$actions['spam'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-s vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				esc_url( $spam_url ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}::spam=1" ),
+				esc_attr__( 'Mark this review as spam', 'woocommerce' ),
+				/* translators: "Mark as spam" link. */
+				esc_html_x( 'Spam', 'verb', 'woocommerce' )
+			);
+		} else {
+			$actions['unspam'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				esc_url( $unspam_url ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:66cc66:unspam=1" ),
+				esc_attr__( 'Restore this review from the spam', 'woocommerce' ),
+				esc_html_x( 'Not Spam', 'review', 'woocommerce' )
+			);
+		}
+
+		if ( 'trash' === $review_status ) {
+			$actions['untrash'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				esc_url( $untrash_url ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:66cc66:untrash=1" ),
+				esc_attr__( 'Restore this review from the Trash', 'woocommerce' ),
+				esc_html__( 'Restore', 'woocommerce' )
+			);
+		}
+
+		if ( 'spam' === $review_status || 'trash' === $review_status || ! EMPTY_TRASH_DAYS ) {
+			$actions['delete'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				esc_url( $delete_url ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}::delete=1" ),
+				esc_attr__( 'Delete this review permanently', 'woocommerce' ),
+				esc_html__( 'Delete Permanently', 'woocommerce' )
+			);
+		} else {
+			$actions['trash'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				esc_url( $trash_url ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}::trash=1" ),
+				esc_attr__( 'Move this review to the Trash', 'woocommerce' ),
+				esc_html_x( 'Trash', 'verb', 'woocommerce' )
+			);
+		}
+
+		if ( 'spam' !== $review_status && 'trash' !== $review_status ) {
+			$actions['edit'] = sprintf(
+				'<a href="%s" aria-label="%s">%s</a>',
+				esc_url(
+					add_query_arg(
+						[
+							'action' => 'editcomment',
+							'c'      => urlencode( $item->comment_ID ),
+						],
+						admin_url( 'comment.php' )
+					)
+				),
+				esc_attr__( 'Edit this review', 'woocommerce' ),
+				esc_html__( 'Edit', 'woocommerce' )
+			);
+
+			$format = '<button type="button" data-comment-id="%d" data-post-id="%d" data-action="%s" class="%s button-link" aria-expanded="false" aria-label="%s">%s</button>';
+
+			$actions['quickedit'] = sprintf(
+				$format,
+				esc_attr( $item->comment_ID ),
+				esc_attr( $item->comment_post_ID ),
+				'edit',
+				'vim-q comment-inline',
+				esc_attr__( 'Quick edit this review inline', 'woocommerce' ),
+				esc_html__( 'Quick Edit', 'woocommerce' )
+			);
+
+			$actions['reply'] = sprintf(
+				$format,
+				esc_attr( $item->comment_ID ),
+				esc_attr( $item->comment_post_ID ),
+				'replyto',
+				'vim-r comment-inline',
+				esc_attr__( 'Reply to this review', 'woocommerce' ),
+				esc_html__( 'Reply', 'woocommerce' )
+			);
+		}
+
+		$always_visible = 'excerpt' === get_user_setting( 'posts_list_mode', 'list' );
+
+		$output = '<div class="' . ( $always_visible ? 'row-actions visible' : 'row-actions' ) . '">';
+
+		$i = 0;
+
+		foreach ( $actions as $action => $link ) {
+			++$i;
+
+			if ( ( ( 'approve' === $action || 'unapprove' === $action ) && 2 === $i ) || 1 === $i ) {
+				$sep = '';
+			} else {
+				$sep = ' | ';
+			}
+
+			if ( ( 'reply' === $action || 'quickedit' === $action ) && ! wp_doing_ajax() ) {
+				$action .= ' hide-if-no-js';
+			} elseif ( ( 'untrash' === $action && 'trash' === $review_status ) || ( 'unspam' === $action && 'spam' === $review_status ) ) {
+				if ( '1' === get_comment_meta( $item->comment_ID, '_wp_trash_meta_status', true ) ) {
+					$action .= ' approve';
+				} else {
+					$action .= ' unapprove';
+				}
+			}
+
+			$output .= "<span class='$action'>$sep$link</span>";
+		}
+
+		$output .= '</div>';
+		$output .= '<button type="button" class="toggle-row"><span class="screen-reader-text">' . esc_html__( 'Show more details', 'woocommerce' ) . '</span></button>';
+
+		return $output;
+	}
+
+	/**
 	 * Gets the columns for the table.
 	 *
 	 * @return array Table columns and their headings.
@@ -732,13 +937,12 @@ class ReviewsListTable extends WP_List_Table {
 
 		if ( $this->current_user_can_edit_review ) :
 
-			if ( ! empty( $item->comment_author_email ) ) :
-				/** This filter is documented in wp-includes/comment-template.php */
-				$email = apply_filters( 'comment_email', $item->comment_author_email, $item );
+			if ( ! empty( $item->comment_author_email ) && is_email( $item->comment_author_email ) ) :
 
-				if ( ! empty( $email ) && '@' !== $email ) {
-					printf( '<a href="%1$s">%2$s</a><br />', esc_url( 'mailto:' . $email ), esc_html( $email ) );
-				}
+				?>
+				<a href="mailto:<?php echo esc_attr( $item->comment_author_email ); ?>"><?php echo esc_html( $item->comment_author_email ); ?></a>
+				<?php
+
 			endif;
 
 			$link = add_query_arg(

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -456,9 +456,6 @@ class ReviewsListTable extends WP_List_Table {
 			);
 		}
 
-		/** This filter is documented in wp-admin/includes/dashboard.php */
-		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $item );
-
 		$always_visible = 'excerpt' === get_user_setting( 'posts_list_mode', 'list' );
 
 		$output = '<div class="' . ( $always_visible ? 'row-actions visible' : 'row-actions' ) . '">';
@@ -713,13 +710,12 @@ class ReviewsListTable extends WP_List_Table {
 
 		if ( $this->current_user_can_edit_review ) :
 
-			if ( ! empty( $item->comment_author_email ) ) :
-				/** This filter is documented in wp-includes/comment-template.php */
-				$email = apply_filters( 'comment_email', $item->comment_author_email, $item );
+			if ( ! empty( $item->comment_author_email ) && is_email( $item->comment_author_email ) ) :
 
-				if ( ! empty( $email ) && '@' !== $email ) {
-					printf( '<a href="%1$s">%2$s</a><br />', esc_url( 'mailto:' . $email ), esc_html( $email ) );
-				}
+				?>
+				<a href="mailto:<?php echo esc_attr( $item->comment_author_email ); ?>"><?php echo esc_html( $item->comment_author_email ); ?></a>
+				<?php
+
 			endif;
 
 			$link = add_query_arg(

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -266,8 +266,6 @@ class ReviewsListTable extends WP_List_Table {
 	 * @return void
 	 */
 	public function display() {
-		$singular = $this->_args['singular'] ?? false;
-
 		$this->display_tablenav( 'top' );
 
 		$this->screen->render_screen_reader_content( 'heading_list' );
@@ -279,7 +277,7 @@ class ReviewsListTable extends WP_List_Table {
 				<?php $this->print_column_headers(); ?>
 			</tr>
 			</thead>
-			<tbody id="the-comment-list" <?php echo esc_attr( $singular ? "data-wp-lists='list:$singular'" : '' ); ?>>
+			<tbody id="the-comment-list" data-wp-lists="list:comment">
 			<?php $this->display_rows_or_placeholder(); ?>
 			</tbody>
 			<tfoot>

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -719,7 +719,18 @@ class ReviewsListTable extends WP_List_Table {
 		<label class="screen-reader-text" for="filter-by-review-rating"><?php esc_html_e( 'Filter by review rating', 'woocommerce' ); ?></label>
 		<select id="filter-by-review-rating" name="review_rating">
 			<?php foreach ( $rating_options as $rating => $label ) : ?>
-				<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $rating, (string) $current_rating ); ?>><?php echo esc_html( $label ); ?></option>
+				<?php
+
+				$title = 0 === (int) $rating
+					? $label
+					: sprintf(
+						/* translators: %s: Star rating. */
+						__( '%s-star reviews', 'woocommerce' ),
+						$rating
+					);
+
+				?>
+				<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $rating, (string) $current_rating ); ?> title="<?php echo esc_html( $title ); ?>"><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>
 		</select>
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -581,7 +581,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param int    $post_id      Current post ID.
 	 * @return string
 	 */
-	protected function get_view_url( $comment_type, $post_id ) : string {
+	protected function get_view_url( string $comment_type, int $post_id ) : string {
 		$link = add_query_arg(
 			[
 				'post_type' => 'product',
@@ -616,7 +616,7 @@ class ReviewsListTable extends WP_List_Table {
 			unset( $status_labels['trash'] );
 		}
 
-		$link = $this->get_view_url( $comment_type, $post_id );
+		$link = $this->get_view_url( (string) $comment_type, (int) $post_id );
 
 		foreach ( $status_labels as $status => $label ) {
 			$current_link_attributes = '';

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -526,7 +526,14 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param string     $column_name Name of the column being rendered.
 	 */
 	protected function column_default( $item, $column_name ) {
-		// @TODO Implement in MWC-5362 {agibson 2022-04-12}
+		/**
+		 * Fires when the default column output is displayed for a single row.
+		 * This action can be used to render custom columns that have been added.
+		 *
+		 * @param string $column_name The custom column's name.
+		 * @param string $comment_id  The review ID as a numeric string.
+		 */
+		do_action( 'woocommerce_manage_product_reviews_custom_column', $column_name, $item->comment_ID );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -657,7 +657,7 @@ class ReviewsListTable extends WP_List_Table {
 		 * @param string $column_name The custom column's name.
 		 * @param string $comment_id  The review ID as a numeric string.
 		 */
-		do_action( 'woocommerce_manage_product_reviews_custom_column', $column_name, $item->comment_ID );
+		do_action( 'woocommerce_product_reviews_table_custom_column', $column_name, $item->comment_ID );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -401,7 +401,10 @@ class ReviewsListTable extends WP_List_Table {
 	 * @return void
 	 */
 	protected function column_comment( $item ) {
+
 		$in_reply_to = $this->get_in_reply_to_review_text( $item );
+
+		ob_start();
 
 		if ( $in_reply_to ) {
 			echo $in_reply_to . '<br><br>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -413,6 +416,14 @@ class ReviewsListTable extends WP_List_Table {
 			get_comment_text( $item->comment_ID ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			'</div>'
 		);
+
+		/**
+		 * Filters the review content column.
+		 *
+		 * @param string     $content Review or reply content.
+		 * @param WP_Comment $item    Review or reply being rendered.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_table_column_comment', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -970,7 +970,7 @@ class ReviewsListTable extends WP_List_Table {
 			return '';
 		}
 
-		$parent_review_link = esc_url( get_comment_link( $review ) );
+		$parent_review_link = get_comment_link( $review );
 		$review_author_name = get_comment_author( $review );
 
 		return sprintf(

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -42,7 +42,15 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param array|string $args Array or string of arguments.
 	 */
 	public function __construct( $args = [] ) {
-		parent::__construct( $args );
+		parent::__construct(
+			wp_parse_args(
+				$args,
+				[
+					'plural'   => 'product-reviews',
+					'singular' => 'product-review',
+				]
+			)
+		);
 
 		$this->current_user_can_moderate_reviews = current_user_can( 'moderate_comments' );
 	}
@@ -711,6 +719,37 @@ class ReviewsListTable extends WP_List_Table {
 			<?php endforeach; ?>
 		</select>
 		<?php
+	}
+
+	/**
+	 * Processes the bulk actions.
+	 *
+	 * @return void
+	 */
+	public function process_bulk_action() {
+		if ( ! $this->current_user_can_moderate_reviews ) {
+			return;
+		}
+
+		$do_action = $this->current_action();
+
+		if ( $do_action ) {
+			check_admin_referer( 'bulk-product-reviews' );
+
+			$query_string = remove_query_arg( [ 'page', '_wpnonce' ], wp_unslash( ( $_SERVER['QUERY_STRING'] ?? '' ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+			// Replace current nonce with bulk-comments nonce.
+			$comments_nonce = wp_create_nonce( 'bulk-comments' );
+			$query_string   = add_query_arg( '_wpnonce', $comments_nonce, $query_string );
+
+			// Redirect to edit-comments.php, which will handle processing the action for us.
+			wp_safe_redirect( esc_url_raw( admin_url( 'edit-comments.php?' . $query_string ) ) );
+			exit;
+		} elseif ( ! empty( $_GET['_wp_http_referer'] ) ) {
+
+			wp_redirect( remove_query_arg( [ '_wp_http_referer', '_wpnonce' ] ) );
+			exit;
+		}
 	}
 
 }

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -730,7 +730,7 @@ class ReviewsListTable extends WP_List_Table {
 					);
 
 				?>
-				<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $rating, (string) $current_rating ); ?> title="<?php echo esc_html( $title ); ?>"><?php echo esc_html( $label ); ?></option>
+				<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $rating, (string) $current_rating ); ?> title="<?php echo esc_attr( $title ); ?>"><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>
 		</select>
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -747,7 +747,7 @@ class ReviewsListTable extends WP_List_Table {
 			exit;
 		} elseif ( ! empty( $_GET['_wp_http_referer'] ) ) {
 
-			wp_redirect( remove_query_arg( [ '_wp_http_referer', '_wpnonce' ] ) );
+			wp_safe_redirect( remove_query_arg( [ '_wp_http_referer', '_wpnonce' ] ) );
 			exit;
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -724,7 +724,7 @@ class ReviewsListTable extends WP_List_Table {
 				$title = 0 === (int) $rating
 					? $label
 					: sprintf(
-						/* translators: %s: Star rating. */
+						/* translators: %s: Star rating (1-5). */
 						__( '%s-star rating', 'woocommerce' ),
 						$rating
 					);

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -239,6 +239,42 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Displays the product reviews HTML table.
+	 *
+	 * Reimplements {@see WP_Comment_::display()} but we change the ID to match the one output by {@see WP_Comments_List_Table::display()}.
+	 * This will automatically handle additional CSS for consistency with the comments page.
+	 *
+	 * @return void
+	 */
+	public function display() {
+		$singular = $this->_args['singular'];
+
+		$this->display_tablenav( 'top' );
+
+		$this->screen->render_screen_reader_content( 'heading_list' );
+
+		?>
+		<table class="wp-list-table <?php echo esc_attr( implode( ' ', $this->get_table_classes() ) ); ?>">
+			<thead>
+				<tr>
+					<?php $this->print_column_headers(); ?>
+				</tr>
+			</thead>
+			<tbody id="the-comment-list" <?php echo esc_attr( $singular ? "data-wp-lists='list:$singular'" : '' ); ?>>
+				<?php $this->display_rows_or_placeholder(); ?>
+			</tbody>
+			<tfoot>
+				<tr>
+					<?php $this->print_column_headers( false ); ?>
+				</tr>
+			</tfoot>
+		</table>
+		<?php
+
+		$this->display_tablenav( 'bottom' );
+	}
+
+	/**
 	 * Render a single row HTML.
 	 *
 	 * @global WP_Post $post
@@ -260,7 +296,7 @@ class ReviewsListTable extends WP_List_Table {
 		$this->current_user_can_edit_review = current_user_can( 'edit_comment', $comment->comment_ID );
 
 		?>
-		<tr id="comment-<?php echo esc_attr( $comment->comment_ID ); ?>" class="<?php echo esc_attr( $the_comment_class ); ?>">
+		<tr id="comment-<?php echo esc_attr( $comment->comment_ID ); ?>" class="comment <?php echo esc_attr( $the_comment_class ); ?>">
 			<?php $this->single_row_columns( $comment ); ?>
 		</tr>
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -247,7 +247,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @return void
 	 */
 	public function display() {
-		$singular = $this->_args['singular'];
+		$singular = $this->_args['singular'] ?? false;
 
 		$this->display_tablenav( 'top' );
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -286,8 +286,6 @@ class ReviewsListTable extends WP_List_Table {
 		}
 
 		$review_status = wp_get_comment_status( $item );
-		$del_nonce     = esc_html( '_wpnonce=' . wp_create_nonce( "delete-comment_$item->comment_ID" ) );
-		$approve_nonce = esc_html( '_wpnonce=' . wp_create_nonce( "approve-comment_$item->comment_ID" ) );
 
 		$url = add_query_arg(
 			[
@@ -296,13 +294,13 @@ class ReviewsListTable extends WP_List_Table {
 			admin_url( 'comment.php' )
 		);
 
-		$approve_url   = $url . "&action=approvecomment&$approve_nonce";
-		$unapprove_url = $url . "&action=unapprovecomment&$approve_nonce";
-		$spam_url      = $url . "&action=spamcomment&$del_nonce";
-		$unspam_url    = $url . "&action=unspamcomment&$del_nonce";
-		$trash_url     = $url . "&action=trashcomment&$del_nonce";
-		$untrash_url   = $url . "&action=untrashcomment&$del_nonce";
-		$delete_url    = $url . "&action=deletecomment&$del_nonce";
+		$approve_url   = wp_nonce_url( add_query_arg( 'action', 'approvecomment', $url ), "approve-comment_$item->comment_ID" );
+		$unapprove_url = wp_nonce_url( add_query_arg( 'action', 'unapprovecomment', $url ), "approve-comment_$item->comment_ID" );
+		$spam_url      = wp_nonce_url( add_query_arg( 'action', 'spamcomment', $url ), "delete-comment_$item->comment_ID" );
+		$unspam_url    = wp_nonce_url( add_query_arg( 'action', 'unspamcomment', $url ), "delete-comment_$item->comment_ID" );
+		$trash_url     = wp_nonce_url( add_query_arg( 'action', 'trashcomment', $url ), "delete-comment_$item->comment_ID" );
+		$untrash_url   = wp_nonce_url( add_query_arg( 'action', 'untrashcomment', $url ), "delete-comment_$item->comment_ID" );
+		$delete_url    = wp_nonce_url( add_query_arg( 'action', 'deletecomment', $url ), "delete-comment_$item->comment_ID" );
 
 		$actions = [
 			'approve'   => '',

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -29,13 +29,12 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	private $current_user_can_moderate_reviews;
 
-
 	/**
 	 * Current rating of reviews to display.
 	 *
-	 * @var string
+	 * @var int
 	 */
-	private $current_rating = '0';
+	private $current_rating = 0;
 
 	/**
 	 * Constructor.
@@ -55,7 +54,7 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	public function prepare_items() {
 
-		$this->current_rating = (string) isset( $_REQUEST['rating'] ) ? wc_clean( wp_unslash( $_REQUEST['rating'] ) ) : 0;
+		$this->current_rating = isset( $_REQUEST['review_rating'] ) ? absint( $_REQUEST['review_rating'] ) : 0;
 
 		$this->set_review_status();
 		$this->set_review_type();
@@ -66,9 +65,10 @@ class ReviewsListTable extends WP_List_Table {
 
 		// Include the order & orderby arguments.
 		$args = wp_parse_args( $this->get_sort_arguments(), $args );
-
 		// Handle the review item types filter.
 		$args = wp_parse_args( $this->get_filter_type_arguments(), $args );
+		// Handle the reviews rating filter.
+		$args = wp_parse_args( $this->get_filter_rating_arguments(), $args );
 
 		$comments = get_comments( $args );
 
@@ -183,6 +183,31 @@ class ReviewsListTable extends WP_List_Table {
 
 				break;
 		}
+
+		return $args;
+	}
+
+	/**
+	 * Builds the `meta_query` arguments based on the current request.
+	 *
+	 * @return array
+	 */
+	public function get_filter_rating_arguments() : array {
+
+		$args = [];
+
+		if ( empty( $this->current_rating ) ) {
+			return $args;
+		}
+
+		$args['meta_query'] = [
+			[
+				'key'     => 'rating',
+				'value'   => (int) $this->current_rating,
+				'compare' => '=',
+				'type'    => 'NUMERIC',
+			],
+		];
 
 		return $args;
 	}
@@ -622,7 +647,7 @@ class ReviewsListTable extends WP_List_Table {
 
 			$this->review_type_dropdown( $comment_type );
 
-			$this->rating_dropdown();
+			$this->rating_dropdown( $this->current_rating );
 
 			$output = ob_get_clean();
 
@@ -653,10 +678,10 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @see WP_Comments_List_Table::comment_type_dropdown() for consistency.
 	 *
-	 * @param string $item_type The current comment item type slug.
+	 * @param string $current_type The current comment item type slug.
 	 * @return void
 	 */
-	protected function review_type_dropdown( $item_type ) {
+	protected function review_type_dropdown( $current_type ) {
 
 		$item_types = [
 			'all'     => __( 'All types', 'woocommerce' ),
@@ -668,7 +693,7 @@ class ReviewsListTable extends WP_List_Table {
 		<label class="screen-reader-text" for="filter-by-review-type"><?php esc_html_e( 'Filter by review type', 'woocommerce' ); ?></label>
 		<select id="filter-by-review-type" name="review_type">
 			<?php foreach ( $item_types as $type => $label ) : ?>
-				<option value="<?php echo esc_attr( $type ); ?>" <?php selected( $type, $item_type ); ?>><?php echo esc_html( $label ); ?></option>
+				<option value="<?php echo esc_attr( $type ); ?>" <?php selected( $type, $current_type ); ?>><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>
 		</select>
 		<?php
@@ -677,9 +702,10 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Displays a review rating drop-down for filtering reviews in the Product Reviews list table.
 	 *
+	 * @param int $current_rating Rating to display reviews for.
 	 * @return void
 	 */
-	public function rating_dropdown() {
+	public function rating_dropdown( $current_rating ) {
 
 		$rating_options = [
 			'0' => __( 'All ratings', 'woocommerce' ),
@@ -694,7 +720,7 @@ class ReviewsListTable extends WP_List_Table {
 		<label class="screen-reader-text" for="filter-by-review-rating"><?php esc_html_e( 'Filter by review rating', 'woocommerce' ); ?></label>
 		<select id="filter-by-review-rating" name="review_rating">
 			<?php foreach ( $rating_options as $rating => $label ) : ?>
-				<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $this->current_rating, $rating ); ?>><?php echo esc_html( $label ); ?></option>
+				<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $rating, (string) $current_rating ); ?>><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>
 		</select>
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -273,26 +273,25 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @global string $comment_status Status for the current listed comments.
 	 *
-	 * @param WP_Comment $review         The product review or reply in context.
-	 * @param string     $column_name    Current column name.
-	 * @param string     $primary_column Primary column name.
+	 * @param WP_Comment $item        The product review or reply in context.
+	 * @param string     $column_name Current column name.
+	 * @param string     $primary     Primary column name.
 	 * @return string
 	 */
-	protected function handle_row_actions( $review, $column_name, $primary_column ) {
+	protected function handle_row_actions( $item, $column_name, $primary ) {
 		global $comment_status;
 
-		if ( $primary_column !== $column_name || ! $this->current_user_can_edit_review ) {
+		if ( $primary !== $column_name || ! $this->current_user_can_edit_review ) {
 			return '';
 		}
 
-		$review_status = wp_get_comment_status( $review );
-
-		$del_nonce     = esc_html( '_wpnonce=' . wp_create_nonce( "delete-comment_$review->comment_ID" ) );
-		$approve_nonce = esc_html( '_wpnonce=' . wp_create_nonce( "approve-comment_$review->comment_ID" ) );
+		$review_status = wp_get_comment_status( $item );
+		$del_nonce     = esc_html( '_wpnonce=' . wp_create_nonce( "delete-comment_$item->comment_ID" ) );
+		$approve_nonce = esc_html( '_wpnonce=' . wp_create_nonce( "approve-comment_$item->comment_ID" ) );
 
 		$url = add_query_arg(
 			[
-				'c' => urlencode( $review->comment_ID ),
+				'c' => urlencode( $item->comment_ID ),
 			],
 			admin_url( 'comment.php' )
 		);
@@ -323,7 +322,7 @@ class ReviewsListTable extends WP_List_Table {
 				$actions['unapprove'] = sprintf(
 					'<a href="%s" data-wp-lists="%s" class="vim-u vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 					esc_url( $unapprove_url ),
-					esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved" ),
+					esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved" ),
 					esc_attr__( 'Unapprove this review', 'woocommerce' ),
 					esc_html__( 'Unapprove', 'woocommerce' )
 				);
@@ -331,7 +330,7 @@ class ReviewsListTable extends WP_List_Table {
 				$actions['approve'] = sprintf(
 					'<a href="%s" data-wp-lists="%s" class="vim-a vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 					esc_url( $approve_url ),
-					esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved" ),
+					esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved" ),
 					esc_attr__( 'Approve this review', 'woocommerce' ),
 					esc_html__( 'Approve', 'woocommerce' )
 				);
@@ -340,7 +339,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['approve'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-a aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $approve_url ),
-				esc_attr( "dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved" ),
+				esc_attr( "dim:the-comment-list:comment-{$item->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved" ),
 				esc_attr__( 'Approve this review', 'woocommerce' ),
 				esc_html__( 'Approve', 'woocommerce' )
 			);
@@ -348,7 +347,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['unapprove'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-u aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $unapprove_url ),
-				esc_attr( "dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved" ),
+				esc_attr( "dim:the-comment-list:comment-{$item->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved" ),
 				esc_attr__( 'Unapprove this review', 'woocommerce' ),
 				esc_html__( 'Unapprove', 'woocommerce' )
 			);
@@ -358,7 +357,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['spam'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-s vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $spam_url ),
-				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}::spam=1" ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}::spam=1" ),
 				esc_attr__( 'Mark this review as spam', 'woocommerce' ),
 				/* translators: "Mark as spam" link. */
 				esc_html_x( 'Spam', 'verb', 'woocommerce' )
@@ -367,7 +366,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['unspam'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $unspam_url ),
-				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:66cc66:unspam=1" ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:66cc66:unspam=1" ),
 				esc_attr__( 'Restore this review from the spam', 'woocommerce' ),
 				esc_html_x( 'Not Spam', 'review', 'woocommerce' )
 			);
@@ -377,7 +376,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['untrash'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $untrash_url ),
-				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:66cc66:untrash=1" ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:66cc66:untrash=1" ),
 				esc_attr__( 'Restore this review from the Trash', 'woocommerce' ),
 				esc_html__( 'Restore', 'woocommerce' )
 			);
@@ -387,7 +386,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['delete'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $delete_url ),
-				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}::delete=1" ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}::delete=1" ),
 				esc_attr__( 'Delete this review permanently', 'woocommerce' ),
 				esc_html__( 'Delete Permanently', 'woocommerce' )
 			);
@@ -395,7 +394,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['trash'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $trash_url ),
-				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}::trash=1" ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}::trash=1" ),
 				esc_attr__( 'Move this review to the Trash', 'woocommerce' ),
 				esc_html_x( 'Trash', 'verb', 'woocommerce' )
 			);
@@ -408,7 +407,7 @@ class ReviewsListTable extends WP_List_Table {
 					add_query_arg(
 						[
 							'action' => 'editcomment',
-							'c'      => urlencode( $review->comment_ID ),
+							'c'      => urlencode( $item->comment_ID ),
 						],
 						admin_url( 'comment.php' )
 					)
@@ -421,8 +420,8 @@ class ReviewsListTable extends WP_List_Table {
 
 			$actions['quickedit'] = sprintf(
 				$format,
-				esc_attr( $review->comment_ID ),
-				esc_attr( $review->comment_post_ID ),
+				esc_attr( $item->comment_ID ),
+				esc_attr( $item->comment_post_ID ),
 				'edit',
 				'vim-q comment-inline',
 				esc_attr__( 'Quick edit this review inline', 'woocommerce' ),
@@ -431,8 +430,8 @@ class ReviewsListTable extends WP_List_Table {
 
 			$actions['reply'] = sprintf(
 				$format,
-				esc_attr( $review->comment_ID ),
-				esc_attr( $review->comment_post_ID ),
+				esc_attr( $item->comment_ID ),
+				esc_attr( $item->comment_post_ID ),
 				'replyto',
 				'vim-r comment-inline',
 				esc_attr__( 'Reply to this review', 'woocommerce' ),
@@ -441,7 +440,7 @@ class ReviewsListTable extends WP_List_Table {
 		}
 
 		/** This filter is documented in wp-admin/includes/dashboard.php */
-		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $review );
+		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $item );
 
 		$always_visible = 'excerpt' === get_user_setting( 'posts_list_mode', 'list' );
 
@@ -461,7 +460,7 @@ class ReviewsListTable extends WP_List_Table {
 			if ( ( 'reply' === $action || 'quickedit' === $action ) && ! wp_doing_ajax() ) {
 				$action .= ' hide-if-no-js';
 			} elseif ( ( 'untrash' === $action && 'trash' === $review_status ) || ( 'unspam' === $action && 'spam' === $review_status ) ) {
-				if ( '1' === get_comment_meta( $review->comment_ID, '_wp_trash_meta_status', true ) ) {
+				if ( '1' === get_comment_meta( $item->comment_ID, '_wp_trash_meta_status', true ) ) {
 					$action .= ' approve';
 				} else {
 					$action .= ' unapprove';

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -720,7 +720,7 @@ class ReviewsListTable extends WP_List_Table {
 		 * @param string     $output The column output.
 		 * @param WP_Comment $item   The product review being rendered.
 		 */
-		return apply_filters( 'woocommerce_product_reviews_table_column_' . $column_name, $output, $item );
+		return apply_filters( 'woocommerce_product_reviews_table_column_' . $column_name . '_content', $output, $item );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -637,11 +637,12 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Displays a comment type drop-down for filtering on the Comments list table.
+	 * Displays a review type drop-down for filtering reviews in the Product Reviews list table.
 	 *
 	 * @see WP_Comments_List_Table::comment_type_dropdown() for consistency.
 	 *
 	 * @param string $item_type The current comment item type slug.
+	 * @return void
 	 */
 	protected function review_type_dropdown( $item_type ) {
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -89,6 +89,8 @@ class ReviewsListTable extends WP_List_Table {
 		$args = wp_parse_args( $this->get_filter_product_arguments(), $args );
 		// Include the review status arguments.
 		$args = wp_parse_args( $this->get_status_arguments(), $args );
+		// Include the search argument.
+		$args = wp_parse_args( $this->get_search_arguments(), $args );
 
 		$comments = get_comments( $args );
 
@@ -252,6 +254,21 @@ class ReviewsListTable extends WP_List_Table {
 
 		if ( ! empty( $comment_status ) && 'all' !== $comment_status && array_key_exists( $comment_status, $this->get_status_filters() ) ) {
 			$args['status'] = $this->convert_status_to_query_value( $comment_status );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Gets the `search` argument based on the current request.
+	 *
+	 * @return array
+	 */
+	protected function get_search_arguments() : array {
+		$args = [];
+
+		if ( ! empty( $_REQUEST['s'] ) ) {
+			$args['search'] = sanitize_text_field( wp_unslash( $_REQUEST['s'] ) );
 		}
 
 		return $args;

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -292,13 +292,13 @@ class ReviewsListTable extends WP_List_Table {
 
 		$url = "comment.php?c=$review->comment_ID";
 
-		$approve_url   = esc_url( $url . "&action=approvecomment&$approve_nonce" );
-		$unapprove_url = esc_url( $url . "&action=unapprovecomment&$approve_nonce" );
-		$spam_url      = esc_url( $url . "&action=spamcomment&$del_nonce" );
-		$unspam_url    = esc_url( $url . "&action=unspamcomment&$del_nonce" );
-		$trash_url     = esc_url( $url . "&action=trashcomment&$del_nonce" );
-		$untrash_url   = esc_url( $url . "&action=untrashcomment&$del_nonce" );
-		$delete_url    = esc_url( $url . "&action=deletecomment&$del_nonce" );
+		$approve_url   = $url . "&action=approvecomment&$approve_nonce";
+		$unapprove_url = $url . "&action=unapprovecomment&$approve_nonce";
+		$spam_url      = $url . "&action=spamcomment&$del_nonce";
+		$unspam_url    = $url . "&action=unspamcomment&$del_nonce";
+		$trash_url     = $url . "&action=trashcomment&$del_nonce";
+		$untrash_url   = $url . "&action=untrashcomment&$del_nonce";
+		$delete_url    = $url . "&action=deletecomment&$del_nonce";
 
 		$actions = [
 			'approve'   => '',
@@ -317,7 +317,7 @@ class ReviewsListTable extends WP_List_Table {
 			if ( 'approved' === $review_status ) {
 				$actions['unapprove'] = sprintf(
 					'<a href="%s" data-wp-lists="%s" class="vim-u vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
-					$unapprove_url,
+					esc_url( $unapprove_url ),
 					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved",
 					esc_attr__( 'Unapprove this review', 'woocommerce' ),
 					esc_html__( 'Unapprove', 'woocommerce' )
@@ -325,7 +325,7 @@ class ReviewsListTable extends WP_List_Table {
 			} elseif ( 'unapproved' === $review_status ) {
 				$actions['approve'] = sprintf(
 					'<a href="%s" data-wp-lists="%s" class="vim-a vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
-					$approve_url,
+					esc_url( $approve_url ),
 					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved",
 					esc_attr__( 'Approve this review', 'woocommerce' ),
 					esc_html__( 'Approve', 'woocommerce' )
@@ -334,7 +334,7 @@ class ReviewsListTable extends WP_List_Table {
 		} else {
 			$actions['approve'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-a aria-button-if-js" aria-label="%s">%s</a>',
-				$approve_url,
+				esc_url( $approve_url ),
 				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved",
 				esc_attr__( 'Approve this review', 'woocommerce' ),
 				esc_html__( 'Approve', 'woocommerce' )
@@ -342,7 +342,7 @@ class ReviewsListTable extends WP_List_Table {
 
 			$actions['unapprove'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-u aria-button-if-js" aria-label="%s">%s</a>',
-				$unapprove_url,
+				esc_url( $unapprove_url ),
 				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved",
 				esc_attr__( 'Unapprove this review', 'woocommerce' ),
 				esc_html__( 'Unapprove', 'woocommerce' )
@@ -352,7 +352,7 @@ class ReviewsListTable extends WP_List_Table {
 		if ( 'spam' !== $review_status ) {
 			$actions['spam'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-s vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
-				$spam_url,
+				esc_url( $spam_url ),
 				"delete:the-comment-list:comment-{$review->comment_ID}::spam=1",
 				esc_attr__( 'Mark this review as spam', 'woocommerce' ),
 				/* translators: "Mark as spam" link. */
@@ -361,7 +361,7 @@ class ReviewsListTable extends WP_List_Table {
 		} else {
 			$actions['unspam'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
-				$unspam_url,
+				esc_url( $unspam_url ),
 				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:unspam=1",
 				esc_attr__( 'Restore this review from the spam', 'woocommerce' ),
 				esc_html_x( 'Not Spam', 'review', 'woocommerce' )
@@ -371,7 +371,7 @@ class ReviewsListTable extends WP_List_Table {
 		if ( 'trash' === $review_status ) {
 			$actions['untrash'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
-				$untrash_url,
+				esc_url( $untrash_url ),
 				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:untrash=1",
 				esc_attr__( 'Restore this review from the Trash', 'woocommerce' ),
 				esc_html__( 'Restore', 'woocommerce' )
@@ -381,7 +381,7 @@ class ReviewsListTable extends WP_List_Table {
 		if ( 'spam' === $review_status || 'trash' === $review_status || ! EMPTY_TRASH_DAYS ) {
 			$actions['delete'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
-				$delete_url,
+				esc_url( $delete_url ),
 				"delete:the-comment-list:comment-{$review->comment_ID}::delete=1",
 				esc_attr__( 'Delete this review permanently', 'woocommerce' ),
 				esc_html__( 'Delete Permanently', 'woocommerce' )
@@ -389,7 +389,7 @@ class ReviewsListTable extends WP_List_Table {
 		} else {
 			$actions['trash'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
-				$trash_url,
+				esc_url( $trash_url ),
 				"delete:the-comment-list:comment-{$review->comment_ID}::trash=1",
 				esc_attr__( 'Move this review to the Trash', 'woocommerce' ),
 				esc_html_x( 'Trash', 'verb', 'woocommerce' )
@@ -399,7 +399,7 @@ class ReviewsListTable extends WP_List_Table {
 		if ( 'spam' !== $review_status && 'trash' !== $review_status ) {
 			$actions['edit'] = sprintf(
 				'<a href="%s" aria-label="%s">%s</a>',
-				"comment.php?action=editcomment&amp;c={$review->comment_ID}",
+				esc_url( "comment.php?action=editcomment&amp;c={$review->comment_ID}" ),
 				esc_attr__( 'Edit this review', 'woocommerce' ),
 				esc_html__( 'Edit', 'woocommerce' )
 			);
@@ -459,7 +459,6 @@ class ReviewsListTable extends WP_List_Table {
 		}
 
 		$output .= '</div>';
-
 		$output .= '<button type="button" class="toggle-row"><span class="screen-reader-text">' . esc_html__( 'Show more details', 'woocommerce' ) . '</span></button>';
 
 		return $output;

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -136,7 +136,7 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Builds the `comment_type` and `parent__in` arguments based on the current request.
+	 * Builds the `type` argument based on the current request.
 	 *
 	 * @return array
 	 */
@@ -145,34 +145,11 @@ class ReviewsListTable extends WP_List_Table {
 		$args      = [];
 		$item_type = isset( $_REQUEST['review_type'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['review_type'] ) ) : 'all';
 
-		switch ( $item_type ) {
-
-			case 'all':
-				break;
-
-			// Review replies.
-			case 'comment':
-				$parents = get_comments(
-					[
-						'type'   => 'review',
-						'fields' => 'ids',
-						'paged'  => -1,
-					]
-				);
-
-				$args['comment_type'] = 'comment';
-				$args['parent__in']   = ! empty( $parents ) ? (array) $parents : [ 0 ];
-
-				break;
-
-			// Reviews and other review types.
-			case 'review':
-			default:
-				$args['comment_type'] = $item_type;
-				$args['parent__in']   = [ 0 ];
-
-				break;
+		if ( 'all' === $item_type ) {
+			return $args;
 		}
+
+		$args['type'] = $item_type;
 
 		return $args;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -804,8 +804,8 @@ class ReviewsListTable extends WP_List_Table {
 			wp_safe_redirect( remove_query_arg( [ '_wp_http_referer', '_wpnonce' ] ) );
 			exit;
 		}
-  }
-    
+	}
+
 	/**
 	 * Displays a product search input for filtering reviews by product in the Product Reviews list table.
 	 *

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -84,7 +84,7 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function set_review_product() {
+	protected function set_review_product() {
 
 		$product_id = isset( $_REQUEST['product_id'] ) ? absint( $_REQUEST['product_id'] ) : null;
 		$product = $product_id ? wc_get_product( $product_id ) : null;

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -29,6 +29,14 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	private $current_user_can_moderate_reviews;
 
+
+	/**
+	 * Current rating of reviews to display.
+	 *
+	 * @var string
+	 */
+	private $current_rating = '0';
+
 	/**
 	 * Constructor.
 	 *
@@ -46,6 +54,8 @@ class ReviewsListTable extends WP_List_Table {
 	 * @return void
 	 */
 	public function prepare_items() {
+
+		$this->current_rating = (string) isset( $_REQUEST['rating'] ) ? wc_clean( wp_unslash( $_REQUEST['rating'] ) ) : 0;
 
 		$this->set_review_status();
 		$this->set_review_type();
@@ -612,6 +622,8 @@ class ReviewsListTable extends WP_List_Table {
 
 			$this->review_type_dropdown( $comment_type );
 
+			$this->rating_dropdown();
+
 			$output = ob_get_clean();
 
 			if ( ! empty( $output ) && $this->has_items() ) {
@@ -637,11 +649,12 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Displays a comment type drop-down for filtering on the Comments list table.
+	 * Displays a review type drop-down for filtering reviews in the Product Reviews list table.
 	 *
 	 * @see WP_Comments_List_Table::comment_type_dropdown() for consistency.
 	 *
 	 * @param string $item_type The current comment item type slug.
+	 * @return void
 	 */
 	protected function review_type_dropdown( $item_type ) {
 
@@ -656,6 +669,32 @@ class ReviewsListTable extends WP_List_Table {
 		<select id="filter-by-review-type" name="review_type">
 			<?php foreach ( $item_types as $type => $label ) : ?>
 				<option value="<?php echo esc_attr( $type ); ?>" <?php selected( $type, $item_type ); ?>><?php echo esc_html( $label ); ?></option>
+			<?php endforeach; ?>
+		</select>
+		<?php
+	}
+
+	/**
+	 * Displays a review rating drop-down for filtering reviews in the Product Reviews list table.
+	 *
+	 * @return void
+	 */
+	public function rating_dropdown() {
+
+		$rating_options = [
+			'0' => __( 'All ratings', 'woocommerce' ),
+			'1' => '&#9733;',
+			'2' => '&#9733;&#9733;',
+			'3' => '&#9733;&#9733;&#9733;',
+			'4' => '&#9733;&#9733;&#9733;&#9733;',
+			'5' => '&#9733;&#9733;&#9733;&#9733;&#9733;',
+		];
+
+		?>
+		<label class="screen-reader-text" for="filter-by-review-rating"><?php esc_html_e( 'Filter by review rating', 'woocommerce' ); ?></label>
+		<select id="filter-by-review-rating" name="review_rating">
+			<?php foreach ( $rating_options as $rating => $label ) : ?>
+				<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $this->current_rating, $rating ); ?>><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>
 		</select>
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -873,6 +873,18 @@ class ReviewsListTable extends WP_List_Table {
 			'</div>'
 		);
 
+		if ( $this->current_user_can_edit_review ) {
+			?>
+			<div id="inline-<?php echo esc_attr( $item->comment_ID ); ?>" class="hidden">
+				<textarea class="comment" rows="1" cols="1"><?php echo esc_textarea( $item->comment_content ); ?></textarea>
+				<div class="author-email"><?php echo esc_attr( $item->comment_author_email ); ?></div>
+				<div class="author"><?php echo esc_attr( $item->comment_author ); ?></div>
+				<div class="author-url"><?php echo esc_attr( $item->comment_author_url ); ?></div>
+				<div class="comment_status"><?php echo esc_html( $item->comment_approved ); ?></div>
+			</div>
+			<?php
+		}
+
 		echo $this->filter_column_output( 'comment', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -834,8 +834,7 @@ class ReviewsListTable extends WP_List_Table {
 			$status_links[ $status ] = '<a href="' . esc_url( $link ) . '"' . $current_link_attributes . '>' . sprintf( translate_nooped_plural( $label, $number_reviews_for_status ), $count_html ) . '</a>';
 		}
 
-		/** This filter is documented in wp-admin/includes/class-wp-comments-list-table.php */
-		return apply_filters( 'comment_status_links', $status_links );
+		return $status_links;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -188,6 +188,23 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::get_dismiss_capability()
+	 * @dataProvider provider_test_get_dismiss_capability()
+	 * @param string $default_capability The default required capability.
+	 * @param string $notice_id The notice ID.
+	 * @param string $expected_capability The expected capability.
+	 */
+	public function test_get_dismiss_capability( string $default_capability, string $notice_id, string $expected_capability ) {
+		$this->assertSame( $expected_capability, ReviewsCommentsOverrides::get_instance()->get_dismiss_capability( $default_capability, $notice_id ) );
+	}
+
+	/** @see test_get_dismiss_capability() */
+	public function provider_test_get_dismiss_capability() : \Generator {
+		yield 'another notice' => [ 'manage_woocommerce', 'other_notice', 'manage_woocommerce' ];
+		yield 'product reviews moved notice' => [ 'manage_woocommerce', ReviewsCommentsOverrides::REVIEWS_MOVED_NOTICE_ID, 'moderate_comments' ];
+	}
+
+	/**
 	 * Tests that can exclude reviews from comments in the comments page.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::exclude_reviews_from_comments()

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -66,11 +66,16 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 
 		$output = trim( ob_get_clean() );
 
+		$nonce = wp_create_nonce( 'woocommerce_hide_notices_nonce' );
+
 		$this->assertSame(
 			'<div class="notice notice-info">
 			<p><strong>Product reviews have moved!</strong></p>
 			<p>Product reviews can now be managed from Products &gt; Reviews.</p>
-			<p class="submit"><a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">Visit new location</a></p>
+			<p class="submit">
+				<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">Visit new location</a>
+				<a href="?wc-hide-notice=product_reviews_moved&#038;_wc_notice_nonce=' . $nonce . '" class="button">Dismiss</a>
+			</p>
 		</div>',
 			$output
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -191,11 +191,11 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::get_dismiss_capability()
 	 * @dataProvider provider_test_get_dismiss_capability()
 	 * @param string $default_capability The default required capability.
-	 * @param string $notice_id The notice ID.
+	 * @param string $notice_name The notice name.
 	 * @param string $expected_capability The expected capability.
 	 */
-	public function test_get_dismiss_capability( string $default_capability, string $notice_id, string $expected_capability ) {
-		$this->assertSame( $expected_capability, ReviewsCommentsOverrides::get_instance()->get_dismiss_capability( $default_capability, $notice_id ) );
+	public function test_get_dismiss_capability( string $default_capability, string $notice_name, string $expected_capability ) {
+		$this->assertSame( $expected_capability, ReviewsCommentsOverrides::get_instance()->get_dismiss_capability( $default_capability, $notice_name ) );
 	}
 
 	/** @see test_get_dismiss_capability() */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -15,14 +15,13 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 
 	/**
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::display_notices()
+	 * @backupGlobals enabled
 	 * @dataProvider provider_test_display_notices()
 	 * @param string $current_screen_base    The current WP_Screen base value.
 	 * @param bool   $should_display_notices Whether notices should be displayed.
 	 */
 	public function test_display_notices( string $current_screen_base, bool $should_display_notices ) {
 		global $current_screen;
-
-		$current_screen_backup = $current_screen;
 
 		$screen = new \stdClass();
 		$screen->base = $current_screen_base;
@@ -40,9 +39,6 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 		} else {
 			$this->assertEmpty( $output );
 		}
-
-		// Restore the global variable.
-		$current_screen = $current_screen_backup; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 
 	/** @see test_display_notices() */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -22,6 +22,8 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	public function test_display_notices( string $current_screen_base, bool $should_display_notices ) {
 		global $current_screen;
 
+		$current_screen_backup = $current_screen;
+
 		$screen = new \stdClass();
 		$screen->base = $current_screen_base;
 
@@ -38,6 +40,9 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 		} else {
 			$this->assertEmpty( $output );
 		}
+
+		// Restore the global variable.
+		$current_screen = $current_screen_backup; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 
 	/** @see test_display_notices() */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -15,13 +15,14 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 
 	/**
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::display_notices()
-	 * @backupGlobals enabled
 	 * @dataProvider provider_test_display_notices()
 	 * @param string $current_screen_base    The current WP_Screen base value.
 	 * @param bool   $should_display_notices Whether notices should be displayed.
 	 */
 	public function test_display_notices( string $current_screen_base, bool $should_display_notices ) {
 		global $current_screen;
+
+		$current_screen_backup = $current_screen;
 
 		$screen = new \stdClass();
 		$screen->base = $current_screen_base;
@@ -39,6 +40,9 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 		} else {
 			$this->assertEmpty( $output );
 		}
+
+		// Restore the global variable (using the @backupGlobals annotation will cause a serialization error).
+		$current_screen = $current_screen_backup; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 
 	/** @see test_display_notices() */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -67,7 +67,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 		$output = trim( ob_get_clean() );
 
 		$this->assertSame(
-			'<div class="notice notice-info is-dismissible">
+			'<div class="notice notice-info">
 			<p><strong>Product reviews have moved!</strong></p>
 			<p>Product reviews can now be managed from Products &gt; Reviews.</p>
 			<p class="submit"><a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">Visit new location</a></p>

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -63,17 +63,9 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 
 		$this->assertSame(
 			'<div class="notice notice-info is-dismissible">
-			<p>
-				<strong>Product reviews have moved!</strong>
-			</p>
-			<p>
-				Product reviews can now be managed from Products &gt; Reviews.			</p>
-			<p class="submit">
-				<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">
-					Visit new location				</a>
-								<a href="#" class="button-secondary">
-					Learn more about product reviews				</a>
-			</p>
+			<p><strong>Product reviews have moved!</strong></p>
+			<p>Product reviews can now be managed from Products &gt; Reviews.</p>
+			<p class="submit"><a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">Visit new location</a></p>
 		</div>',
 			$output
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -175,13 +175,13 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 		$nonce = wp_create_nonce( 'woocommerce_hide_notices_nonce' );
 
 		$this->assertSame(
-			'<div class="notice notice-info">
+			'<div class="notice notice-info is-dismissible">
 			<p><strong>Product reviews have moved!</strong></p>
 			<p>Product reviews can now be managed from Products &gt; Reviews.</p>
 			<p class="submit">
 				<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">Visit new location</a>
-				<a href="?wc-hide-notice=product_reviews_moved&#038;_wc_notice_nonce=' . $nonce . '" class="button">Dismiss</a>
 			</p>
+			<button type="button" class="notice-dismiss" onclick="window.location = \'?wc-hide-notice=product_reviews_moved&#038;_wc_notice_nonce=' . $nonce . '\';"><span class="screen-reader-text">Dismiss this notice.</span></button>
 		</div>',
 			$output
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -13,7 +13,11 @@ use WC_Unit_Test_Case;
 class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 
 	/**
+	 * Tests that can exclude reviews from comments in the comments page.
+	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::exclude_reviews_from_comments()
+	 *
+	 * @return void
 	 */
 	public function test_exclude_reviews_from_comments() {
 		$overrides = new ReviewsCommentsOverrides();

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1198,8 +1198,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( '<label class="screen-reader-text" for="filter-by-product">Filter by product</label>', $output );
-		$this->assertStringContainsString( '<select id="filter-by-product" name="product_id">', $output );
-		$this->assertStringContainsString( '<option value="' . $product->get_id() . '"  selected', $output );
+		$this->assertStringContainsString( '<option value="' . $product->get_id() . '"', $output );
 	}
 
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1095,9 +1095,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( '<select id="filter-by-review-type" name="review_type">', $output );
 
 		if ( ! in_array( $chosen_type, [ 'all', 'comment', 'review' ], true ) ) {
-			$this->assertStringNotContainsString( '<option value="' . $chosen_type . '" selected', $output );
+			$this->assertStringNotContainsString( '<option value="' . $chosen_type . '"  selected', $output );
 		} else {
-			$this->assertStringContainsString( '<option value="' . $chosen_type . '" selected', $output );
+			$this->assertStringContainsString( '<option value="' . $chosen_type . '"  selected', $output );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1600,4 +1600,34 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_status_arguments()
+	 * @dataProvider provider_get_status_arguments
+	 *
+	 * @param string $status        Current status for the request.
+	 * @param array  $expected_args Expected result of the method.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_status_arguments( string $status, array $expected_args ) {
+		global $comment_status;
+		$comment_status = $status; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_status_arguments' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected_args, $method->invoke( $list_table ) );
+	}
+
+	/** @see test_get_status_arguments */
+	public function provider_get_status_arguments() : Generator {
+		yield 'all statuses' => [ 'all', [] ];
+		yield 'moderated status' => [ 'moderated', [ 'status' => '0' ] ];
+		yield 'approved status' => [ 'approved', [ 'status' => '1' ] ];
+		yield 'spam status' => [ 'spam', [ 'status' => 'spam' ] ];
+		yield 'trash status' => [ 'trash', [ 'status' => 'trash' ] ];
+		yield 'invalid status' => [ 'not-valid', [] ];
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -882,7 +882,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$product = WC_Helper_Product::create_simple_product( true );
 
-		$property->setValue( $product );
+		$property->setValue( $list_table, $product );
 
 		$this->assertSame( [ 'post_id' => $product->get_id() ], $method->invoke( $list_table ) );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -957,6 +957,38 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can get the status arguments based on the current request.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_status_arguments()
+	 * @dataProvider provider_get_status_arguments
+	 *
+	 * @param string $status        Current status for the request.
+	 * @param array  $expected_args Expected result of the method.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_status_arguments( string $status, array $expected_args ) {
+		global $comment_status;
+		$comment_status = $status; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_status_arguments' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected_args, $method->invoke( $list_table ) );
+	}
+
+	/** @see test_get_status_arguments */
+	public function provider_get_status_arguments() : Generator {
+		yield 'all statuses' => [ 'all', [] ];
+		yield 'moderated status' => [ 'moderated', [ 'status' => '0' ] ];
+		yield 'approved status' => [ 'approved', [ 'status' => '1' ] ];
+		yield 'spam status' => [ 'spam', [ 'status' => 'spam' ] ];
+		yield 'trash status' => [ 'trash', [ 'status' => 'trash' ] ];
+		yield 'invalid status' => [ 'not-valid', [] ];
+	}
+
+	/**
 	 * Tests that can output the text for when no reviews are found.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::no_items()
@@ -1361,6 +1393,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can get the reviews' status filter.
+	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_status_filters()
 	 *
 	 * @return void
@@ -1424,6 +1458,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can get a view URL for the product reviews page.
+	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_view_url()
 	 * @dataProvider provider_get_view_url
 	 *
@@ -1472,6 +1508,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can convert the status to a query value.
+	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::convert_status_to_query_value()
 	 * @dataProvider provider_convert_status_string_to_comment_approved
 	 *
@@ -1499,10 +1537,12 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can get the product reviews count.
+	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_review_count()
 	 *
 	 * @return void
-	 * @throws ReflectionException If the metehod doesn't exist.
+	 * @throws ReflectionException If the method doesn't exist.
 	 */
 	public function test_get_review_count() {
 		// Add a normal post with some comments -- these should not appear in our counts.
@@ -1575,6 +1615,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can get the product reviews page views.
+	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_views()
 	 *
 	 * @return void
@@ -1598,36 +1640,6 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			],
 			$method->invoke( $list_table )
 		);
-	}
-
-	/**
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_status_arguments()
-	 * @dataProvider provider_get_status_arguments
-	 *
-	 * @param string $status        Current status for the request.
-	 * @param array  $expected_args Expected result of the method.
-	 * @return void
-	 * @throws ReflectionException If the method doesn't exist.
-	 */
-	public function test_get_status_arguments( string $status, array $expected_args ) {
-		global $comment_status;
-		$comment_status = $status; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-
-		$list_table = $this->get_reviews_list_table();
-		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_status_arguments' );
-		$method->setAccessible( true );
-
-		$this->assertSame( $expected_args, $method->invoke( $list_table ) );
-	}
-
-	/** @see test_get_status_arguments */
-	public function provider_get_status_arguments() : Generator {
-		yield 'all statuses' => [ 'all', [] ];
-		yield 'moderated status' => [ 'moderated', [ 'status' => '0' ] ];
-		yield 'approved status' => [ 'approved', [ 'status' => '1' ] ];
-		yield 'spam status' => [ 'spam', [ 'status' => 'spam' ] ];
-		yield 'trash status' => [ 'trash', [ 'status' => 'trash' ] ];
-		yield 'invalid status' => [ 'not-valid', [] ];
 	}
 
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -42,7 +42,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( '<table class="wp-list-table', $output );
-		$this->assertStringContainsString( '<tbody id="the-comment-list', $output );
+		$this->assertStringContainsString( '<tbody id="the-comment-list" data-wp-lists="list:comment">', $output );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -646,6 +646,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		if ( null !== $review_type ) {
 			$_REQUEST['review_type'] = $review_type;
+		} else {
+			unset( $_REQUEST['review_type'] );
 		}
 
 		$method->invoke( $list_table );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -26,6 +26,26 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that will output the reviews list table with the expected HTML elements.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::display()
+	 *
+	 * @return void
+	 */
+	public function test_display() {
+		$this->factory()->comment->create_many( 2 );
+
+		ob_start();
+
+		$this->get_reviews_list_table()->display();
+
+		$output = ob_get_clean();
+
+		$this->assertContains( '<table class="wp-list-table"', $output );
+		$this->assertContains( '<tbody id="the-comment-list"', $output );
+	}
+
+	/**
 	 * Tests that can process the row output for a review or reply.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::single_row()

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1300,9 +1300,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		);
 
 		if ( ! empty( $hook_callback ) ) {
-			add_action( 'woocommerce_manage_product_reviews_custom_column', $hook_callback, 10, 2 );
+			add_action( 'woocommerce_product_reviews_table_custom_column', $hook_callback, 10, 2 );
 		} else {
-			remove_all_actions( 'woocommerce_manage_product_reviews_custom_column' );
+			remove_all_actions( 'woocommerce_product_reviews_table_custom_column' );
 		}
 
 		ob_start();

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1283,7 +1283,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * Tests that can output the default column content.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_default()
-	 * @dataProvider provider_column_default
+	 * @dataProvider data_provider_column_default
 	 *
 	 * @param callable|null $hook_callback   Optional callback to add to the action.
 	 * @param string        $expected_output Expected output from the method.
@@ -1315,7 +1315,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/** @see test_column_default */
-	public function provider_column_default() : Generator {
+	public function data_provider_column_default() : Generator {
 		yield 'no callback' => [ null, '' ];
 
 		yield 'custom callback' => [

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1773,4 +1773,36 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		yield 'page 2' => [ null, 2, [ 'offset' => 20 ] ];
 	}
 
+	/**
+	 * Tests that `offset` and `number` values are always set to `0`, and that `count` is added to the array.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_total_comments_arguments()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_total_comments_arguments() {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_total_comments_arguments' );
+		$method->setAccessible( true );
+
+		$default_query_args = [
+			'offset'  => 20,
+			'number'  => 20,
+			'status'  => '1',
+			'post_id' => 5,
+		];
+
+		$this->assertSame(
+			[
+				'offset'  => 0,
+				'number'  => 0,
+				'status'  => '1',
+				'post_id' => 5,
+				'count'   => true,
+			],
+			$method->invoke( $list_table, $default_query_args )
+		);
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1280,6 +1280,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can output the default column content.
+	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_default()
 	 * @dataProvider provider_column_default
 	 *
@@ -1348,4 +1350,5 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( '<label class="screen-reader-text" for="filter-by-product">Filter by product</label>', $output );
 		$this->assertStringContainsString( '<option value="' . $product->get_id() . '"', $output );
 	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1108,4 +1108,40 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		yield 'Replies'      => [ 'comment' ];
 		yield 'Reviews'      => [ 'review' ];
 	}
+
+	/**
+	 * Tests that can output a filter dropdown for review ratings.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::review_rating_dropdown()
+	 * @dataProvider data_provider_test_review_rating_dropdown
+	 *
+	 * @param string $chosen_rating The rating to filter reviews for.
+	 * @return void
+	 * @throws ReflectionException If the method is not defined.
+	 */
+	public function test_review_rating_dropdown( $chosen_rating ) {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'review_rating_dropdown' );
+		$method->setAccessible( true );
+
+		ob_start();
+
+		$method->invokeArgs( $list_table, [ $chosen_rating ] );
+
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<label class="screen-reader-text" for="filter-by-review-rating">Filter by review rating</label>', $output );
+		$this->assertStringContainsString( '<select id="filter-by-review-rating" name="review_rating">', $output );
+		$this->assertStringContainsString( '<option value="' . $chosen_rating . '"  selected', $output );
+	}
+
+	/** @see test_review_type_dropdown */
+	public function data_provider_test_review_rating_dropdown() : Generator {
+		yield 'All ratings'    => [ 0 ];
+		yield '1 star'         => [ 1 ];
+		yield '2 stars'        => [ 2 ];
+		yield '3 stars'        => [ 3 ];
+		yield '4 stars'        => [ 4 ];
+		yield '5 stars'        => [ 5 ];
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -844,7 +844,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( [], $args );
 
-		$property->setValue( $list_table, 1 );
+		$property->setValue( $list_table, 5 );
 
 		$args = $method->invoke( $list_table );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1175,4 +1175,30 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		yield 'Replies'      => [ 'comment' ];
 		yield 'Reviews'      => [ 'review' ];
 	}
+
+	/**
+	 * Tests that can output a product search field for the product in context.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::product_search()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method is not defined.
+	 */
+	public function test_product_search() {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'product_search' );
+		$method->setAccessible( true );
+
+		$product = WC_Helper_Product::create_simple_product( false );
+
+		ob_start();
+
+		$method->invokeArgs( $list_table, [ $product ] );
+
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<label class="screen-reader-text" for="filter-by-product">Filter by product</label>', $output );
+		$this->assertStringContainsString( '<select id="filter-by-product" name="product_id">', $output );
+		$this->assertStringContainsString( '<option value="' . $product->get_id() . '"  selected', $output );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -823,6 +823,47 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can set the filter rating for the current request.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_filter_rating_arguments()
+	 *
+	 * @return void
+	 * @throws ReflectionException If reflected method or property don't exist.
+	 */
+	public function test_get_filter_rating_arguments() {
+		$list_table = $this->get_reviews_list_table();
+		$reflection = new ReflectionClass( $list_table );
+		$method = $reflection->getMethod( 'get_filter_rating_arguments' );
+		$method->setAccessible( true );
+		$property = $reflection->getProperty( 'current_reviews_rating' );
+		$property->setAccessible( true );
+
+		$property->setValue( $list_table, 0 );
+
+		$args = $method->invoke( $list_table );
+
+		$this->assertSame( [], $args );
+
+		$property->setValue( $list_table, 1 );
+
+		$args = $method->invoke( $list_table );
+
+		$this->assertEquals(
+			[
+				'meta_query' => [
+					[
+						'key'     => 'rating',
+						'value'   => 5,
+						'compare' => '=',
+						'type'    => 'NUMERIC',
+					],
+				],
+			],
+			$args
+		);
+	}
+
+	/**
 	 * Tests that can output the text for when no reviews are found.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::no_items()

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1293,15 +1293,11 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method->setAccessible( true );
 
 		$review = $this->factory()->comment->create_and_get();
+		$callback = function( $review ) {
+			echo 'Custom content for "custom_column" for ID ' . esc_html( $review->comment_ID );
+		};
 
-		add_action(
-			'woocommerce_product_reviews_table_column_custom_column',
-			static function( $review ) {
-				echo 'Custom content for "custom_column" for ID ' . esc_html( $review->comment_ID );
-			},
-			10,
-			2
-		);
+		add_action( 'woocommerce_product_reviews_table_column_custom_column', $callback, 10, 2 );
 
 		ob_start();
 
@@ -1309,7 +1305,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 'Custom content for "custom_column" for ID ' . $review->comment_ID, ob_get_clean() );
 
-		remove_all_actions( 'woocommerce_product_reviews_table_column_custom_column' );
+		remove_action( 'woocommerce_product_reviews_table_column_custom_column', $callback );
 	}
 
 	/**
@@ -1326,23 +1322,19 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method->setAccessible( true );
 
 		$review = $this->factory()->comment->create_and_get();
+		$callback = function( $content, $review ) {
+			return 'Additional content to "' . $content . '" for test column belonging to review with ID: ' . esc_html( $review->comment_ID );
+		};
 
-		add_filter(
-			'woocommerce_product_reviews_table_column_test_content',
-			static function( $content, $review ) {
-				return 'Additional content to "' . $content . '" for test column belonging to review with ID: ' . $review->comment_ID; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			},
-			10,
-			2
-		);
+		add_filter( 'woocommerce_product_reviews_table_column_test_content', $callback, 10, 2 );
 
 		ob_start();
 
 		$method->invokeArgs( $list_table, [ 'test', 'test content', $review ] );
 
-		$this->assertSame( 'Additional content to "test content" for test column belonging to review with ID: ' . $review->comment_ID, ob_get_clean() );
+		$this->assertSame( 'Additional content to "test content" for test column belonging to review with ID: ' . (string) $review->comment_ID, ob_get_clean() );
 
-		remove_all_filters( 'woocommerce_product_reviews_table_column_test_content' );
+		remove_filter( 'woocommerce_product_reviews_table_column_test_content', $callback );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -380,11 +380,51 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$this->assertSame(
 			[
-				'all'       => 'All',
-				'moderated' => 'Pending',
-				'approved'  => 'Approved',
-				'spam'      => 'Spam',
-				'trash'     => 'Trash',
+				'all'       => [
+					'All <span class="count">(%s)</span>',
+					'All <span class="count">(%s)</span>',
+					'product reviews',
+					'singular' => 'All <span class="count">(%s)</span>',
+					'plural'   => 'All <span class="count">(%s)</span>',
+					'context'  => 'product reviews',
+					'domain'   => 'woocommerce',
+				],
+				'moderated' => [
+					'Pending <span class="count">(%s)</span>',
+					'Pending <span class="count">(%s)</span>',
+					'product reviews',
+					'singular' => 'Pending <span class="count">(%s)</span>',
+					'plural'   => 'Pending <span class="count">(%s)</span>',
+					'context'  => 'product reviews',
+					'domain'   => 'woocommerce',
+				],
+				'approved'  => [
+					'Approved <span class="count">(%s)</span>',
+					'Approved <span class="count">(%s)</span>',
+					'product reviews',
+					'singular' => 'Approved <span class="count">(%s)</span>',
+					'plural'   => 'Approved <span class="count">(%s)</span>',
+					'context'  => 'product reviews',
+					'domain'   => 'woocommerce',
+				],
+				'spam'      => [
+					'Spam <span class="count">(%s)</span>',
+					'Spam <span class="count">(%s)</span>',
+					'product reviews',
+					'singular' => 'Spam <span class="count">(%s)</span>',
+					'plural'   => 'Spam <span class="count">(%s)</span>',
+					'context'  => 'product reviews',
+					'domain'   => 'woocommerce',
+				],
+				'trash'     => [
+					'Trash <span class="count">(%s)</span>',
+					'Trash <span class="count">(%s)</span>',
+					'product reviews',
+					'singular' => 'Trash <span class="count">(%s)</span>',
+					'plural'   => 'Trash <span class="count">(%s)</span>',
+					'context'  => 'product reviews',
+					'domain'   => 'woocommerce',
+				],
 			],
 			$method->invoke( $list_table )
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -670,13 +670,13 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_sort_arguments' );
 		$method->setAccessible( true );
 
-		if ( ! is_null( $orderby ) ) {
+		if ( null !== $orderby ) {
 			$_REQUEST['orderby'] = $orderby;
 		} else {
 			unset( $_REQUEST['orderby'] );
 		}
 
-		if ( ! is_null( $order ) ) {
+		if ( null !== $order ) {
 			$_REQUEST['order'] = $order;
 		} else {
 			unset( $_REQUEST['order'] );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1086,6 +1086,31 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @covers       \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_search_arguments()
+	 * @dataProvider provider_get_search_arguments
+	 *
+	 * @param mixed $search_value  Current search value in the request.
+	 * @param array $expected_args Expected result of the method.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_search_arguments( $search_value, array $expected_args ) {
+		$_REQUEST['s'] = $search_value;
+
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_search_arguments' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected_args, $method->invoke( $list_table ) );
+	}
+
+	/** @see test_get_search_arguments */
+	public function provider_get_search_arguments() : Generator {
+		yield 'no search' => [ null, [] ];
+		yield 'search value' => [ 'test', [ 'search' => 'test' ] ];
+	}
+
+	/**
 	 * Tests that can output the text for when no reviews are found.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::no_items()

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -431,6 +431,54 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_view_url()
+	 * @dataProvider provider_get_view_url
+	 *
+	 * @param string $comment_type Current type filter.
+	 * @param int    $post_id      Current post ID filter.
+	 * @param string $expected     Expected URL from the method.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_view_url( string $comment_type, int $post_id, string $expected ) {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_view_url' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			$expected,
+			$method->invoke( $list_table, $comment_type, $post_id )
+		);
+	}
+
+	/** @see test_get_view_url */
+	public function provider_get_view_url() : Generator {
+		yield 'empty type, empty post ID' => [
+			'comment_type' => '',
+			'post_id'      => 0,
+			'expected'     => 'http://example.org/wp-admin/edit.php?post_type=product&page=product-reviews',
+		];
+
+		yield 'review type, empty post ID' => [
+			'comment_type' => 'review',
+			'post_id'      => 0,
+			'expected'     => 'http://example.org/wp-admin/edit.php?post_type=product&page=product-reviews&comment_type=review',
+		];
+
+		yield 'reply type, with post ID' => [
+			'comment_type' => 'reply',
+			'post_id'      => 123,
+			'expected'     => 'http://example.org/wp-admin/edit.php?post_type=product&page=product-reviews&comment_type=reply&p=123',
+		];
+
+		yield 'all type, with post ID' => [
+			'comment_type' => 'all',
+			'post_id'      => 123,
+			'expected'     => 'http://example.org/wp-admin/edit.php?post_type=product&page=product-reviews&p=123',
+		];
+	}
+
+	/**
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::convert_status_to_query_value()
 	 * @dataProvider provider_convert_status_string_to_comment_approved
 	 *

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -624,6 +624,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$this->assertSame( $product->get_id(), $property->getValue( $list_table )->get_id() );
 
 		WC_Helper_Product::delete_product( $product->get_id() );
+
+		unset( $_REQUEST['product_id'] );
 	}
 
 	/**
@@ -858,6 +860,33 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		yield 'Replies'           => [ 'comment', 'comment' ];
 		yield 'Reviews'           => [ 'review', 'review' ];
 		yield 'Other'             => [ 'other', 'other' ];
+	}
+
+	/**
+	 * Tests that can get the post ID argument for the current request.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_filter_product_arguments()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method or the property don't exist.
+	 */
+	public function test_get_filter_product_arguments() {
+		$list_table = $this->get_reviews_list_table();
+		$reflection = new ReflectionClass( $list_table );
+		$method = $reflection->getMethod( 'get_filter_product_arguments' );
+		$method->setAccessible( true );
+		$property = $reflection->getProperty( 'current_product_for_reviews' );
+		$property->setAccessible( true );
+
+		$this->assertSame( [], $method->invoke( $list_table ) );
+
+		$product = WC_Helper_Product::create_simple_product( true );
+
+		$property->setValue( $product );
+
+		$this->assertSame( [ 'post_id' => $product->get_id() ], $method->invoke( $list_table ) );
+
+		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1325,10 +1325,12 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'filter_column_output' );
 		$method->setAccessible( true );
 
+		$review = $this->factory()->comment->create_and_get();
+
 		add_filter(
 			'woocommerce_product_reviews_table_column_test_content',
 			static function( $content, $review ) {
-				return 'Additional content to ' . $content . ' for test column for review with content: ' . $review->comment_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				return 'Additional content to "' . $content . '" for test column for review with ID: ' . $review->comment_ID; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			},
 			10,
 			2
@@ -1336,9 +1338,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		ob_start();
 
-		$method->invokeArgs( $list_table, [ 'test', '"example content"', $review ] );
+		$method->invokeArgs( $list_table, [ 'test', 'test content', $review ] );
 
-		$this->assertSame( 'Additional content to "example content" for review with content: ' . $review->comment_content, ob_get_clean() );
+		$this->assertSame( 'Additional content to "test content" for review with ID: ' . $review->comment_ID, ob_get_clean() );
 
 		remove_all_filters( 'woocommerce_product_reviews_table_column_test_content' );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1325,12 +1325,16 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'filter_column_output' );
 		$method->setAccessible( true );
 
-		$review = $this->factory()->comment->create_and_get();
+		$review = $this->factory()->comment->create_and_get(
+			[
+				'comment_content' => 'Test content',
+			]
+		);
 
 		add_filter(
 			'woocommerce_product_reviews_table_column_test_content',
 			static function( $content, $review ) {
-				return 'Additional content to ' . $content . ' for test column for review ID ' . $review->comment_ID; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				return 'Additional content to ' . $content . ' for test column for review with content: ' . $review->comment_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			},
 			10,
 			2
@@ -1340,7 +1344,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$method->invokeArgs( $list_table, [ 'test', '"example content"', $review ] );
 
-		$this->assertSame( 'Additional content to "example content" for review ID ' . $review->comment_ID, ob_get_clean() );
+		$this->assertSame( 'Additional content to "example content" for review with content: ' . $review->comment_content, ob_get_clean() );
 
 		remove_all_filters( 'woocommerce_product_reviews_table_column_test_content' );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\Internal\Admin\ReviewsListTable;
 use Generator;
 use ReflectionClass;
 use ReflectionException;
+use WC_Helper_Product;
 use WC_Unit_Test_Case;
 
 /**
@@ -590,6 +591,39 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 				'delete',
 			],
 		];
+	}
+
+	/**
+	 * Tests that can set the product to filter reviews by.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::set_review_product()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method or the property do not exist.
+	 */
+	public function test_set_review_product() {
+		$list_table = $this->get_reviews_list_table();
+		$reflection = new ReflectionClass( $list_table );
+		$method = $reflection->getMethod( 'set_review_product' );
+		$method->setAccessible( true );
+		$property = $reflection->getProperty( 'current_product_for_reviews' );
+		$property->setAccessible( true );
+
+		$_REQUEST['product_id'] = 0;
+
+		$method->invoke( $list_table );
+
+		$this->assertNull( $property->getValue( $list_table ) );
+
+		$product = WC_Helper_Product::create_simple_product( true );
+
+		$_REQUEST['product_id'] = $product->get_id();
+
+		$method->invoke( $list_table );
+
+		$this->assertSame( $product->get_id(), $property->getValue( $list_table )->get_id() );
+
+		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -96,7 +96,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			];
 		};
 
-		add_filter( 'woocommerce_product_review_table_columns', $filter_callback );
+		add_filter( 'woocommerce_product_reviews_table_columns', $filter_callback );
 
 		$this->assertSame(
 			[
@@ -105,7 +105,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			$this->get_reviews_list_table()->get_columns()
 		);
 
-		remove_filter( 'woocommerce_product_review_table_columns', $filter_callback );
+		remove_filter( 'woocommerce_product_reviews_table_columns', $filter_callback );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -229,7 +229,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * Tests that can output the author information.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_author()
-	 * @dataProvider provider_column_author
+	 * @dataProvider data_provider_column_author
 	 *
 	 * @param bool $show_avatars          Value for the `show_avatars` option.
 	 * @param bool $should_contain_avatar If the HTML should contain an avatar.
@@ -275,7 +275,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/** @see test_column_author */
-	public function provider_column_author() : Generator {
+	public function data_provider_column_author() : Generator {
 		yield 'avatars disabled' => [ false, false ];
 		yield 'avatars enabled'  => [ true, true ];
 	}
@@ -520,7 +520,10 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @dataProvider provider_get_bulk_actions
+	 * Tests that can get the bulk actions for the product reviews page.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_bulk_actions()
+	 * @dataProvider data_provider_get_bulk_actions
 	 *
 	 * @param string $current_comment_status Currently set status.
 	 * @param array  $expected_actions       Keys of the expected actions.
@@ -542,7 +545,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/** @see test_get_bulk_actions */
-	public function provider_get_bulk_actions() : Generator {
+	public function data_provider_get_bulk_actions() : Generator {
 		yield 'all statuses' => [
 			'current_comment_status' => 'all',
 			'expected_actions' => [
@@ -593,7 +596,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * Tests that can set the review status for the current request.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::set_review_status()
-	 * @dataProvider provider_set_review_status
+	 * @dataProvider data_provider_set_review_status
 	 *
 	 * @param string|null $request_status          Status that's in the request.
 	 * @param string      $expected_comment_status Expected value for the global variable.
@@ -615,7 +618,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/** @see test_set_review_status */
-	public function provider_set_review_status() : Generator {
+	public function data_provider_set_review_status() : Generator {
 		yield 'not set'          => [ null, 'all' ];
 		yield 'invalid status'   => [ 'invalid', 'all' ];
 		yield 'moderated status' => [ 'moderated', 'moderated' ];
@@ -653,8 +656,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the sort arguments for the current request.
 	 *
-	 * @covers       \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_sort_arguments()
-	 * @dataProvider provider_get_sort_arguments
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_sort_arguments()
+	 * @dataProvider data_provider_get_sort_arguments
 	 *
 	 * @param string|null $orderby       The orderby value that's set in the request.
 	 * @param string|null $order         The order value that's set in the request.
@@ -683,7 +686,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/** @see test_get_sort_arguments */
-	public function provider_get_sort_arguments() : Generator {
+	public function data_provider_get_sort_arguments() : Generator {
 		yield 'order by comment_author desc' => [
 			'comment_author',
 			'desc',
@@ -753,7 +756,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * Tests that can output the text for when no reviews are found.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::no_items()
-	 * @dataProvider provider_no_items
+	 * @dataProvider data_provider_no_items
 	 *
 	 * @param string $status   Filtered status.
 	 * @param string $expected Expected text.
@@ -771,7 +774,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/** @see test_no_items */
-	public function provider_no_items() : \Generator {
+	public function data_provider_no_items() : \Generator {
 		yield 'moderated filter' => [ 'moderated', 'No reviews awaiting moderation.' ];
 		yield 'no filter'        => [ '', 'No reviews found.' ];
 		yield 'spam filter'      => [ 'spam', 'No reviews found.' ];
@@ -781,7 +784,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * Tests that can render the extra controls for the product reviews page.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::extra_tablenav()
-	 * @dataProvider provider_test_extra_tablenav()
+	 * @dataProvider data_provider_test_extra_tablenav()
 	 *
 	 * @param string   $position                  Position (top or bottom).
 	 * @param bool     $has_items                 Whether the table has items.
@@ -831,7 +834,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/** @see test_extra_tablenav() */
-	public function provider_test_extra_tablenav() : Generator {
+	public function data_provider_test_extra_tablenav() : Generator {
 		yield 'no items top' => [
 			'position' => 'top',
 			'has_items' => false,

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1328,11 +1328,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		add_filter( 'woocommerce_product_reviews_table_column_test_content', $callback, 10, 2 );
 
-		ob_start();
+		$output = $method->invokeArgs( $list_table, [ 'test', 'test content', $review ] );
 
-		$method->invokeArgs( $list_table, [ 'test', 'test content', $review ] );
-
-		$this->assertSame( 'Additional content to "test content" for test column belonging to review with ID: ' . (string) $review->comment_ID, ob_get_clean() );
+		$this->assertSame( 'Additional content to "test content" for test column belonging to review with ID: ' . (string) $review->comment_ID, $output );
 
 		remove_filter( 'woocommerce_product_reviews_table_column_test_content', $callback );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -122,6 +122,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			} else {
 				$this->assertStringContainsString( 'Trash', $actions );
 			}
+
+			// Should not contain any tags with _only_ a pipe separator, but no label.
+			$this->assertStringNotContainsString( '> | </span>', $actions );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -531,7 +531,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * @throws ReflectionException If the method doesn't exist.
 	 */
 	public function test_get_bulk_actions( string $current_comment_status, array $expected_actions ) {
-		$list_table = new ReviewsListTable( [ 'screen' => 'product_page_product-reviews' ] );
+		$list_table = $this->get_reviews_list_table();
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_bulk_actions' );
 		$method->setAccessible( true );
 
@@ -604,7 +604,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * @throws ReflectionException If the method doesn't exist.
 	 */
 	public function test_set_review_status( ?string $request_status, string $expected_comment_status ) {
-		$list_table = new ReviewsListTable( [ 'screen' => 'product_page_product-reviews' ] );
+		$list_table = $this->get_reviews_list_table();
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'set_review_status' );
 		$method->setAccessible( true );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -41,8 +41,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$output = ob_get_clean();
 
-		$this->assertContains( '<table class="wp-list-table"', $output );
-		$this->assertContains( '<tbody id="the-comment-list"', $output );
+		$this->assertStringContainsString( '<table class="wp-list-table"', $output );
+		$this->assertStringContainsString( '<tbody id="the-comment-list"', $output );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -7,7 +7,6 @@ use Generator;
 use ReflectionClass;
 use ReflectionException;
 use WC_Unit_Test_Case;
-use WP_Comment;
 
 /**
  * Tests that product reviews page handler.
@@ -29,6 +28,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * Tests that can process the row output for a review or reply.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::single_row()
+	 *
+	 * @return void
 	 */
 	public function test_single_row() {
 		$post_id = $this->factory()->post->create();
@@ -63,6 +64,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * Tests that can get the product reviews' page columns.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_columns()
+	 *
+	 * @return void
 	 */
 	public function test_get_columns() {
 		$this->assertSame(
@@ -84,6 +87,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_primary_column_name()
 	 *
+	 * @return void
 	 * @throws ReflectionException If the method does not exist.
 	 */
 	public function test_get_primary_column_name() {
@@ -100,6 +104,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * @dataProvider data_provider_test_column_cb()
 	 * @param bool   $current_user_can_edit Whether the current user has the capability to edit this review.
 	 * @param string $expected_output The expected output.
+	 * @return void
+	 * @throws ReflectionException If the method does not exist.
 	 */
 	public function test_column_cb( bool $current_user_can_edit, string $expected_output ) {
 		$list_table = $this->get_reviews_list_table();
@@ -146,6 +152,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 *
 	 * @param string $comment_type The comment type (usually review or comment).
 	 * @param string $expected_output The expected output.
+	 * @return void
 	 * @throws ReflectionException If the method does not exist.
 	 */
 	public function test_column_type( $comment_type, $expected_output ) {
@@ -176,11 +183,14 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_rating()
+	 * Tests that can generate the column rating HTML output.
 	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_rating()
 	 * @dataProvider data_provider_test_column_rating()
+	 *
 	 * @param string $meta_value The comment meta value for rating.
 	 * @param string $expected_output The expected output.
+	 * @return void
 	 * @throws ReflectionException If the method does not exist.
 	 */
 	public function test_column_rating( $meta_value, $expected_output ) {
@@ -203,7 +213,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/** @see test_column_rating() */
-	public function data_provider_test_column_rating() {
+	public function data_provider_test_column_rating() : array {
 		return [
 			'no rating' => [ '', '' ],
 			'1 star' => [ '1', '<span aria-label="1 out of 5">&#9733;&#9734;&#9734;&#9734;&#9734;</span>' ],
@@ -223,7 +233,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 *
 	 * @param bool $show_avatars          Value for the `show_avatars` option.
 	 * @param bool $should_contain_avatar If the HTML should contain an avatar.
-	 *
+	 * @return void
 	 * @throws ReflectionException If the method does not exist.
 	 */
 	public function test_column_author( bool $show_avatars, bool $should_contain_avatar ) {
@@ -267,7 +277,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/** @see test_column_author */
 	public function provider_column_author() : Generator {
 		yield 'avatars disabled' => [ false, false ];
-		yield 'avatars enabled' => [ true, true ];
+		yield 'avatars enabled'  => [ true, true ];
 	}
 
 	/**
@@ -278,6 +288,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 *
 	 * @param string $comment_author_url The comment author URL.
 	 * @param string $expected_author_url The expected author URL.
+	 * @return void
 	 * @throws ReflectionException If the method does not exist.
 	 */
 	public function test_get_item_author_url( $comment_author_url, $expected_author_url ) {
@@ -316,6 +327,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 *
 	 * @param string $author_url The author URL.
 	 * @param string $author_url_for_display The author URL for display.
+	 * @return void
 	 * @throws ReflectionException If the method does not exist.
 	 */
 	public function test_get_item_author_url_for_display( $author_url, $author_url_for_display ) {
@@ -347,6 +359,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 *
 	 * @param bool $has_product   Whether the review is for a valid product object.
 	 * @param int  $approved_flag The review (comment) approved flag.
+	 * @return void
 	 * @throws ReflectionException If the method does not exist.
 	 */
 	public function test_column_date( $has_product, $approved_flag ) {
@@ -386,9 +399,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/** @see test_column_date() */
 	public function data_provider_test_column_date() {
 		return [
-			'No product' => [ false, 1 ],
+			'No product'   => [ false, 1 ],
 			'Not approved' => [ true, 0 ],
-			'Approved' => [ true, 1 ],
+			'Approved'     => [ true, 1 ],
 		];
 	}
 
@@ -397,6 +410,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_response()
 	 *
+	 * @return void
 	 * @throws ReflectionException If the method does not exist.
 	 */
 	public function test_column_response() {
@@ -429,6 +443,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_comment()
 	 *
+	 * @return void
 	 * @throws ReflectionException If the method does not exist.
 	 */
 	public function test_column_comment() {
@@ -475,6 +490,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_in_reply_to_review_text()
 	 *
+	 * @return void
 	 * @throws ReflectionException If the method does not exist.
 	 */
 	public function test_get_in_reply_to_review_text() {
@@ -574,6 +590,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can set the review status for the current request.
+	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::set_review_status()
 	 * @dataProvider provider_set_review_status
 	 *
@@ -598,16 +616,18 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 	/** @see test_set_review_status */
 	public function provider_set_review_status() : Generator {
-		yield 'not set' => [ null, 'all' ];
-		yield 'invalid status' => [ 'invalid', 'all' ];
+		yield 'not set'          => [ null, 'all' ];
+		yield 'invalid status'   => [ 'invalid', 'all' ];
 		yield 'moderated status' => [ 'moderated', 'moderated' ];
-		yield 'all status' => [ 'all', 'all' ];
-		yield 'approved status' => [ 'approved', 'approved' ];
-		yield 'spam status' => [ 'spam', 'spam' ];
-		yield 'trash status' => [ 'trash', 'trash' ];
+		yield 'all statuses'     => [ 'all', 'all' ];
+		yield 'approved status'  => [ 'approved', 'approved' ];
+		yield 'spam status'      => [ 'spam', 'spam' ];
+		yield 'trash status'     => [ 'trash', 'trash' ];
 	}
 
 	/**
+	 * Tests that can get the sortable columns for the reviews table.
+	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_sortable_columns()
 	 *
 	 * @return void
@@ -631,6 +651,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can get the sort arguments for the current request.
+	 *
 	 * @covers       \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_sort_arguments()
 	 * @dataProvider provider_get_sort_arguments
 	 *
@@ -728,6 +750,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can output the text for when no reviews are found.
+	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::no_items()
 	 * @dataProvider provider_no_items
 	 *
@@ -749,11 +773,13 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/** @see test_no_items */
 	public function provider_no_items() : \Generator {
 		yield 'moderated filter' => [ 'moderated', 'No reviews awaiting moderation.' ];
-		yield 'no filter' => [ '', 'No reviews found.' ];
-		yield 'spam filter' => [ 'spam', 'No reviews found.' ];
+		yield 'no filter'        => [ '', 'No reviews found.' ];
+		yield 'spam filter'      => [ 'spam', 'No reviews found.' ];
 	}
 
 	/**
+	 * Tests that can render the extra controls for the product reviews page.
+	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::extra_tablenav()
 	 * @dataProvider provider_test_extra_tablenav()
 	 *
@@ -765,6 +791,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * @param string[] $expected_elements         Output should contain these elements.
 	 * @param string   $expected_end              Output should end with this string.
 	 * @param string[] $not_expected_elements     Output should not contain these elements.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
 	 */
 	public function test_extra_tablenav( string $position, bool $has_items, bool $current_user_can_moderate, string $status, string $expected_start, array $expected_elements, string $expected_end, array $not_expected_elements ) {
 		global $comment_status;

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -814,7 +814,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$args = $method->invoke( $list_table );
 
-		$this->assertSame( $comment_type, $args['comment_type'] ?? null );
+		$this->assertSame( $comment_type, $args['type'] ?? null );
 	}
 
 	/** @see test_get_filter_type_arguments */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1328,9 +1328,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$review = $this->factory()->comment->create_and_get();
 
 		add_filter(
-			'woocommerce_product_reviews_table_column_test',
+			'woocommerce_product_reviews_table_column_test_content',
 			static function( $content, $review ) {
-				return 'Additional content to ' . $content . ' for test column for review ID ' . esc_html( $review->comment_ID );
+				return 'Additional content to ' . $content . ' for test column for review ID ' . $review->comment_ID; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			},
 			10,
 			2
@@ -1342,7 +1342,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 'Additional content to "example content" for review ID ' . $review->comment_ID, ob_get_clean() );
 
-		remove_all_filters( 'woocommerce_product_reviews_table_column_test' );
+		remove_all_filters( 'woocommerce_product_reviews_table_column_test_content' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -808,6 +808,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		if ( null !== ( $review_type ) ) {
 			$_REQUEST['review_type'] = $review_type;
+		} else {
+			unset( $_REQUEST['review_type'] );
 		}
 
 		$args = $method->invoke( $list_table );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1214,4 +1214,30 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$this->assertSame( 5, $method->invoke( $list_table, 'all', $product_id ) );
 	}
 
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_views()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_views() {
+		global $comment_status;
+		$comment_status = 'all'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_views' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			[
+				'all'       => '<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews&#038;comment_status=all" class="current" aria-current="page">All <span class="count">(<span class="all-count">0</span>)</span></a>',
+				'moderated' => '<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews&#038;comment_status=moderated">Pending <span class="count">(<span class="pending-count">0</span>)</span></a>',
+				'approved'  => '<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews&#038;comment_status=approved">Approved <span class="count">(<span class="approved-count">0</span>)</span></a>',
+				'spam'      => '<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews&#038;comment_status=spam">Spam <span class="count">(<span class="spam-count">0</span>)</span></a>',
+				'trash'     => '<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews&#038;comment_status=trash">Trash <span class="count">(<span class="trash-count">0</span>)</span></a>',
+			],
+			$method->invoke( $list_table )
+		);
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -83,6 +83,32 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can get the product reviews' page columns when a filter is applied.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_columns()
+	 *
+	 * @return void
+	 */
+	public function test_get_columns_filtered() {
+		$filter_callback = function( $columns ) {
+			return [
+				'custom_column' => 'Custom column',
+			];
+		};
+
+		add_filter( 'woocommerce_product_review_table_columns', $filter_callback );
+
+		$this->assertSame(
+			[
+				'custom_column' => 'Custom column',
+			],
+			$this->get_reviews_list_table()->get_columns()
+		);
+
+		remove_filter( 'woocommerce_product_review_table_columns', $filter_callback );
+	}
+
+	/**
 	 * Tests that can get the primary column name.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_primary_column_name()

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -61,6 +61,80 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can handle the row actions for a review in the Reviews page table.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::handle_row_actions()
+	 * @dataProvider data_provider_test_handle_row_actions
+	 *
+	 * @param string $review_status  The review status.
+	 * @param string $column_name    The current column name being output.
+	 * @param string $primary_column The primary colum name.
+	 * @param bool   $user_can_edit  Whether the current user can edit reviews.
+	 * @return void
+	 * @throws ReflectionException If the method does not exist.
+	 */
+	public function test_handle_row_actions( $review_status, $column_name, $primary_column, $user_can_edit ) {
+		global $comment_status;
+
+		$comment_status = 'test'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$list_table = $this->get_reviews_list_table();
+		$reflection = new ReflectionClass( $list_table );
+		$method = $reflection->getMethod( 'handle_row_actions' );
+		$method->setAccessible( true );
+		$property = $reflection->getProperty( 'current_user_can_edit_review' );
+		$property->setAccessible( true );
+
+		$property->setValue( $list_table, $user_can_edit );
+
+		$review = $this->factory()->comment->create_and_get(
+			[
+				'comment_approved' => $review_status,
+			]
+		);
+
+		$actions = $method->invokeArgs( $list_table, [ $review, $column_name, $primary_column ] );
+
+		if ( $column_name !== $primary_column || ! $user_can_edit ) {
+
+			$this->assertEmpty( $actions );
+
+		} else {
+
+			if ( '1' === $review_status ) {
+				$review_status = 'approved';
+			} elseif ( '0' === $review_status ) {
+				$review_status = 'unapproved';
+			}
+
+			if ( 'approved' === $review_status || 'unapproved' === $review_status ) {
+				$this->assertStringContainsString( 'approved' === $review_status ? 'Unapprove' : 'Approve', $actions );
+				$this->assertStringContainsString( 'Spam', $actions );
+			} elseif ( 'spam' === $review_status ) {
+				$this->assertStringContainsString( 'Not Spam', $actions );
+			} elseif ( 'trash' === $review_status ) {
+				$this->assertStringContainsString( 'Restore', $actions );
+			}
+
+			if ( 'trash' === $review_status || 'spam' === $review_status ) {
+				$this->assertStringContainsString( 'Delete Permanently', $actions );
+			} else {
+				$this->assertStringContainsString( 'Trash', $actions );
+			}
+		}
+	}
+
+	/** @see test_handle_row_actions */
+	public function data_provider_test_handle_row_actions() : Generator {
+		yield 'Not the primary column'   => [ 'foo', 'bar', 'baz', true ];
+		yield 'User cannot edit reviews' => [ 'test', 'foo', 'foo', false ];
+		yield 'Approved review'          => [ '1', 'foo', 'foo', true ];
+		yield 'Unapproved review'        => [ '0', 'foo', 'foo', true ];
+		yield 'Trashed review'           => [ 'trash', 'foo', 'foo', true ];
+		yield 'Spam review'              => [ 'spam', 'foo', 'foo', true ];
+	}
+
+	/**
 	 * Tests that can get the product reviews' page columns.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_columns()

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1330,7 +1330,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		add_filter(
 			'woocommerce_product_reviews_table_column_test_content',
 			static function( $content, $review ) {
-				return 'Additional content to "' . $content . '" for test column for review with ID: ' . $review->comment_ID; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				return 'Additional content to "' . $content . '" for test column belonging to review with ID: ' . $review->comment_ID; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			},
 			10,
 			2
@@ -1340,7 +1340,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$method->invokeArgs( $list_table, [ 'test', 'test content', $review ] );
 
-		$this->assertSame( 'Additional content to "test content" for review with ID: ' . $review->comment_ID, ob_get_clean() );
+		$this->assertSame( 'Additional content to "test content" for test column belonging to review with ID: ' . $review->comment_ID, ob_get_clean() );
 
 		remove_all_filters( 'woocommerce_product_reviews_table_column_test_content' );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1805,4 +1805,20 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * This is only testing the default value as we don't have a "current user".
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_per_page()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_per_page() {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_per_page' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 20, $method->invoke( $list_table ) );
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1201,4 +1201,5 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( '<select id="filter-by-product" name="product_id">', $output );
 		$this->assertStringContainsString( '<option value="' . $product->get_id() . '"  selected', $output );
 	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1296,7 +1296,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$review = $this->factory()->comment->create_and_get();
 
 		add_action(
-			'woocommerce_product_reviews_table_custom_column',
+			'woocommerce_product_reviews_table_column_custom_column',
 			static function( $review ) {
 				echo 'Custom content for "custom_column" for ID ' . esc_html( $review->comment_ID );
 			},

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -520,7 +520,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Tests that can get the product reviews bulk actions.
+	 * Tests that can get the bulk actions for the product reviews page.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_bulk_actions()
 	 * @dataProvider data_provider_get_bulk_actions

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -41,8 +41,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( '<table class="wp-list-table"', $output );
-		$this->assertStringContainsString( '<tbody id="the-comment-list"', $output );
+		$this->assertStringContainsString( '<table class="wp-list-table', $output );
+		$this->assertStringContainsString( '<tbody id="the-comment-list', $output );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1739,4 +1739,38 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * @covers       \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_offset_arguments()
+	 * @dataProvider provider_get_offset_arguments
+	 *
+	 * @param mixed    $request_start_value `$_REQUEST['start']` value.
+	 * @param int|null $current_page_number Current page number (used if `$_REQUEST['start']` isn't set).
+	 * @param array    $expected_args       Expected result of the method.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_offset_arguments( $request_start_value, ?int $current_page_number, array $expected_args ) {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_offset_arguments' );
+		$method->setAccessible( true );
+
+		if ( ! is_null( $request_start_value ) ) {
+			$_REQUEST['start'] = $request_start_value;
+		} else {
+			unset( $_REQUEST['start'] );
+		}
+
+		$_REQUEST['paged'] = $current_page_number;
+
+		$this->assertSame( $expected_args, $method->invoke( $list_table ) );
+	}
+
+	/** @see test_get_offset_arguments */
+	public function provider_get_offset_arguments() : Generator {
+		yield 'start value has offset' => [ 5, null, [ 'offset' => 5 ] ];
+		yield 'start value set, but empty string' => [ '', null, [ 'offset' => 0 ] ];
+		yield 'page 1' => [ null, 1, [ 'offset' => 0 ] ];
+		yield 'page 2' => [ null, 2, [ 'offset' => 20 ] ];
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -208,17 +208,17 @@ class ReviewsTest extends WC_Unit_Test_Case {
 		global $comment;
 
 		$product = $this->factory()->post->create( [ 'post_type' => 'product' ] );
-		$review  = $this->factory()->comment->create( [ 'comment_post_ID' => $product ] );
-		$reply   = $this->factory()->comment->create(
+		$review  = $this->factory()->comment->create_and_get( [ 'comment_post_ID' => $product ] );
+		$reply   = $this->factory()->comment->create_and_get(
 			[
 				'comment_post_ID' => $product,
-				'comment_parent'  => $review,
+				'comment_parent'  => $review->comment_ID,
 			]
 		);
 
 		if ( ! $is_review ) {
 			$post    = $this->factory()->post->create();
-			$comment = $this->factory()->comment->create( [ 'comment_post_ID' => $post ] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$comment = $this->factory()->comment->create_and_get( [ 'comment_post_ID' => $post ] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		} else {
 			$comment = $is_reply ? $reply : $review; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -172,6 +172,26 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that it will override the parent file and the submenu file globals when editing a review.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::edit_review_parent_file()
+	 *
+	 * @return void
+	 */
+	public function test_edit_review_parent_file() {
+		global $submenu_file, $current_screen;
+
+		$product = $this->factory()->post->create( [ 'post_type' => 'product' ] );
+		$review = $this->factory()->comment->create( [ 'comment_post_ID' => $product ] );
+		$current_screen = (object) [ 'id' => 'comment' ]; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$_GET['c'] = $review;
+		$reviews = new Reviews();
+
+		$this->assertSame( 'edit.php?post_type=product', $reviews->edit_review_parent_file( 'test' ) );
+		$this->assertSame( 'product-reviews', $submenu_file );
+	}
+
+	/**
 	 * Tests that can output the reviews list table and filter it.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::render_reviews_list_table()

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -182,7 +182,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * @dataProvider provider_is_reviews_page
 	 *
 	 * @param string|null $new_pagenow     the value of the global $pageview var.
-	 * @param string|null $page            the value of $_GET['page'].
+	 * @param string|null $page            the value of $_GET[ 'page' ].
 	 * @param bool        $expected_result the expected bool result.
 	 * @return void
 	 */
@@ -229,6 +229,131 @@ class ReviewsTest extends WC_Unit_Test_Case {
 			'new_pagenow'     => 'edit.php',
 			'page'            => 'product-reviews',
 			'expected_result' => true,
+		];
+	}
+
+	/**
+	 * Tests that the admin notice messages are properly returned.
+	 *
+	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::get_bulk_action_notice_messages()
+	 * @dataProvider provider_get_bulk_action_notice_messages
+	 *
+	 * @param string[] $statuses        the wp comment statuses after a bulk operation.
+	 * @param int      $count           the number of affected comments.
+	 * @param array    $expected_result the action notice messages.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_bulk_action_notice_messages( $statuses, $count, $expected_result ) {
+
+		$reviews = new Reviews();
+
+		$method = ( new ReflectionClass( $reviews ) )->getMethod( 'get_bulk_action_notice_messages' );
+		$method->setAccessible( true );
+
+		foreach ( $statuses as $status ) {
+			$_REQUEST[ $status ] = $count;
+		}
+		$_REQUEST['ids'] = '1,2,3';
+
+		$result = $method->invoke( $reviews );
+
+		foreach ( $expected_result as $i => $expected_message ) {
+			$this->assertContains( $expected_message, $result[ $i ] );
+		}
+	}
+
+	/** @see test_get_bulk_action_notice_messages */
+	public function provider_get_bulk_action_notice_messages() : Generator {
+
+		yield 'An approved comment status' => [
+			'status'         => [ 'approved' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment approved' ],
+		];
+
+		yield 'Two approved comment statuses' => [
+			'status'         => [ 'approved' ],
+			'count'          => 2,
+			'expected_array' => [ '2 comments approved' ],
+		];
+
+		yield 'An unapproved comment status' => [
+			'status'         => [ 'unapproved' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment unapproved' ],
+		];
+
+		yield 'Two unapproved comment statuses' => [
+			'status'         => [ 'unapproved' ],
+			'count'          => 2,
+			'expected_array' => [ '2 comments unapproved' ],
+		];
+
+		yield 'A deleted comment status' => [
+			'status'         => [ 'deleted' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment permanently deleted' ],
+		];
+
+		yield 'Two deleted comment statuses' => [
+			'status'         => [ 'deleted' ],
+			'count'          => 2,
+			'expected_array' => [ '2 comments permanently deleted' ],
+		];
+
+		yield 'A trashed comment status' => [
+			'status'         => [ 'trashed' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment moved to the Trash.' ],
+		];
+
+		yield 'Two trashed comment statuses' => [
+			'status'         => [ 'trashed' ],
+			'count'          => 2,
+			'expected_array' => [ '2 comments moved to the Trash.' ],
+		];
+
+		yield 'An untrashed comment status' => [
+			'status'         => [ 'untrashed' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment restored from the Trash' ],
+		];
+
+		yield 'Two untrashed comment statuses' => [
+			'status'         => [ 'untrashed' ],
+			'count'          => 2,
+			'expected_array' => [ '2 comments restored from the Trash' ],
+		];
+
+		yield 'A spammed comment status' => [
+			'status'         => [ 'spammed' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment marked as spam.' ],
+		];
+
+		yield 'Two spammed comment statuses' => [
+			'status'         => [ 'spammed' ],
+			'count'          => 2,
+			'expected_array' => [ '2 comments marked as spam.' ],
+		];
+
+		yield 'An unspammed comment status' => [
+			'status'         => [ 'unspammed' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment restored from the spam' ],
+		];
+
+		yield 'Two unspammed comment statuses' => [
+			'status'         => [ 'unspammed' ],
+			'count'          => 2,
+			'expected_array' => [ '2 comments restored from the spam' ],
+		];
+
+		yield 'Two different statuses' => [
+			'status'         => [ 'approved', 'unapproved' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment approved', '1 comment unapproved' ],
 		];
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -57,7 +57,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * Tests that can get the pending comment count bubble.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::get_pending_count_bubble()
-	 * @dataProvider provider_get_pending_count_bubble
+	 * @dataProvider data_provider_get_pending_count_bubble
 	 *
 	 * @param int    $number_pending Number of pending product reviews.
 	 * @param string $expected_html  Expected return value.
@@ -119,7 +119,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	}
 
 	/** @see test_get_pending_count_bubble */
-	public function provider_get_pending_count_bubble() : Generator {
+	public function data_provider_get_pending_count_bubble() : Generator {
 		yield 'no pending' => [ 0, '' ];
 		yield 'has pending' => [
 			2,

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -190,17 +190,14 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::is_reviews_page()
 	 * @dataProvider provider_is_reviews_page
 	 *
-	 * @param string|null $new_pagenow     the value of the global $pageview var.
-	 * @param string|null $page            the value of $_GET[ 'page' ].
+	 * @param string|null $new_current_screen     the value of the global $pageview var.
 	 * @param bool        $expected_result the expected bool result.
 	 * @return void
 	 */
-	public function test_is_reviews_page( $new_pagenow, $page, $expected_result ) {
-		global $pagenow;
+	public function test_is_reviews_page( $new_current_screen, $expected_result ) {
+		global $current_screen;
 
-		$pagenow = $new_pagenow; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-
-		$_GET['page'] = $page;
+		$current_screen = $new_current_screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		$reviews = new Reviews();
 
@@ -210,34 +207,28 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	/** @see test_is_reviews_page */
 	public function provider_is_reviews_page() : Generator {
 
-		yield 'Global pagenow is null' => [
-			'new_pagenow'     => null,
-			'page'            => null,
-			'expected_result' => false,
+		yield 'Global current_screen is null' => [
+			'new_current_screen' => null,
+			'expected_result'    => false,
 		];
 
-		yield 'Global pagenow is anything other than the edit page' => [
-			'new_pagenow'     => 'test.php',
-			'page'            => null,
-			'expected_result' => false,
+		yield 'Global current_screen has no base' => [
+			'new_current_screen' => (object) [],
+			'expected_result'    => false,
 		];
 
-		yield 'Page is null' => [
-			'new_pagenow'     => 'edit.php',
-			'page'            => null,
-			'expected_result' => false,
+		$any_screen = (object) [ 'base' => 'any-page' ];
+
+		yield 'current_screen->base is anything other than the reviews page' => [
+			'new_current_screen' => $any_screen,
+			'expected_result'    => false,
 		];
 
-		yield 'Page is anything other than product-reviews' => [
-			'new_pagenow'     => 'edit.php',
-			'page'            => 'test',
-			'expected_result' => false,
-		];
+		$reviews_screen = (object) [ 'base' => 'product_page_product-reviews' ];
 
 		yield 'Page is product-reviews' => [
-			'new_pagenow'     => 'edit.php',
-			'page'            => 'product-reviews',
-			'expected_result' => true,
+			'new_current_screen' => $reviews_screen,
+			'expected_result'    => true,
 		];
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -17,16 +17,23 @@ use WC_Unit_Test_Case;
 class ReviewsTest extends WC_Unit_Test_Case {
 
 	/**
+	 * Tests that can get the class instance.
+	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::get_instance()
+	 *
+	 * @return void
 	 */
 	public function test_get_instance() {
 		$this->assertInstanceOf( Reviews::class, Reviews::get_instance() );
 	}
 
 	/**
-	 * Tests that `load_reviews_screen()` creates an instance of ReviewsListTable.
+	 * Tests that `load_reviews_screen()` creates an instance of {@see ReviewsListTable}.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::load_reviews_screen()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method or the property is not found.
 	 */
 	public function test_load_reviews_screen() {
 		$reviews = new Reviews();
@@ -47,7 +54,9 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::get_pending_count_bubble()
+	 * Tests that can get the pending comment count bubble.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::get_pending_count_bubble()
 	 * @dataProvider provider_get_pending_count_bubble
 	 *
 	 * @param int    $number_pending Number of pending product reviews.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -20,9 +20,9 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * Sets the global vars before each test.
 	 */
 	public function setUp() : void {
-		global $pagenow;
+		global $current_screen;
 
-		$this->old_pagenow = $pagenow;
+		$this->old_current_screen = $current_screen;
 
 		parent::setUp();
 	}
@@ -31,9 +31,11 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * Restores the global vars after each test.
 	 */
 	public function tearDown() : void {
-		global $pagenow;
+		global $current_screen;
 
-		$pagenow = $this->old_pagenow; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$current_screen = $this->old_current_screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		parent::tearDown();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -42,11 +42,11 @@ class ReviewsTest extends WC_Unit_Test_Case {
 			return 'manage_woocommerce';
 		};
 
-		add_filter( 'woocommerce_view_product_reviews_page_capability', $callback );
+		add_filter( 'woocommerce_product_reviews_page_capability', $callback );
 
 		$this->assertEquals( 'manage_woocommerce', Reviews::get_capability() );
 
-		remove_filter( 'woocommerce_view_product_reviews_page_capability', $callback );
+		remove_filter( 'woocommerce_product_reviews_page_capability', $callback );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -611,4 +611,11 @@ test2</p></div>',
 		$this->assertTrue( $method->invoke( $reviews, $review_reply ) );
 	}
 
+	/**
+	 * @covers Reviews::get_reviews_page_url()
+	 */
+	public function test_get_reviews_page_url() : void {
+		$this->assertSame( 'http://example.org/wp-admin/edit.php?post_type=product&page=product-reviews', Reviews::get_reviews_page_url() );
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -214,8 +214,8 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::is_reviews_page()
 	 * @dataProvider provider_is_reviews_page
 	 *
-	 * @param string|null $new_current_screen     the value of the global $pageview var.
-	 * @param bool        $expected_result the expected bool result.
+	 * @param string|null $new_current_screen The value of the global $pageview var.
+	 * @param bool        $expected_result    The expected bool result.
 	 * @return void
 	 */
 	public function test_is_reviews_page( $new_current_screen, $expected_result ) {
@@ -262,9 +262,9 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::get_bulk_action_notice_messages()
 	 * @dataProvider provider_get_bulk_action_notice_messages
 	 *
-	 * @param string[] $statuses        the wp comment statuses after a bulk operation.
-	 * @param int      $count           the number of affected comments.
-	 * @param array    $expected_result the action notice messages.
+	 * @param string[] $statuses        The wp comment statuses after a bulk operation.
+	 * @param int      $count           The number of affected comments.
+	 * @param array    $expected_result The action notice messages.
 	 * @return void
 	 * @throws ReflectionException If the method doesn't exist.
 	 */
@@ -389,8 +389,8 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::maybe_display_reviews_bulk_action_notice()
 	 * @dataProvider provider_maybe_display_reviews_bulk_action_notice
 	 *
-	 * @param array  $messages        the action notice messages.
-	 * @param string $expected_result the expected result.
+	 * @param array  $messages        The action notice messages.
+	 * @param string $expected_result The expected result.
 	 * @return void
 	 * @throws ReflectionException If the method doesn't exist.
 	 */
@@ -440,8 +440,8 @@ test2</p></div>',
 	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::display_notices()
 	 * @dataProvider provider_display_notices
 	 *
-	 * @param bool $is_reviews_page                whether the current page is the reviews page or not.
-	 * @param bool $should_call_the_display_method indicates if the display method should be called.
+	 * @param bool $is_reviews_page                Whether the current page is the reviews page or not.
+	 * @param bool $should_call_the_display_method Indicates if the display method should be called.
 	 */
 	public function test_display_notices( $is_reviews_page, $should_call_the_display_method ) {
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -28,6 +28,28 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can get the capability to view the reviews page.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::get_view_page_capability()
+	 *
+	 * @return void
+	 */
+	public function test_get_view_page_capability() {
+
+		$this->assertEquals( 'moderate_comments', Reviews::get_view_page_capability() );
+
+		$callback = function() {
+			return 'manage_woocommerce';
+		};
+
+		add_filter( 'woocommerce_view_product_reviews_page_capability', $callback );
+
+		$this->assertEquals( 'manage_woocommerce', Reviews::get_view_page_capability() );
+
+		remove_filter( 'woocommerce_view_product_reviews_page_capability', $callback );
+	}
+
+	/**
 	 * Tests that `load_reviews_screen()` creates an instance of {@see ReviewsListTable}.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::load_reviews_screen()

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -205,22 +205,22 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_edit_comments_screen_text( string $translated_text, string $original_text, bool $is_review, bool $is_reply, string $expected_text ) {
+		global $comment;
+
 		$product = $this->factory()->post->create( [ 'post_type' => 'product' ] );
-		$comment = $this->factory()->comment->create( [ 'comment_post_ID' => $this->factory->post->create() ] );
-		$review = $this->factory()->comment->create( [ 'comment_post_ID' => $product ] );
-		$reply = $this->factory()->comment->create(
+		$review  = $this->factory()->comment->create( [ 'comment_post_ID' => $product ] );
+		$reply   = $this->factory()->comment->create(
 			[
 				'comment_post_ID' => $product,
 				'comment_parent'  => $review,
 			]
 		);
 
-		$_GET['action'] = 'editcomment';
-
 		if ( ! $is_review ) {
-			$_GET['c'] = $comment;
+			$post    = $this->factory()->post->create();
+			$comment = $this->factory()->comment->create( [ 'comment_post_ID' => $post ] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		} else {
-			$_GET['c'] = $is_reply ? $reply : $review;
+			$comment = $is_reply ? $reply : $review; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
 		$this->assertSame( $expected_text, ( new Reviews() )->edit_comments_screen_text( $translated_text, $original_text ) );
@@ -228,12 +228,12 @@ class ReviewsTest extends WC_Unit_Test_Case {
 
 	/** @see test_edit_comments_screen_text */
 	public function data_provider_edit_comments_screen_text() : Generator {
-		yield 'Regular comment' => [ 'Foo', 'Bar', false, false, 'Foo' ];
+		yield 'Regular comment' => [ 'Edit Comment', 'Edit Comment', false, false, 'Edit Comment' ];
 		yield 'Not the expected text'  => [ 'Foo', 'Bar', true, false, 'Foo' ];
-		yield 'Edit Review' => [ 'Edit Comment', 'Edit Comment', true, false, 'Edit Review' ];
-		yield 'Edit Review Reply' => [ 'Edit Comment', 'Edit Comment', true, true, 'Edit Review Reply' ];
-		yield 'Moderate Review' => [ 'Moderate Comment', 'Moderate Comment', true, false, 'Moderate Review' ];
-		yield 'Moderate Review Reply' => [ 'Moderate Comment', 'Moderate Comment', true, true, 'Moderate Review Reply' ];
+		yield 'Edit Review' => [ 'Edit Comment Translated', 'Edit Comment', true, false, 'Edit Review' ];
+		yield 'Edit Review Reply' => [ 'Edit Comment Translated', 'Edit Comment', true, true, 'Edit Review Reply' ];
+		yield 'Moderate Review' => [ 'Moderate Comment Translated', 'Moderate Comment', true, false, 'Moderate Review' ];
+		yield 'Moderate Review Reply' => [ 'Moderate Comment Translated', 'Moderate Comment', true, true, 'Moderate Review Reply' ];
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -268,94 +268,94 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	/** @see test_get_bulk_action_notice_messages */
 	public function provider_get_bulk_action_notice_messages() : Generator {
 
-		yield 'An approved comment status' => [
+		yield 'An approved review status' => [
 			'status'         => [ 'approved' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment approved' ],
+			'expected_array' => [ '1 review approved' ],
 		];
 
-		yield 'Two approved comment statuses' => [
+		yield 'Two approved review statuses' => [
 			'status'         => [ 'approved' ],
 			'count'          => 2,
-			'expected_array' => [ '2 comments approved' ],
+			'expected_array' => [ '2 reviews approved' ],
 		];
 
-		yield 'An unapproved comment status' => [
+		yield 'An unapproved review status' => [
 			'status'         => [ 'unapproved' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment unapproved' ],
+			'expected_array' => [ '1 review unapproved' ],
 		];
 
-		yield 'Two unapproved comment statuses' => [
+		yield 'Two unapproved review statuses' => [
 			'status'         => [ 'unapproved' ],
 			'count'          => 2,
-			'expected_array' => [ '2 comments unapproved' ],
+			'expected_array' => [ '2 reviews unapproved' ],
 		];
 
-		yield 'A deleted comment status' => [
+		yield 'A deleted review status' => [
 			'status'         => [ 'deleted' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment permanently deleted' ],
+			'expected_array' => [ '1 review permanently deleted' ],
 		];
 
-		yield 'Two deleted comment statuses' => [
+		yield 'Two deleted review statuses' => [
 			'status'         => [ 'deleted' ],
 			'count'          => 2,
-			'expected_array' => [ '2 comments permanently deleted' ],
+			'expected_array' => [ '2 reviews permanently deleted' ],
 		];
 
-		yield 'A trashed comment status' => [
+		yield 'A trashed review status' => [
 			'status'         => [ 'trashed' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment moved to the Trash.' ],
+			'expected_array' => [ '1 review moved to the Trash.' ],
 		];
 
-		yield 'Two trashed comment statuses' => [
+		yield 'Two trashed review statuses' => [
 			'status'         => [ 'trashed' ],
 			'count'          => 2,
-			'expected_array' => [ '2 comments moved to the Trash.' ],
+			'expected_array' => [ '2 reviews moved to the Trash.' ],
 		];
 
-		yield 'An untrashed comment status' => [
+		yield 'An untrashed review status' => [
 			'status'         => [ 'untrashed' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment restored from the Trash' ],
+			'expected_array' => [ '1 review restored from the Trash' ],
 		];
 
-		yield 'Two untrashed comment statuses' => [
+		yield 'Two untrashed review statuses' => [
 			'status'         => [ 'untrashed' ],
 			'count'          => 2,
-			'expected_array' => [ '2 comments restored from the Trash' ],
+			'expected_array' => [ '2 reviews restored from the Trash' ],
 		];
 
-		yield 'A spammed comment status' => [
+		yield 'A spammed review status' => [
 			'status'         => [ 'spammed' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment marked as spam.' ],
+			'expected_array' => [ '1 review marked as spam.' ],
 		];
 
-		yield 'Two spammed comment statuses' => [
+		yield 'Two spammed review statuses' => [
 			'status'         => [ 'spammed' ],
 			'count'          => 2,
-			'expected_array' => [ '2 comments marked as spam.' ],
+			'expected_array' => [ '2 reviews marked as spam.' ],
 		];
 
-		yield 'An unspammed comment status' => [
+		yield 'An unspammed review status' => [
 			'status'         => [ 'unspammed' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment restored from the spam' ],
+			'expected_array' => [ '1 review restored from the spam' ],
 		];
 
-		yield 'Two unspammed comment statuses' => [
+		yield 'Two unspammed review statuses' => [
 			'status'         => [ 'unspammed' ],
 			'count'          => 2,
-			'expected_array' => [ '2 comments restored from the spam' ],
+			'expected_array' => [ '2 reviews restored from the spam' ],
 		];
 
 		yield 'Two different statuses' => [
 			'status'         => [ 'approved', 'unapproved' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment approved', '1 comment unapproved' ],
+			'expected_array' => [ '1 review approved', '1 review unapproved' ],
 		];
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -357,4 +357,55 @@ class ReviewsTest extends WC_Unit_Test_Case {
 		];
 	}
 
+	/**
+	 * Tests that a notice message will result in a valid HTML return.
+	 *
+	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::maybe_display_reviews_bulk_action_notice()
+	 * @dataProvider provider_maybe_display_reviews_bulk_action_notice
+	 *
+	 * @param array  $messages        the action notice messages.
+	 * @param string $expected_result the expected result.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_maybe_display_reviews_bulk_action_notice( $messages, $expected_result ) {
+
+		$mock = $this->getMockBuilder( Reviews::class )
+			->setMethods( [ 'get_bulk_action_notice_messages' ] )
+			->getMock();
+
+		$mock->expects( $this->once() )
+			->method( 'get_bulk_action_notice_messages' )
+			->willReturn( $messages );
+
+		$method = ( new ReflectionClass( $mock ) )->getMethod( 'maybe_display_reviews_bulk_action_notice' );
+		$method->setAccessible( true );
+
+		ob_start();
+
+		$method->invoke( $mock );
+
+		$this->assertSame( $expected_result, ob_get_clean() );
+	}
+
+	/** @see test_maybe_display_reviews_bulk_action_notice */
+	public function provider_maybe_display_reviews_bulk_action_notice() : Generator {
+
+		yield 'No messages are returned' => [
+			'messages'        => [],
+			'expected_result' => '',
+		];
+
+		yield 'A message is returned' => [
+			'messages'        => [ 'test' ],
+			'expected_result' => '<div id="moderated" class="updated"><p>test</p></div>',
+		];
+
+		yield 'Two messages are returned' => [
+			'messages'        => [ 'test1', 'test2' ],
+			'expected_result' => '<div id="moderated" class="updated"><p>test1<br/>
+test2</p></div>',
+		];
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -251,6 +251,8 @@ class ReviewsTest extends WC_Unit_Test_Case {
 		$method = ( new ReflectionClass( $reviews ) )->getMethod( 'get_bulk_action_notice_messages' );
 		$method->setAccessible( true );
 
+		$_REQUEST = [];
+
 		foreach ( $statuses as $status ) {
 			$_REQUEST[ $status ] = $count;
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -408,4 +408,43 @@ test2</p></div>',
 		];
 	}
 
+	/**
+	 * Tests that the display method is called only for the reviews page.
+	 *
+	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::display_notices()
+	 * @dataProvider provider_display_notices
+	 *
+	 * @param bool $is_reviews_page                whether the current page is the reviews page or not.
+	 * @param bool $should_call_the_display_method indicates if the display method should be called.
+	 */
+	public function test_display_notices( $is_reviews_page, $should_call_the_display_method ) {
+
+		$mock = $this->getMockBuilder( Reviews::class )
+			->setMethods( [ 'is_reviews_page', 'maybe_display_reviews_bulk_action_notice' ] )
+			->getMock();
+
+		$mock->expects( $this->once() )
+			->method( 'is_reviews_page' )
+			->willReturn( $is_reviews_page );
+
+		$mock->expects( $this->exactly( (int) $should_call_the_display_method ) )
+			->method( 'maybe_display_reviews_bulk_action_notice' );
+
+		$mock->display_notices();
+	}
+
+	/** @see test_display_notices */
+	public function provider_display_notices() : Generator {
+
+		yield 'Is the reviews page' => [
+			'is_reviews_page'                          => true,
+			'maybe_display_reviews_bulk_action_notice' => true,
+		];
+
+		yield 'Is not the reviews page' => [
+			'is_reviews_page'                          => false,
+			'maybe_display_reviews_bulk_action_notice' => false,
+		];
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -30,13 +30,13 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the capability to view the reviews page.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::get_view_page_capability()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::get_capability()
 	 *
 	 * @return void
 	 */
 	public function test_get_view_page_capability() {
 
-		$this->assertEquals( 'moderate_comments', Reviews::get_view_page_capability() );
+		$this->assertEquals( 'moderate_comments', Reviews::get_capability() );
 
 		$callback = function() {
 			return 'manage_woocommerce';
@@ -44,7 +44,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 
 		add_filter( 'woocommerce_view_product_reviews_page_capability', $callback );
 
-		$this->assertEquals( 'manage_woocommerce', Reviews::get_view_page_capability() );
+		$this->assertEquals( 'manage_woocommerce', Reviews::get_capability() );
 
 		remove_filter( 'woocommerce_view_product_reviews_page_capability', $callback );
 	}


### PR DESCRIPTION
### Summary

This is the base branch for adding a Product Reviews page in WooCommerce core

## Epics

- [MWC-5367](https://jira.godaddy.com/browse/MWC-5367) - Add the new Core Reviews page
- [MWC-5368](https://jira.godaddy.com/browse/MWC-5368) - Updates to the existing Comments page
- [MWC-5369](https://jira.godaddy.com/browse/MWC-5369) - Updates to the WooCommerce Home page
- [MWC-5370](https://jira.godaddy.com/browse/MWC-5370) - Reviews page extensibility

⚠️ DO NOT MERGE ⚠️ 