### PR TITLE
Implement the author column in the Reviews page

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -11,6 +11,11 @@ namespace Automattic\WooCommerce\Internal\Admin;
 class Reviews {
 
 	/**
+	 * Admin page identifier.
+	 */
+	const MENU_SLUG = 'product-reviews';
+
+	/**
 	 * Class instance.
 	 *
 	 * @var Reviews|null instance
@@ -62,7 +67,7 @@ class Reviews {
 			__( 'Reviews', 'woocommerce' ),
 			__( 'Reviews', 'woocommerce' ),
 			'moderate_comments',
-			'product-reviews',
+			static::MENU_SLUG,
 			[ $this, 'render_reviews_list_table' ]
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -21,6 +21,24 @@ class ReviewsListTable extends WP_List_Table {
 	private $current_user_can_edit = false;
 
 	/**
+	 * Prepares reviews for display.
+	 *
+	 * @return void
+	 */
+	public function prepare_items() {
+
+		$comments = get_comments(
+			[
+				'post_type' => 'product',
+			]
+		);
+
+		update_comment_cache( $comments );
+
+		$this->items = $comments;
+	}
+
+	/**
 	 * Render a single row HTML.
 	 *
 	 * @param WP_Comment $item Review or reply being rendered.
@@ -221,24 +239,6 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	protected function column_default( $item, $column_name ) {
 		// @TODO Implement in MWC-5362 {agibson 2022-04-12}
-	}
-
-	/**
-	 * Prepares reviews for display.
-	 *
-	 * @return void
-	 */
-	public function prepare_items() {
-
-		$comments = get_comments(
-			[
-				'post_type' => 'product',
-			]
-		);
-
-		update_comment_cache( $comments );
-
-		$this->items = $comments;
 	}
 
 }

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -188,7 +188,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param string $author_url The review or reply author URL (raw).
 	 * @return string
 	 */
