### PR TITLE
Hide reviews from the comments page

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -66,6 +66,7 @@ class Loader {
 		Translations::get_instance();
 		WCAdminUser::get_instance();
 		Settings::get_instance();
+		ReviewsCommentsOverrides::get_instance();
 
 		add_filter( 'admin_body_class', array( __CLASS__, 'add_admin_body_classes' ) );
 		add_filter( 'admin_title', array( __CLASS__, 'update_admin_title' ) );

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -46,12 +46,10 @@ class ReviewsCommentsOverrides {
 	 */
 	public function exclude_reviews_from_comments( $args ) {
 
-		$post_types = get_post_types();
-
-		if ( ! empty( $args['post_type'] ) ) {
-			if ( 'any' !== $args['post_type'] ) {
-				$post_types = (array) $args['post_type'];
-			}
+		if ( ! empty( $args['post_type'] ) && 'any' !== $args['post_type'] ) {
+			$post_types = (array) $args['post_type'];
+		} else {
+			$post_types = get_post_types();
 		}
 
 		$index = array_search( 'product', $post_types );

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -2,9 +2,69 @@
 
 namespace Automattic\WooCommerce\Internal\Admin;
 
+use WP_Comment_Query;
+
 /**
  * Tweaks the WordPress comments page to exclude reviews.
  */
 class ReviewsCommentsOverrides {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var ReviewsCommentsOverrides|null instance
+	 */
+	protected static $instance;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+
+		add_filter( 'comments_list_table_query_args', [ $this, 'exclude_reviews_from_comments' ] );
+	}
+
+	/**
+	 * Gets the class instance.
+	 *
+	 * @return object instance
+	 */
+	public static function get_instance() {
+
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Excludes product reviews from showing in the comments page.
+	 *
+	 * @internal
+	 *
+	 * @param array $args {@see WP_Comment_Query} query args.
+	 * @return array
+	 */
+	public function exclude_reviews_from_comments( $args ) {
+
+		$post_types = get_post_types();
+
+		if ( ! empty( $args['post_type'] ) ) {
+			if ( 'any' !== $args['post_type'] ) {
+				$post_types = (array) $args['post_type'];
+			}
+		}
+
+		$index = array_search( 'product', $post_types );
+
+		if ( false !== $index ) {
+			unset( $post_types[ $index ] );
+		}
+
+		$args['post_type'] = $post_types;
+
+		return $args;
+	}
 
 }

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -41,8 +41,6 @@ class ReviewsCommentsOverrides {
 	/**
 	 * Excludes product reviews from showing in the comments page.
 	 *
-	 * @internal
-	 *
 	 * @param array $args {@see WP_Comment_Query} query args.
 	 * @return array
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Tests\Internal\Admin;
 
+use Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides;
 use WC_Unit_Test_Case;
 
 /**
@@ -10,5 +11,22 @@ use WC_Unit_Test_Case;
  * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides
  */
 class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
+
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::exclude_reviews_from_comments()
+	 */
+	public function test_exclude_reviews_from_comments() {
+		$overrides = new ReviewsCommentsOverrides();
+
+		$original_args = [
+			'post_type' => [ 'product' ],
+		];
+
+		$this->assertTrue( in_array( 'product', $original_args['post_type'] ) );
+
+		$new_args = $overrides->exclude_reviews_from_comments( $original_args );
+
+		$this->assertFalse( in_array( 'product', $new_args['post_type'] ) );
+	}
 
 }


### PR DESCRIPTION
## Summary

Excludes reviews from showing up in the WordPress Comments admin page.

### Story: [MWC-5355](https://jira.godaddy.com/browse/MWC-5355)

## Details

Since the engineering proposal suggested to use `comments_list_table_query_args`, I had to figure a way to exclude "comments" (reviews) belonging to the product post type.

The `WP_Comment_Query` used in `WP_Comments_List_Table::prepare_items()`  via `get_comments()` does not support an argument like `post_type__not_in` [to my knowledge](https://developer.wordpress.org/reference/classes/wp_comment_query/__construct/). So I figured a way around that is to look for the `post_type` argument and add all the post types (equivalent of using `any`) minus the `product` post type. Probably this isn't the most efficient way. But I don't see another. Maybe we could modify the query as in Product Reviews Pro using the `comments_clauses` for admin contexts. But I see how `comments_list_table_query_args` would be very specific to the Comments page.

I noticed we may have omitted discussing how we should be loading the components we add where autoloading isn't implied, such as for this handler. I followed a pattern seen in the WC internals but I'm not sure if we are supposed to follow that.

As for tests, there's still an open discussion whether we should use E2E tests instead or stick with "unit" tests - for the latter, these are integration tests and I'm not sure of the best approach we should take in absence of Mockery and WP_Mock.

## QA

1. Have blog posts and comments 
1. Have one or more products
1. Have multiple reviews for your products 
1. Before this PR:
    - [x] Product reviews can be seen in the WordPress > Comments page
1. After this PR
    - [x] Product reviews cannot be seen in the WordPress > Comments page
    - [x] All other blog comments are visible