### PR TITLE
Render the rating column

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -105,22 +105,16 @@ class ReviewsListTable extends WP_List_Table {
 		$rating = get_comment_meta( $item->comment_ID, 'rating', true );
 
 		if ( ! empty( $rating ) && is_numeric( $rating ) ) {
+			$rating = (int) $rating;
 			$accessibility_label = sprintf(
 				/* translators: 1: number representing a rating */
 				__( '%1$s out of 5', 'woocommerce' ),
 				$rating
 			);
+			$stars = str_repeat( '&#9733;', $rating );
+			$stars .= str_repeat( '&#9734;', 5 - $rating );
 			?>
-			<span aria-label="<?php echo esc_attr( $accessibility_label ); ?>">
-			<?php
-			for ( $count = 0; $count < $rating; $count++ ) {
-				echo '&#9733;';
-			}
-			for ( $count = 0; $count < 5 - $rating; $count++ ) {
-				echo '&#9734;';
-			}
-			?>
-			</span>
+			<span aria-label="<?php echo esc_attr( $accessibility_label ); ?>"><?php echo esc_html( $stars ); ?></span>
 			<?php
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -102,7 +102,24 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param object|array $item Review or reply being rendered.
 	 */
 	protected function column_rating( $item ) {
-		// @TODO Implement in MWC-5333 {agibson 2022-04-12}
+		$rating = get_comment_meta( $item->comment_ID, 'rating', true );
+
+		if ( ! empty( $rating ) && is_numeric( $rating ) ) {
+			$accessibility_label = sprintf(
+				/* translators: 1: number representing a rating */
+				__( '%1$s out of 5', 'woocommerce' ),
+				$rating
+			);
+			?>
+			<span aria-label="<?php echo esc_attr( $accessibility_label ); ?>">
+			<?php
+			for ( $count = 0; $count < $rating; $count++ ) {
+				echo '&#9733;';
+			}
+			?>
+			</span>
+			<?php
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -116,6 +116,9 @@ class ReviewsListTable extends WP_List_Table {
 			for ( $count = 0; $count < $rating; $count++ ) {
 				echo '&#9733;';
 			}
+			for ( $count = 0; $count < 5 - $rating; $count++ ) {
+				echo '&#9734;';
+			}
 			?>
 			</span>
 			<?php

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -103,4 +103,43 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			'default to reply' => [ 'anything', 'Reply' ],
 		];
 	}
+
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_rating()
+	 *
+	 * @dataProvider data_provider_test_column_rating()
+	 * @param string $meta_value The comment meta value for rating.
+	 * @param string $expected_output The expected output.
+	 */
+	public function test_column_rating( $meta_value, $expected_output ) {
+
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'column_rating' );
+		$method->setAccessible( true );
+
+		$review = $this->get_test_review();
+
+		if ( ! empty( $meta_value ) ) {
+			update_comment_meta( $review->comment_ID, 'rating', $meta_value );
+		}
+
+		ob_start();
+		$method->invokeArgs( $list_table, [ $review ] );
+		$output = trim( ob_get_clean() );
+
+		$this->assertSame( $expected_output, $output );
+	}
+
+	/** @see test_column_rating() */
+	public function data_provider_test_column_rating() {
+		return [
+			'no rating' => [ '', '' ],
+			'1 star' => [ '1', '<span aria-label="1 out of 5">&#9733;&#9734;&#9734;&#9734;&#9734;</span>' ],
+			'2 stars' => [ '2', '<span aria-label="2 out of 5">&#9733;&#9733;&#9734;&#9734;&#9734;</span>' ],
+			'3 stars' => [ '3', '<span aria-label="3 out of 5">&#9733;&#9733;&#9733;&#9734;&#9734;</span>' ],
+			'4 stars' => [ '4', '<span aria-label="4 out of 5">&#9733;&#9733;&#9733;&#9733;&#9734;</span>' ],
+			'5 stars' => [ '5', '<span aria-label="5 out of 5">&#9733;&#9733;&#9733;&#9733;&#9733;</span>' ],
+			'2.5 stars (rounds down)' => [ '2.5', '<span aria-label="2 out of 5">&#9733;&#9733;&#9734;&#9734;&#9734;</span>' ],
+		];
+	}
 }


### PR DESCRIPTION
## Summary

Renders the Rating column.

## Story: [MWC-5333](https://jira.godaddy.com/browse/MWC-5333)

## Details

I've branched off https://github.com/godaddy-wordpress/woocommerce/pull/10 so I could reuse a test helper method.

This looks a bit different than the original layout because the Product team decided to go with stars out of 5, as per [this discussion](https://godaddy.slack.com/archives/C02PYQALB2Q/p1649796953795319). Tabitha documented that decision [here](https://docs.google.com/document/d/1oMku-8Fqzj6PCSmXh5j3ElE2hsxABp6TQ3ayuQ-Or8Q/edit#bookmark=id.ougtwusc92wz).

## QA

### Setup

- Have at least one product review with a star rating

### Steps

1. Navigate to Products > Reviews
    - [ ] The Rating column displays the rating for the review in stars (out of 5 stars)

## Before merge

- [x] https://github.com/godaddy-wordpress/woocommerce/pull/10 is merged