-	private function get_item_author_url_for_display( $author_url ) {
+	private function get_item_author_url_for_display( $author_url ) : string {
 
 		$author_url_display = untrailingslashit( preg_replace( '|^http(s)?://(www\.)?|i', '', $author_url ) );
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -170,7 +170,7 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @return string
 	 */
-	private function get_item_author_url() {
+	private function get_item_author_url() : string {
 
 		$author_url = get_comment_author_url();
 		$protocols = [ 'https://', 'http://' ];

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -50,7 +50,7 @@ class ReviewsListTable extends WP_List_Table {
 
 		// Overrides the comment global for properly rendering rows.
 		$comment           = $item; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$the_comment_class = wp_get_comment_status( $comment->comment_ID );
+		$the_comment_class = wp_get_comment_status( $comment->comment_ID ) ?: '';
 		$the_comment_class = implode( ' ', get_comment_class( $the_comment_class, $comment->comment_ID, $comment->comment_post_ID ) );
 		// Sets the post for the product in context.
 		$post = get_post( $comment->comment_post_ID ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -162,7 +162,7 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @return string
 	 */
-	private function get_item_author_url() {
+	protected function get_item_author_url() {
 
 		$author_url = get_comment_author_url();
 		$protocols = [ 'https://', 'http://' ];
@@ -180,7 +180,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param string $author_url The review or reply author URL (raw).
 	 * @return string
 	 */
-	private function get_item_author_url_for_display( $author_url ) {
+	protected function get_item_author_url_for_display( $author_url ) {
 
 		$author_url_display = str_replace( [ 'http://', 'https://' ], '', $author_url );
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -50,7 +50,7 @@ class ReviewsListTable extends WP_List_Table {
 
 		// Overrides the comment global for properly rendering rows.
 		$comment           = $item; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$the_comment_class = wp_get_comment_status( $comment->comment_ID ) ?: '';
+		$the_comment_class = (string) wp_get_comment_status( $comment->comment_ID );
 		$the_comment_class = implode( ' ', get_comment_class( $the_comment_class, $comment->comment_ID, $comment->comment_post_ID ) );
 		// Sets the post for the product in context.
 		$post = get_post( $comment->comment_post_ID ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -121,9 +121,15 @@ class ReviewsListTable extends WP_List_Table {
 		$author_url = $this->get_item_author_url();
 		$author_url_display = $this->get_item_author_url_for_display( $author_url );
 
-		?>
-		<strong><?php comment_author(); ?></strong><br />
-		<?php
+		if ( get_option( 'show_avatars' ) ) {
+			$author_avatar = get_avatar( $item, 32, 'mystery' );
+		} else {
+			$author_avatar = '';
+		}
+
+		echo '<strong>' . $author_avatar; // // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		comment_author();
+		echo '</strong><br>';
 
 		if ( ! empty( $author_url ) ) :
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -127,7 +127,7 @@ class ReviewsListTable extends WP_List_Table {
 			$author_avatar = '';
 		}
 
-		echo '<strong>' . $author_avatar; // // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<strong>' . $author_avatar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		comment_author();
 		echo '</strong><br>';
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -114,8 +114,8 @@ class ReviewsListTable extends WP_List_Table {
 	protected function column_author( $item ) {
 		global $comment_status;
 
-		$author_url = $this->get_review_author_url();
-		$author_url_display = $this->get_review_author_url_for_display( $author_url );
+		$author_url = $this->get_item_author_url();
+		$author_url_display = $this->get_item_author_url_for_display( $author_url );
 
 		?>
 		<strong><?php comment_author(); ?></strong><br />
@@ -158,11 +158,11 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Gets the review author URL.
+	 * Gets the item author URL.
 	 *
 	 * @return string
 	 */
-	private function get_review_author_url() {
+	private function get_item_author_url() {
 
 		$author_url = get_comment_author_url();
 		$protocols = [ 'https://', 'http://' ];
@@ -175,12 +175,12 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Gets the review author URL for display.
+	 * Gets the item author URL for display.
 	 *
-	 * @param string $author_url The review author URL (raw).
+	 * @param string $author_url The review or reply author URL (raw).
 	 * @return string
 	 */
-	private function get_review_author_url_for_display( $author_url ) {
+	private function get_item_author_url_for_display( $author_url ) {
 
 		$author_url_display = str_replace( [ 'http://', 'https://' ], '', $author_url );
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -147,7 +147,7 @@ class ReviewsListTable extends WP_List_Table {
 
 			$link = add_query_arg(
 				[
-					's'    => get_comment_author_IP( $item->comment_ID ),
+					's'    => urlencode( get_comment_author_IP( $item->comment_ID ) ),
 					'page' => Reviews::MENU_SLUG,
 					'mode' => 'detail',
 				],

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -128,7 +128,7 @@ class ReviewsListTable extends WP_List_Table {
 		if ( ! empty( $author_url ) ) :
 
 			?>
-			<a title="<?php echo esc_attr( $author_url ); ?>" href="<?php echo esc_attr( $author_url ); ?>" rel="noopener noreferrer"><?php echo esc_html( $author_url_display ); ?></a>
+			<a title="<?php echo esc_attr( $author_url ); ?>" href="<?php echo esc_url( $author_url ); ?>" rel="noopener noreferrer"><?php echo esc_html( $author_url_display ); ?></a>
 			<br>
 			<?php
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Internal\Admin;
 
 use WP_Comment;
+use WP_Comments_List_Table;
 use WP_List_Table;
 
 /**
@@ -110,6 +111,8 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the author column.
 	 *
+	 * @see WP_Comments_List_Table::column_author() for consistency.
+	 *
 	 * @param WP_Comment $item Review or reply being rendered.
 	 */
 	protected function column_author( $item ) {
@@ -125,7 +128,7 @@ class ReviewsListTable extends WP_List_Table {
 		if ( ! empty( $author_url ) ) :
 
 			?>
-			<a title="<?php echo esc_attr( $author_url ); ?>" href="<?php echo esc_attr( $author_url ); ?>"><?php echo esc_html( $author_url_display ); ?></a>
+			<a title="<?php echo esc_attr( $author_url ); ?>" href="<?php echo esc_attr( $author_url ); ?>" rel="noopener noreferrer"><?php echo esc_html( $author_url_display ); ?></a>
 			<br>
 			<?php
 
@@ -134,8 +137,12 @@ class ReviewsListTable extends WP_List_Table {
 		if ( $this->current_user_can_edit ) :
 
 			if ( ! empty( $item->comment_author_email ) ) :
-				comment_author_email_link();
-				echo '<br>';
+				/** This filter is documented in wp-includes/comment-template.php */
+				$email = apply_filters( 'comment_email', $item->comment_author_email, $item );
+
+				if ( ! empty( $email ) && '@' !== $email ) {
+					printf( '<a href="%1$s">%2$s</a><br />', esc_url( 'mailto:' . $email ), esc_html( $email ) );
+				}
 			endif;
 
 			$link = add_query_arg(
@@ -183,10 +190,10 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	private function get_item_author_url_for_display( $author_url ) {
 
-		$author_url_display = str_replace( [ 'http://', 'https://' ], '', $author_url );
+		$author_url_display = untrailingslashit( preg_replace( '|^http(s)?://(www\.)?|i', '', $author_url ) );
 
 		if ( strlen( $author_url_display ) > 50 ) {
-			$author_url_display = substr( $author_url_display, 0, 49 ) . '&hellip;';
+			$author_url_display = wp_html_excerpt( $author_url_display, 49, '&hellip;' );
 		}
 
 		return $author_url_display;

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -162,7 +162,7 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @return string
 	 */
-	protected function get_item_author_url() {
+	private function get_item_author_url() {
 
 		$author_url = get_comment_author_url();
 		$protocols = [ 'https://', 'http://' ];
@@ -180,7 +180,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param string $author_url The review or reply author URL (raw).
 	 * @return string
 	 */
-	protected function get_item_author_url_for_display( $author_url ) {
+	private function get_item_author_url_for_display( $author_url ) {
 
 		$author_url_display = str_replace( [ 'http://', 'https://' ], '', $author_url );
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -24,6 +24,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * Render a single row HTML.
 	 *
 	 * @param WP_Comment $item Review or reply being rendered.
+	 * @return void
 	 */
 	public function single_row( $item ) {
 		global $post, $comment;
@@ -224,6 +225,8 @@ class ReviewsListTable extends WP_List_Table {
 
 	/**
 	 * Prepares reviews for display.
+	 *
+	 * @return void
 	 */
 	public function prepare_items() {
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -47,10 +47,11 @@ class ReviewsListTable extends WP_List_Table {
 	public function single_row( $item ) {
 		global $post, $comment;
 
+		// Overrides the comment global for properly rendering rows.
 		$comment           = $item; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$the_comment_class = wp_get_comment_status( $comment->comment_ID );
 		$the_comment_class = implode( ' ', get_comment_class( $the_comment_class, $comment->comment_ID, $comment->comment_post_ID ) );
-
+		// Sets the post for the product in context.
 		$post = get_post( $comment->comment_post_ID ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		$this->current_user_can_edit = current_user_can( 'edit_comment', $comment->comment_ID );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -137,9 +137,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * @throws ReflectionException If the method does not exist.
 	 */
 	public function test_get_item_author_url_for_display( $author_url, $author_url_for_display ) {
-
 		$list_table = $this->get_reviews_list_table();
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_item_author_url_for_display' );
+		$method->setAccessible( true );
 
 		$this->assertSame( $author_url_for_display, $method->invokeArgs( $list_table, [ $author_url ] ) );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -190,8 +190,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			'Empty URL' => [ '', '' ],
 			'Empty URL (http)' => [ 'http://', '' ],
 			'Empty URL (https)' => [ 'https://', '' ],
-			'Regular URL' => [ 'https://www.example.com', 'www.example.com' ],
-			'Very long URL' => [ $very_long_url, substr( str_replace( 'https://', '', $very_long_url ), 0, 49 ) . '&hellip;' ],
+			'Regular URL' => [ 'https://www.example.com', 'example.com' ],
+			'Very long URL' => [ $very_long_url, substr( str_replace( 'https://www.', '', $very_long_url ), 0, 49 ) . '&hellip;' ],
 		];
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -127,6 +127,44 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can get the item author URL.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_item_author_url()
+	 * @dataProvider data_provider_test_get_item_author_url
+	 *
+	 * @param string $comment_author_url The comment author URL.
+	 * @param string $expected_author_url The expected author URL.
+	 * @throws ReflectionException If the method does not exist.
+	 */
+	public function test_get_item_author_url( $comment_author_url, $expected_author_url ) {
+		global $comment;
+
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_item_author_url' );
+		$method->setAccessible( true );
+
+		$the_comment = $this->factory()->comment->create_and_get(
+			[
+				'comment_author_url' => $comment_author_url,
+			]
+		);
+
+		$comment = $the_comment; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$this->assertSame( $expected_author_url, $method->invoke( $list_table ) );
+	}
+
+	/** @see test_get_item_author_url() */
+	public function data_provider_test_get_item_author_url() {
+		return [
+			'No URL' => [ '', '' ],
+			'Empty URL (http)' => [ 'http://', '' ],
+			'Empty URL (https)' => [ 'https://', '' ],
+			'Valid URL' => [ 'https://example.com', 'https://example.com' ],
+		];
+	}
+
+	/**
 	 * Tests that can get a review author url for display.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_item_author_url_for_display()

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -42,7 +42,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_primary_column_name()
 	 *
-	 * @throws ReflectionException
+	 * @throws ReflectionException If the method does not exist.
 	 */
 	public function test_get_primary_column_name() {
 		$list_table = $this->get_reviews_list_table();
@@ -60,7 +60,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 *
 	 * @param string $comment_type The comment type (usually review or comment).
 	 * @param string $expected_output The expected output.
-	 * @throws ReflectionException
+	 * @throws ReflectionException If the method does not exist.
 	 */
 	public function test_column_type( $comment_type, $expected_output ) {
 		$list_table = $this->get_reviews_list_table();
@@ -83,6 +83,37 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			'review' => [ 'review', '&#9734;&nbsp;Review' ],
 			'reply' => [ 'comment', 'Reply' ],
 			'default to reply' => [ 'anything', 'Reply' ],
+		];
+	}
+
+	/**
+	 * Tests that can get a review author url for display.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_item_author_url_for_display()
+	 * @dataProvider data_provider_test_get_item_author_url_for_display()
+	 *
+	 * @param string $author_url The author URL.
+	 * @param string $author_url_for_display The author URL for display.
+	 * @throws ReflectionException If the method does not exist.
+	 */
+	public function test_get_item_author_url_for_display( $author_url, $author_url_for_display ) {
+
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_item_author_url_for_display' );
+
+		$this->assertSame( $author_url_for_display, $method->invokeArgs( $list_table, [ $author_url ] ) );
+	}
+
+	/** @see test_get_item_author_url_for_display() */
+	public function data_provider_test_get_item_author_url_for_display() {
+		$very_long_url = 'https://www.example.com/this-is-a-very-long-url-that-is-longer-than-the-maximum-allowed-length-of-the-url-for-display-purposes/';
+
+		return [
+			'Empty URL' => [ '', '' ],
+			'Empty URL (http)' => [ 'http://', '' ],
+			'Empty URL (https)' => [ 'https://', '' ],
+			'Regular URL' => [ 'https://www.example.com', 'https://www.example.com' ],
+			'Very long URL' => [ $very_long_url, substr( $very_long_url, 0, 49 ) . '&hellip;' ],
 		];
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -152,8 +152,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			'Empty URL' => [ '', '' ],
 			'Empty URL (http)' => [ 'http://', '' ],
 			'Empty URL (https)' => [ 'https://', '' ],
-			'Regular URL' => [ 'https://www.example.com', 'https://www.example.com' ],
-			'Very long URL' => [ $very_long_url, substr( $very_long_url, 0, 49 ) . '&hellip;' ],
+			'Regular URL' => [ 'https://www.example.com', 'www.example.com' ],
+			'Very long URL' => [ $very_long_url, substr( str_replace( 'https://', '', $very_long_url ), 0, 49 ) . '&hellip;' ],
 		];
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -18,6 +18,40 @@ use WP_Comment;
 class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 	/**
+	 * Tests that can process the row output for a review or reply.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::single_row()
+	 */
+	public function test_single_row() {
+		$post_id = $this->factory()->post->create();
+		$review = $this->factory()->comment->create_and_get(
+			[
+				'comment_post_ID'  => $post_id,
+			]
+		);
+
+		$reviews_list_table = $this->get_reviews_list_table();
+
+		ob_start();
+
+		$reviews_list_table->single_row( $review );
+
+		$row_output = trim( ob_get_clean() );
+
+		$this->assertStringStartsWith( '<tr id="comment-' . $review->comment_ID . '"', $row_output );
+
+		foreach ( $reviews_list_table->get_columns() as $column_id => $column_name ) {
+			if ( 'cb' !== $column_id ) {
+				$this->assertStringContainsString( 'data-colname="' . $column_name . '"', $row_output );
+			} else {
+				$this->assertStringContainsString( '<th scope="row" class="check-column"></th>', $row_output );
+			}
+		}
+
+		$this->assertStringEndsWith( '</tr>', $row_output );
+	}
+
+	/**
 	 * Tests that can get the product reviews' page columns.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_columns()

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -41,6 +41,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * Tests that can get the primary column name.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_primary_column_name()
+	 *
+	 * @throws ReflectionException
 	 */
 	public function test_get_primary_column_name() {
 		$list_table = $this->get_reviews_list_table();

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -127,6 +127,40 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can output the author information.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_author()
+	 *
+	 * @throws ReflectionException If the method does not exist.
+	 */
+	public function test_column_author() {
+		global $comment;
+
+		$review = $this->factory()->comment->create_and_get(
+			[
+				'comment_author_url' => 'https://example.com',
+			]
+		);
+
+		$comment = $review; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'column_author' );
+		$method->setAccessible( true );
+
+		ob_start();
+
+		$method->invokeArgs( $list_table, [ $review ] );
+
+		$author_output = ob_get_clean();
+
+		$author = get_comment_author( $review->comment_ID );
+
+		$this->assertStringContainsString( '<strong>' . $author . '</strong>', $author_output );
+		$this->assertStringContainsString( '<a title="https://example.com" href="https://example.com" rel="noopener noreferrer">example.com</a>', $author_output );
+	}
+
+	/**
 	 * Tests that can get the item author URL.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_item_author_url()


### PR DESCRIPTION
## Summary

Implements the review/reply author column output.

### Story: [MWC-5336](https://jira.godaddy.com/browse/MWC-5336)

## Details

I had to implement an additional method to ensure the comment and post objects would be set in the comment loop utilized in the `WP_Comment_List_Table` parent object.

The output should also be consistent with the `WP_Comment_List_Table`.

## QA

- [x] Code review
- [x] Unit Tests pass

### User testing

1. Have at least one product in your installation
1. Have a review left by a registered user
1. Have a review left by a guest
1. Have multiple replies on both reviews
1. Check the Product > Reviews page
    - [x] The "Author" column should be properly populated for all the review types