### PR TITLE
Render the type column

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -89,7 +89,11 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param object|array $item Review or reply being rendered.
 	 */
 	protected function column_type( $item ) {
-		// @TODO Implement in MWC-5334 {agibson 2022-04-12}
+		echo esc_html(
+			'review' === $item->comment_type ?
+			'&#9734;&nbsp;' . __( 'Review', 'woocommerce' ) :
+			__( 'Reply', 'woocommerce' )
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -3,7 +3,9 @@
 namespace Automattic\WooCommerce\Tests\Internal\Admin;
 
 use Automattic\WooCommerce\Internal\Admin\ReviewsListTable;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper;
 use ReflectionClass;
+use WC_Helper_Product;
 use WC_Unit_Test_Case;
 
 /**
@@ -51,4 +53,44 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$this->assertSame( 'comment', $method->invoke( $list_table ) );
 	}
 
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_type()
+	 *
+	 * @dataProvider data_provider_test_column_type()
+	 * @param string $comment_type The comment type (usually review or comment).
+	 * @param string $expected_output The expected output.
+	 */
+	public function test_column_type( $comment_type, $expected_output ) {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'column_type' );
+		$method->setAccessible( true );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$review_id = ProductHelper::create_product_review( $product->get_id() );
+
+		$reviews = get_comments(
+			[
+				'id' => $review_id,
+			]
+		);
+
+		$review = ! empty( $reviews ) ? current( $reviews ) : null;
+		$review->comment_type = $comment_type;
+
+		ob_start();
+		$method->invokeArgs( $list_table, [ $review ] );
+		$output = ob_get_clean();
+
+		$this->assertSame( $expected_output, $output );
+	}
+
+	/** @see test_column_type() */
+	public function data_provider_test_column_type() {
+		return [
+			'review' => [ 'review', '&#9734;&nbsp;Review' ],
+			'reply' => [ 'comment', 'Reply' ],
+			'default to reply' => [ 'anything', 'Reply' ],
+		];
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -25,6 +25,26 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Returns a test review object.
+	 *
+	 * @return WP_Comment|null
+	 */
+	protected function get_test_review() {
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$review_id = ProductHelper::create_product_review( $product->get_id() );
+
+		$reviews = get_comments(
+			[
+				'id' => $review_id,
+			]
+		);
+
+		return ! empty( $reviews ) ? current( $reviews ) : null;
+	}
+
+	/**
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_columns()
 	 */
 	public function test_get_columns() {
@@ -65,17 +85,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'column_type' );
 		$method->setAccessible( true );
 
-		$product = WC_Helper_Product::create_simple_product();
-
-		$review_id = ProductHelper::create_product_review( $product->get_id() );
-
-		$reviews = get_comments(
-			[
-				'id' => $review_id,
-			]
-		);
-
-		$review = ! empty( $reviews ) ? current( $reviews ) : null;
+		$review = $this->get_test_review();
 		$review->comment_type = $comment_type;
 
 		ob_start();


### PR DESCRIPTION
## Summary

Renders the Type column.

## Story: [MWC-5334](https://jira.godaddy.com/browse/MWC-5334)

## Details

I've branched off https://github.com/godaddy-wordpress/woocommerce/pull/8 so we can user test this.

## QA

### Setup

- Have at least one review and one review reply

### Steps

1. Navigate to Products > Reviews
    - [x] The Type column displays "☆ Review" for the review and "Reply" for the reply

## Before merge

- [ ] https://github.com/godaddy-wordpress/woocommerce/pull/8 is merged