### PR TITLE
Add the list of supported bulk actions

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -130,9 +130,26 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Sets the `$comment_status` global based on the current request.
+	 *
+	 * @return void
+	 */
+	protected function set_review_status() {
+		global $comment_status;
+
+		$comment_status = sanitize_text_field( wp_unslash( $_REQUEST['comment_status'] ?? 'all' ) ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		if ( ! in_array( $comment_status, [ 'all', 'moderated', 'approved', 'spam', 'trash' ], true ) ) {
+			$comment_status = 'all'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+	}
+
+	/**
 	 * Prepares reviews for display.
 	 */
 	public function prepare_items() {
+
+		$this->set_review_status();
 
 		$comments = get_comments(
 			[

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -28,4 +28,43 @@ class ReviewsListTable extends WP_List_Table {
 		$this->items = $comments;
 	}
 
+	/**
+	 * Returns a list of available bulk actions.
+	 *
+	 * @global string $comment_status
+	 *
+	 * @return array
+	 */
+	protected function get_bulk_actions() {
+		global $comment_status;
+
+		$actions = [];
+
+		if ( in_array( $comment_status, [ 'all', 'approved' ], true ) ) {
+			$actions['unapprove'] = __( 'Unapprove', 'woocommerce' );
+		}
+
+		if ( in_array( $comment_status, [ 'all', 'moderated' ], true ) ) {
+			$actions['approve'] = __( 'Approve', 'woocommerce' );
+		}
+
+		if ( in_array( $comment_status, [ 'all', 'moderated', 'approved', 'trash' ], true ) ) {
+			$actions['spam'] = _x( 'Mark as spam', 'review', 'woocommerce' );
+		}
+
+		if ( 'trash' === $comment_status ) {
+			$actions['untrash'] = __( 'Restore', 'woocommerce' );
+		} elseif ( 'spam' === $comment_status ) {
+			$actions['unspam'] = _x( 'Not spam', 'review', 'woocommerce' );
+		}
+
+		if ( in_array( $comment_status, [ 'trash', 'spam' ], true ) || ! EMPTY_TRASH_DAYS ) {
+			$actions['delete'] = __( 'Delete permanently', 'woocommerce' );
+		} else {
+			$actions['trash'] = __( 'Move to Trash', 'woocommerce' );
+		}
+
+		return $actions;
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -214,4 +214,38 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			],
 		];
 	}
+
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::set_review_status()
+	 * @dataProvider provider_set_review_status
+	 *
+	 * @param string|null $request_status          Status that's in the request.
+	 * @param string      $expected_comment_status Expected value for the global variable.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_set_review_status( ?string $request_status, string $expected_comment_status ) {
+		$list_table = new ReviewsListTable( [ 'screen' => 'product_page_product-reviews' ] );
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'set_review_status' );
+		$method->setAccessible( true );
+
+		$_REQUEST['comment_status'] = $request_status;
+
+		$method->invoke( $list_table );
+
+		global $comment_status;
+
+		$this->assertSame( $expected_comment_status, $comment_status );
+	}
+
+	/** @see test_set_review_status */
+	public function provider_set_review_status() : Generator {
+		yield 'not set' => [ null, 'all' ];
+		yield 'invalid status' => [ 'invalid', 'all' ];
+		yield 'moderated status' => [ 'moderated', 'moderated' ];
+		yield 'all status' => [ 'all', 'all' ];
+		yield 'approved status' => [ 'approved', 'approved' ];
+		yield 'spam status' => [ 'spam', 'spam' ];
+		yield 'trash status' => [ 'trash', 'trash' ];
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -158,9 +158,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_bulk_actions' );
 		$method->setAccessible( true );
 
-		// @TODO PHPCS doesn't like this {agibson 2022-04-12}
-		// global $comment_status;
-		// $comment_status = $current_comment_status;
+		global $comment_status;
+		$comment_status = $current_comment_status; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		$this->assertEqualsCanonicalizing(
 			$expected_actions,
@@ -177,6 +176,41 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 				'approve',
 				'spam',
 				'trash',
+			],
+		];
+
+		yield 'approved status' => [
+			'current_comment_status' => 'approved',
+			'expected_actions' => [
+				'unapprove',
+				'spam',
+				'trash',
+			],
+		];
+
+		yield 'moderated status' => [
+			'current_comment_status' => 'moderated',
+			'expected_actions' => [
+				'approve',
+				'spam',
+				'trash',
+			],
+		];
+
+		yield 'trash status' => [
+			'current_comment_status' => 'trash',
+			'expected_actions' => [
+				'spam',
+				'untrash',
+				'delete',
+			],
+		];
+
+		yield 'spam status' => [
+			'current_comment_status' => 'spam',
+			'expected_actions' => [
+				'unspam',
+				'delete',
 			],
 		];
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -2,6 +2,9 @@
 
 namespace Automattic\WooCommerce\Tests\Internal\Admin;
 
+use Automattic\WooCommerce\Internal\Admin\ReviewsListTable;
+use Generator;
+use ReflectionClass;
 use WC_Unit_Test_Case;
 
 /**
@@ -10,5 +13,40 @@ use WC_Unit_Test_Case;
  * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable
  */
 class ReviewsListTableTest extends WC_Unit_Test_Case {
+
+	/**
+	 * @dataProvider provider_get_bulk_actions
+	 *
+	 * @param string $current_comment_status Currently set status.
+	 * @param array  $expected_actions       Keys of the expected actions.
+	 * @return void
+	 */
+	public function test_get_bulk_actions( string $current_comment_status, array $expected_actions ) {
+		$list_table = new ReviewsListTable( [ 'screen' => 'product_page_product-reviews' ] );
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_bulk_actions' );
+		$method->setAccessible( true );
+
+		// @TODO PHPCS doesn't like this {agibson 2022-04-12}
+		// global $comment_status;
+		// $comment_status = $current_comment_status;
+
+		$this->assertEqualsCanonicalizing(
+			$expected_actions,
+			array_keys( $method->invoke( $list_table ) )
+		);
+	}
+
+	/** @see test_get_bulk_actions */
+	public function provider_get_bulk_actions() : Generator {
+		yield 'all statuses' => [
+			'current_comment_status' => 'all',
+			'expected_actions' => [
+				'unapprove',
+				'approve',
+				'spam',
+				'trash',
+			],
+		];
+	}
 
 }


### PR DESCRIPTION
## Overview

Defines the list of supported bulk actions.

## Story: [MWC-5346](https://jira.godaddy.com/browse/MWC-5346)

## QA

- Go to Products > Reviews.
    - [x] "Bulk actions" dropdown appears.
- Expand the dropdown.
    - [x] Options are: "Unapprove", "Approve", "Mark as spam", "Move to trash"
- Add this query arg to the URL: `&comment_status=moderated`, then expand the dropdown again.
    - [x] Options are: "Approve", "Mark as spam", "Move to trash"
- Change the query arg value to `approved`
    - [x] Options are: "Unapprove", "Mark as spam", "Move to trash"
- Change the query arg value to `spam`
    - [x] Options are: "Not spam" and "Delete Permanently"
- Change the query arg value to `trash`
    - [x] Options are: "Mark as spam", "Restore", and "Delete Permanently"
- Change the query arg value to `sdfdsfs`
    - [x] Options are: "Unapprove", "Approve", "Mark as spam", "Move to trash"