### PR TITLE
Add the “Reviews” menu item

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -66,6 +66,7 @@ class Loader {
 		Translations::get_instance();
 		WCAdminUser::get_instance();
 		Settings::get_instance();
+		Reviews::get_instance();
 
 		add_filter( 'admin_body_class', array( __CLASS__, 'add_admin_body_classes' ) );
 		add_filter( 'admin_title', array( __CLASS__, 'update_admin_title' ) );

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -10,4 +10,97 @@ namespace Automattic\WooCommerce\Internal\Admin;
  */
 class Reviews {
 
+	/**
+	 * Class instance.
+	 *
+	 * @var Reviews|null instance
+	 */
+	protected static $instance;
+
+	/**
+	 * Reviews page hook name.
+	 *
+	 * @var string
+	 */
+	protected $reviews_page_hook;
+
+	/**
+	 * Reviews list table instance.
+	 *
+	 * @var ReviewsListTable
+	 */
+	protected $reviews_list_table;
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', [ $this, 'add_reviews_page' ] );
+	}
+
+	/**
+	 * Gets the class instance.
+	 *
+	 * @return Reviews instance
+	 */
+	public static function get_instance(): ?Reviews {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Registers the Reviews submenu page.
+	 *
+	 * @return void
+	 */
+	public function add_reviews_page() {
+		$this->reviews_page_hook = add_submenu_page(
+			'edit.php?post_type=product',
+			__( 'Reviews', 'woocommerce' ),
+			__( 'Reviews', 'woocommerce' ),
+			'moderate_comments',
+			'product-reviews',
+			[ $this, 'render_reviews_list_table' ]
+		);
+
+		add_action( "load-{$this->reviews_page_hook}", [ $this, 'load_reviews_screen' ] );
+	}
+
+	/**
+	 * Initializes the list table.
+	 *
+	 * @return void
+	 */
+	public function load_reviews_screen() {
+		$this->reviews_list_table = new ReviewsListTable( [ 'screen' => $this->reviews_page_hook ] );
+	}
+
+	/**
+	 * Renders the Reviews page.
+	 *
+	 * @return void
+	 */
+	public function render_reviews_list_table() {
+		$this->reviews_list_table->prepare_items();
+		?>
+		<div class="wrap">
+			<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
+
+			<?php $this->reviews_list_table->views(); ?>
+
+			<form id="reviews-filter" method="get">
+
+				<input type="hidden" name="page" value="product-reviews" />
+
+				<?php $this->reviews_list_table->search_box( __( 'Search reviews', 'woocommerce' ), 'reviews' ); ?>
+
+				<?php $this->reviews_list_table->display(); ?>
+			</form>
+		</div>
+		<?php
+	}
+
 }

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -89,7 +89,11 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param object|array $item Review or reply being rendered.
 	 */
 	protected function column_type( $item ) {
-		// @TODO Implement in MWC-5334 {agibson 2022-04-12}
+		echo esc_html(
+			'review' === $item->comment_type ?
+			'&#9734;&nbsp;' . __( 'Review', 'woocommerce' ) :
+			__( 'Reply', 'woocommerce' )
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -3,7 +3,9 @@
 namespace Automattic\WooCommerce\Tests\Internal\Admin;
 
 use Automattic\WooCommerce\Internal\Admin\ReviewsListTable;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper;
 use ReflectionClass;
+use WC_Helper_Product;
 use WC_Unit_Test_Case;
 
 /**
@@ -51,4 +53,44 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$this->assertSame( 'comment', $method->invoke( $list_table ) );
 	}
 
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_type()
+	 *
+	 * @dataProvider data_provider_test_column_type()
+	 * @param string $comment_type The comment type (usually review or comment).
+	 * @param string $expected_output The expected output.
+	 */
+	public function test_column_type( $comment_type, $expected_output ) {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'column_type' );
+		$method->setAccessible( true );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$review_id = ProductHelper::create_product_review( $product->get_id() );
+
+		$reviews = get_comments(
+			[
+				'id' => $review_id,
+			]
+		);
+
+		$review = ! empty( $reviews ) ? current( $reviews ) : null;
+		$review->comment_type = $comment_type;
+
+		ob_start();
+		$method->invokeArgs( $list_table, [ $review ] );
+		$output = ob_get_clean();
+
+		$this->assertSame( $expected_output, $output );
+	}
+
+	/** @see test_column_type() */
+	public function data_provider_test_column_type() {
+		return [
+			'review' => [ 'review', '&#9734;&nbsp;Review' ],
+			'reply' => [ 'comment', 'Reply' ],
+			'default to reply' => [ 'anything', 'Reply' ],
+		];
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -25,6 +25,26 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Returns a test review object.
+	 *
+	 * @return WP_Comment|null
+	 */
+	protected function get_test_review() {
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$review_id = ProductHelper::create_product_review( $product->get_id() );
+
+		$reviews = get_comments(
+			[
+				'id' => $review_id,
+			]
+		);
+
+		return ! empty( $reviews ) ? current( $reviews ) : null;
+	}
+
+	/**
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_columns()
 	 */
 	public function test_get_columns() {
@@ -65,17 +85,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'column_type' );
 		$method->setAccessible( true );
 
-		$product = WC_Helper_Product::create_simple_product();
-
-		$review_id = ProductHelper::create_product_review( $product->get_id() );
-
-		$reviews = get_comments(
-			[
-				'id' => $review_id,
-			]
-		);
-
-		$review = ! empty( $reviews ) ? current( $reviews ) : null;
+		$review = $this->get_test_review();
 		$review->comment_type = $comment_type;
 
 		ob_start();

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -2,6 +2,9 @@
 
 namespace Automattic\WooCommerce\Tests\Internal\Admin;
 
+use Automattic\WooCommerce\Internal\Admin\Reviews;
+use Automattic\WooCommerce\Internal\Admin\ReviewsListTable;
+use ReflectionClass;
 use WC_Unit_Test_Case;
 
 /**
@@ -10,5 +13,35 @@ use WC_Unit_Test_Case;
  * @covers \Automattic\WooCommerce\Internal\Admin\Reviews
  */
 class ReviewsTest extends WC_Unit_Test_Case {
+
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::get_instance()
+	 */
+	public function test_get_instance() {
+		$this->assertInstanceOf( Reviews::class, Reviews::get_instance() );
+	}
+
+	/**
+	 * Tests that `load_reviews_screen()` creates an instance of ReviewsListTable.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::load_reviews_screen()
+	 */
+	public function test_load_reviews_screen() {
+		$reviews = new Reviews();
+
+		// This has to be manually set, otherwise instantiating ReviewsListTable will throw an undefined index error.
+		$hook_property = ( new ReflectionClass( $reviews ) )->getProperty( 'reviews_page_hook' );
+		$hook_property->setAccessible( true );
+		$hook_property->setValue( $reviews, 'product_page_product-reviews' );
+
+		$list_table_property = ( new ReflectionClass( $reviews ) )->getProperty( 'reviews_list_table' );
+		$list_table_property->setAccessible( true );
+
+		$this->assertNull( $list_table_property->getValue( $reviews ) );
+
+		$reviews->load_reviews_screen();
+
+		$this->assertInstanceOf( ReviewsListTable::class, $list_table_property->getValue( $reviews ) );
+	}
 
 }


### PR DESCRIPTION
## Summary

Registers the `Reviews` submenu page under `Products`. Also initializes the list table.

## Story: [MWC-5330](https://jira.godaddy.com/browse/MWC-5330)

## Details

I followed the same loading method @unfulvio used here https://github.com/godaddy-wordpress/woocommerce/pull/6

## QA

### Set up

This cannot be fully tested unless the list table columns are registered, which is done in https://github.com/godaddy-wordpress/woocommerce/pull/5.

- Copy the [get_columns()](https://github.com/godaddy-wordpress/woocommerce/blob/4d5c8f9bdbc9bc9a77ef2ed9b2651de928002f40/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php#L20-L30) method and add it to the `ReviewsListTable` class.

### Steps

- Load your WP admin.
    - [x] A new "Reviews" submenu appears under "Products".
- Click through to the reviews page.
    - [x] A page is rendered with the title "Reviews".
    - [x] An empty table is rendered ("No items found.")