### PR TITLE
Add columns to the reviews list table

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -109,7 +109,7 @@ class ReviewsListTable extends WP_List_Table {
 
 		$comments = get_comments(
 			[
-				'post_type'  => 'product',
+				'post_type' => 'product',
 			]
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -95,8 +95,8 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders any custom columns.
 	 *
-	 * @param object|array $item Comment or reply being rendered.
-	 * @param string $column_name Name of the column being rendered.
+	 * @param object|array $item        Comment or reply being rendered.
+	 * @param string       $column_name Name of the column being rendered.
 	 */
 	protected function column_default( $item, $column_name ) {
 		// @TODO Implement in MWC-5362 {agibson 2022-04-12}

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -32,7 +32,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the checkbox column.
 	 *
-	 * @param object|array $item Comment or reply being rendered.
+	 * @param object|array $item Review or reply being rendered.
 	 */
 	protected function column_cb( $item ) {
 		// @TODO Implement in MWC-5335 {agibson 2022-04-12}
@@ -41,7 +41,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the review column.
 	 *
-	 * @param object|array $item Comment or reply being rendered.
+	 * @param object|array $item Review or reply being rendered.
 	 */
 	protected function column_comment( $item ) {
 		// @TODO Implement in MWC-5339 {agibson 2022-04-12}
@@ -50,7 +50,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the author column.
 	 *
-	 * @param object|array $item Comment or reply being rendered.
+	 * @param object|array $item Review or reply being rendered.
 	 */
 	protected function column_author( $item ) {
 		// @TODO Implement in MWC-5336 {agibson 2022-04-12}
@@ -59,7 +59,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the "submitted on" column.
 	 *
-	 * @param object|array $item Comment or reply being rendered.
+	 * @param object|array $item Review or reply being rendered.
 	 */
 	protected function column_date( $item ) {
 		// @TODO Implement in MWC-5338 {agibson 2022-04-12}
@@ -68,7 +68,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the product column.
 	 *
-	 * @param object|array $item Comment or reply being rendered.
+	 * @param object|array $item Review or reply being rendered.
 	 */
 	protected function column_response( $item ) {
 		// @TODO Implement in MWC-5337 {agibson 2022-04-12}
@@ -77,7 +77,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the type column.
 	 *
-	 * @param object|array $item Comment or reply being rendered.
+	 * @param object|array $item Review or reply being rendered.
 	 */
 	protected function column_type( $item ) {
 		// @TODO Implement in MWC-5334 {agibson 2022-04-12}
@@ -86,7 +86,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the rating column.
 	 *
-	 * @param object|array $item Comment or reply being rendered.
+	 * @param object|array $item Review or reply being rendered.
 	 */
 	protected function column_rating( $item ) {
 		// @TODO Implement in MWC-5333 {agibson 2022-04-12}
@@ -95,7 +95,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders any custom columns.
 	 *
-	 * @param object|array $item        Comment or reply being rendered.
+	 * @param object|array $item        Review or reply being rendered.
 	 * @param string       $column_name Name of the column being rendered.
 	 */
 	protected function column_default( $item, $column_name ) {
@@ -103,7 +103,7 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Prepare reviews for display
+	 * Prepares reviews for display.
 	 */
 	public function prepare_items() {
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -13,6 +13,96 @@ use WP_List_Table;
 class ReviewsListTable extends WP_List_Table {
 
 	/**
+	 * Returns the columns for the table.
+	 *
+	 * @return array
+	 */
+	public function get_columns() {
+		return [
+			'cb' => '<input type="checkbox" />',
+			'type' => _x( 'Type', 'review type', 'woocommerce' ),
+			'author' => __( 'Author', 'woocommerce' ),
+			'rating' => __( 'Rating', 'woocommerce' ),
+			'comment' => _x( 'Review', 'column name', 'woocommerce' ),
+			'response' => __( 'Product', 'woocommerce' ),
+			'date' => _x( 'Submitted on', 'column name', 'woocommerce' ),
+		];
+	}
+
+	/**
+	 * Renders the checkbox column.
+	 *
+	 * @param object|array $item
+	 */
+	protected function column_cb( $item ) {
+		//@TODO Implement in MWC-5335 {agibson 2022-04-12}
+	}
+
+	/**
+	 * Renders the review column.
+	 *
+	 * @param object|array $item
+	 */
+	protected function column_comment( $item ) {
+		//@TODO Implement in MWC-5339 {agibson 2022-04-12}
+	}
+
+	/**
+	 * Renders the author column.
+	 *
+	 * @param object|array $item
+	 */
+	protected function column_author( $item ) {
+		//@TODO Implement in MWC-5336 {agibson 2022-04-12}
+	}
+
+	/**
+	 * Renders the "submitted on" column.
+	 *
+	 * @param object|array $item
+	 */
+	protected function column_date( $item ) {
+		//@TODO Implement in MWC-5338 {agibson 2022-04-12}
+	}
+
+	/**
+	 * Renders the product column.
+	 *
+	 * @param object|array $item
+	 */
+	protected function column_response( $item ) {
+		//@TODO Implement in MWC-5337 {agibson 2022-04-12}
+	}
+
+	/**
+	 * Renders the type column.
+	 *
+	 * @param object|array $item
+	 */
+	protected function column_type( $item ) {
+		//@TODO Implement in MWC-5334 {agibson 2022-04-12}
+	}
+
+	/**
+	 * Renders the rating column.
+	 *
+	 * @param object|array $item
+	 */
+	protected function column_rating( $item ) {
+		//@TODO Implement in MWC-5333 {agibson 2022-04-12}
+	}
+
+	/**
+	 * Renders any custom columns.
+	 *
+	 * @param object|array $item
+	 * @param string $column_name
+	 */
+	protected function column_default( $item, $column_name ) {
+		//@TODO Implement in MWC-5362 {agibson 2022-04-12}
+	}
+
+	/**
 	 * Prepare reviews for display
 	 */
 	public function prepare_items() {

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -15,7 +15,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Returns the columns for the table.
 	 *
-	 * @return array
+	 * @return array Table columns and their headings.
 	 */
 	public function get_columns() {
 		return [
@@ -32,7 +32,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the checkbox column.
 	 *
-	 * @param object|array $item
+	 * @param object|array $item Comment or reply being rendered.
 	 */
 	protected function column_cb( $item ) {
 		// @TODO Implement in MWC-5335 {agibson 2022-04-12}
@@ -41,7 +41,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the review column.
 	 *
-	 * @param object|array $item
+	 * @param object|array $item Comment or reply being rendered.
 	 */
 	protected function column_comment( $item ) {
 		// @TODO Implement in MWC-5339 {agibson 2022-04-12}
@@ -50,7 +50,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the author column.
 	 *
-	 * @param object|array $item
+	 * @param object|array $item Comment or reply being rendered.
 	 */
 	protected function column_author( $item ) {
 		// @TODO Implement in MWC-5336 {agibson 2022-04-12}
@@ -59,7 +59,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the "submitted on" column.
 	 *
-	 * @param object|array $item
+	 * @param object|array $item Comment or reply being rendered.
 	 */
 	protected function column_date( $item ) {
 		// @TODO Implement in MWC-5338 {agibson 2022-04-12}
@@ -68,7 +68,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the product column.
 	 *
-	 * @param object|array $item
+	 * @param object|array $item Comment or reply being rendered.
 	 */
 	protected function column_response( $item ) {
 		// @TODO Implement in MWC-5337 {agibson 2022-04-12}
@@ -77,7 +77,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the type column.
 	 *
-	 * @param object|array $item
+	 * @param object|array $item Comment or reply being rendered.
 	 */
 	protected function column_type( $item ) {
 		// @TODO Implement in MWC-5334 {agibson 2022-04-12}
@@ -86,7 +86,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the rating column.
 	 *
-	 * @param object|array $item
+	 * @param object|array $item Comment or reply being rendered.
 	 */
 	protected function column_rating( $item ) {
 		// @TODO Implement in MWC-5333 {agibson 2022-04-12}
@@ -95,8 +95,8 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders any custom columns.
 	 *
-	 * @param object|array $item
-	 * @param string $column_name
+	 * @param object|array $item Comment or reply being rendered.
+	 * @param string $column_name Name of the column being rendered.
 	 */
 	protected function column_default( $item, $column_name ) {
 		// @TODO Implement in MWC-5362 {agibson 2022-04-12}

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -35,7 +35,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param object|array $item
 	 */
 	protected function column_cb( $item ) {
-		//@TODO Implement in MWC-5335 {agibson 2022-04-12}
+		// @TODO Implement in MWC-5335 {agibson 2022-04-12}
 	}
 
 	/**
@@ -44,7 +44,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param object|array $item
 	 */
 	protected function column_comment( $item ) {
-		//@TODO Implement in MWC-5339 {agibson 2022-04-12}
+		// @TODO Implement in MWC-5339 {agibson 2022-04-12}
 	}
 
 	/**
@@ -53,7 +53,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param object|array $item
 	 */
 	protected function column_author( $item ) {
-		//@TODO Implement in MWC-5336 {agibson 2022-04-12}
+		// @TODO Implement in MWC-5336 {agibson 2022-04-12}
 	}
 
 	/**
@@ -62,7 +62,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param object|array $item
 	 */
 	protected function column_date( $item ) {
-		//@TODO Implement in MWC-5338 {agibson 2022-04-12}
+		// @TODO Implement in MWC-5338 {agibson 2022-04-12}
 	}
 
 	/**
@@ -71,7 +71,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param object|array $item
 	 */
 	protected function column_response( $item ) {
-		//@TODO Implement in MWC-5337 {agibson 2022-04-12}
+		// @TODO Implement in MWC-5337 {agibson 2022-04-12}
 	}
 
 	/**
@@ -80,7 +80,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param object|array $item
 	 */
 	protected function column_type( $item ) {
-		//@TODO Implement in MWC-5334 {agibson 2022-04-12}
+		// @TODO Implement in MWC-5334 {agibson 2022-04-12}
 	}
 
 	/**
@@ -89,7 +89,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param object|array $item
 	 */
 	protected function column_rating( $item ) {
-		//@TODO Implement in MWC-5333 {agibson 2022-04-12}
+		// @TODO Implement in MWC-5333 {agibson 2022-04-12}
 	}
 
 	/**
@@ -99,7 +99,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param string $column_name
 	 */
 	protected function column_default( $item, $column_name ) {
-		//@TODO Implement in MWC-5362 {agibson 2022-04-12}
+		// @TODO Implement in MWC-5362 {agibson 2022-04-12}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -19,13 +19,13 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	public function get_columns() {
 		return [
-			'cb' => '<input type="checkbox" />',
-			'type' => _x( 'Type', 'review type', 'woocommerce' ),
-			'author' => __( 'Author', 'woocommerce' ),
-			'rating' => __( 'Rating', 'woocommerce' ),
-			'comment' => _x( 'Review', 'column name', 'woocommerce' ),
+			'cb'       => '<input type="checkbox" />',
+			'type'     => _x( 'Type', 'review type', 'woocommerce' ),
+			'author'   => __( 'Author', 'woocommerce' ),
+			'rating'   => __( 'Rating', 'woocommerce' ),
+			'comment'  => _x( 'Review', 'column name', 'woocommerce' ),
 			'response' => __( 'Product', 'woocommerce' ),
-			'date' => _x( 'Submitted on', 'column name', 'woocommerce' ),
+			'date'     => _x( 'Submitted on', 'column name', 'woocommerce' ),
 		];
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -16,15 +16,18 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_columns()
 	 */
 	public function test_get_columns() {
-		$this->assertSame( [
-			'cb'       => '<input type="checkbox" />',
-			'type'     => _x( 'Type', 'review type', 'woocommerce' ),
-			'author'   => __( 'Author', 'woocommerce' ),
-			'rating'   => __( 'Rating', 'woocommerce' ),
-			'comment'  => _x( 'Review', 'column name', 'woocommerce' ),
-			'response' => __( 'Product', 'woocommerce' ),
-			'date'     => _x( 'Submitted on', 'column name', 'woocommerce' ),
-		], ( new ReviewsListTable() )->get_columns() );
+		$this->assertSame(
+			[
+				'cb'       => '<input type="checkbox" />',
+				'type'     => _x( 'Type', 'review type', 'woocommerce' ),
+				'author'   => __( 'Author', 'woocommerce' ),
+				'rating'   => __( 'Rating', 'woocommerce' ),
+				'comment'  => _x( 'Review', 'column name', 'woocommerce' ),
+				'response' => __( 'Product', 'woocommerce' ),
+				'date'     => _x( 'Submitted on', 'column name', 'woocommerce' ),
+			],
+			( new ReviewsListTable() )->get_columns()
+		);
 	}
 
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -17,13 +17,13 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 */
 	public function test_get_columns() {
 		$this->assertSame( [
-			'cb' => '<input type="checkbox" />',
-			'type' => _x( 'Type', 'review type', 'woocommerce' ),
-			'author' => __( 'Author', 'woocommerce' ),
-			'rating' => __( 'Rating', 'woocommerce' ),
-			'comment' => _x( 'Review', 'column name', 'woocommerce' ),
+			'cb'       => '<input type="checkbox" />',
+			'type'     => _x( 'Type', 'review type', 'woocommerce' ),
+			'author'   => __( 'Author', 'woocommerce' ),
+			'rating'   => __( 'Rating', 'woocommerce' ),
+			'comment'  => _x( 'Review', 'column name', 'woocommerce' ),
 			'response' => __( 'Product', 'woocommerce' ),
-			'date' => _x( 'Submitted on', 'column name', 'woocommerce' ),
+			'date'     => _x( 'Submitted on', 'column name', 'woocommerce' ),
 		], ( new ReviewsListTable() )->get_columns() );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -14,6 +14,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 	/**
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_columns()
+	 * @TODO Change the `screen` to be our page when it gets created in MWC-5330
 	 */
 	public function test_get_columns() {
 		$this->assertSame(
@@ -26,7 +27,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 				'response' => __( 'Product', 'woocommerce' ),
 				'date'     => _x( 'Submitted on', 'column name', 'woocommerce' ),
 			],
-			( new ReviewsListTable() )->get_columns()
+			( new ReviewsListTable( [ 'screen' => 'comments' ] ) )->get_columns()
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -14,7 +14,6 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 	/**
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_columns()
-	 * @TODO Change the `screen` to be our page when it gets created in MWC-5330
 	 */
 	public function test_get_columns() {
 		$this->assertSame(
@@ -27,7 +26,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 				'response' => __( 'Product', 'woocommerce' ),
 				'date'     => _x( 'Submitted on', 'column name', 'woocommerce' ),
 			],
-			( new ReviewsListTable( [ 'screen' => 'comments' ] ) )->get_columns()
+			( new ReviewsListTable( [ 'screen' => 'product_page_product-reviews' ] ) )->get_columns()
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Tests\Internal\Admin;
 
+use Automattic\WooCommerce\Internal\Admin\ReviewsListTable;
 use WC_Unit_Test_Case;
 
 /**
@@ -10,5 +11,20 @@ use WC_Unit_Test_Case;
  * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable
  */
 class ReviewsListTableTest extends WC_Unit_Test_Case {
+
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_columns()
+	 */
+	public function test_get_columns() {
+		$this->assertSame( [
+			'cb' => '<input type="checkbox" />',
+			'type' => _x( 'Type', 'review type', 'woocommerce' ),
+			'author' => __( 'Author', 'woocommerce' ),
+			'rating' => __( 'Rating', 'woocommerce' ),
+			'comment' => _x( 'Review', 'column name', 'woocommerce' ),
+			'response' => __( 'Product', 'woocommerce' ),
+			'date' => _x( 'Submitted on', 'column name', 'woocommerce' ),
+		], ( new ReviewsListTable() )->get_columns() );
+	}
 
 }


### PR DESCRIPTION
## Summary

Implements the `get_columns()` method to register our columns. Adds stubs for each of the callbacks.

## Story: [MWC-5331](https://jira.godaddy.com/browse/MWC-5331)

## QA

- [x] Code review
- [x] Tests pass