### PR TITLE
Implement the review content column in the Reviews page

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -102,7 +102,10 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the review column.
 	 *
+	 * @see WP_Comments_List_Table::column_comment() for consistency.
+	 *
 	 * @param WP_Comment $item Review or reply being rendered.
+	 * @return void
 	 */
 	protected function column_comment( $item ) {
 
@@ -147,6 +150,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @see WP_Comments_List_Table::column_author() for consistency.
 	 *
 	 * @param WP_Comment $item Review or reply being rendered.
+	 * @return void
 	 */
 	protected function column_author( $item ) {
 		global $comment_status;

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -130,7 +130,7 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	private function get_in_reply_to_review_text( $reply ) {
 
-		$review = get_comment( $reply->comment_parent );
+		$review = $reply->comment_parent ? get_comment( $reply->comment_parent ) : null;
 
 		if ( ! $review ) {
 			return '';

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -100,10 +100,43 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the review column.
 	 *
-	 * @param object|array $item Review or reply being rendered.
+	 * @param WP_Comment $item Review or reply being rendered.
 	 */
 	protected function column_comment( $item ) {
-		// @TODO Implement in MWC-5339 {agibson 2022-04-12}
+
+		$in_reply_to = $this->get_in_reply_to_review_text( $item );
+
+		echo $in_reply_to ? $in_reply_to . '<br><br>' : ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+		?>
+		<div class="comment-text">
+			<?php echo get_comment_text( $item->comment_ID ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Gets the in-reply-to-review text.
+	 *
+	 * @param WP_Comment $reply Reply to review.
+	 * @return string
+	 */
+	private function get_in_reply_to_review_text( $reply ) {
+
+		$review = get_comment( $reply->comment_parent );
+
+		if ( ! $review ) {
+			return '';
+		}
+
+		$parent_review_link = esc_url( get_comment_link( $review ) );
+		$review_author_name = get_comment_author( $review );
+
+		return sprintf(
+			/* translators: %s: Parent review link with review author name. */
+			ent2ncr( __( 'In reply to %s.', 'woocommerce' ) ),
+			'<a href="' . esc_url( $parent_review_link ) . '">' . esc_html( $review_author_name ) . '</a>'
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -108,16 +108,18 @@ class ReviewsListTable extends WP_List_Table {
 	 * @return void
 	 */
 	protected function column_comment( $item ) {
-
 		$in_reply_to = $this->get_in_reply_to_review_text( $item );
 
-		echo $in_reply_to ? $in_reply_to . '<br><br>' : ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		if ( $in_reply_to ) {
+			echo $in_reply_to . '<br><br>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
 
-		?>
-		<div class="comment-text">
-			<?php echo get_comment_text( $item->comment_ID ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		</div>
-		<?php
+		printf(
+			'%1$s%2$s%3$s',
+			'<div class="comment-text">',
+			get_comment_text( $item->comment_ID ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			'</div>'
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -230,6 +230,34 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can output the review or reply content.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_content()
+	 *
+	 * @throws ReflectionException If the method does not exist.
+	 */
+	public function test_column_comment() {
+
+		$review = $this->factory()->comment->create_and_get(
+			[
+				'comment_content' => 'Test review',
+			]
+		);
+
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'column_comment' );
+		$method->setAccessible( true );
+
+		ob_start();
+
+		$method->invokeArgs( $list_table, [ $review ] );
+
+		$column_content = ob_get_clean();
+
+		$this->assertStringContainsString( '<div class="comment-text">Test review</div>', $column_content );
+	}
+
+	/**
 	 * Returns a new instance of the {@see ReviewsListTable} class.
 	 *
 	 * @return ReviewsListTable

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -258,6 +258,35 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can get the in reply to review text message for the review content column.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_in_reply_to_review_text()
+	 *
+	 * @throws ReflectionException If the method does not exist.
+	 */
+	public function test_get_in_reply_to_review_text() {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_in_reply_to_review_text' );
+		$method->setAccessible( true );
+
+		$review = $this->factory()->comment->create_and_get();
+
+		$output = $method->invokeArgs( $list_table, [ $review ] );
+
+		$this->assertSame( '', $output );
+
+		$reply = $this->factory()->comment->create_and_get(
+			[
+				'comment_parent' => $review->comment_ID,
+			]
+		);
+
+		$output = $method->invokeArgs( $list_table, [ $reply ] );
+
+		$this->assertSame( 'In reply to <a href="' . get_comment_link( $review ) . '">' . get_comment_author( $review ) . '</a>.', $output );
+	}
+
+	/**
 	 * Returns a new instance of the {@see ReviewsListTable} class.
 	 *
 	 * @return ReviewsListTable

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -232,7 +232,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can output the review or reply content.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_content()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_comment()
 	 *
 	 * @throws ReflectionException If the method does not exist.
 	 */
@@ -254,7 +254,25 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$column_content = ob_get_clean();
 
+		$this->assertStringNotContainsString( 'In reply to', $column_content );
 		$this->assertStringContainsString( '<div class="comment-text">Test review</div>', $column_content );
+
+		$reply = $this->factory()->comment->create_and_get(
+			[
+				'comment_content' => 'Test reply',
+				'comment_parent'  => $review->comment_ID,
+			]
+		);
+
+		ob_start();
+
+		$method->invokeArgs( $list_table, [ $reply ] );
+
+		$column_content = ob_get_clean();
+
+		$this->assertStringContainsString( 'In reply to', $column_content );
+		$this->assertStringContainsString( '<div class="comment-text">Test reply</div>', $column_content );
+
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -241,6 +241,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$review = $this->factory()->comment->create_and_get(
 			[
 				'comment_content' => 'Test review',
+				'comment_parent'  => 0,
 			]
 		);
 
@@ -272,7 +273,6 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$this->assertStringContainsString( 'In reply to', $column_content );
 		$this->assertStringContainsString( '<div class="comment-text">Test reply</div>', $column_content );
-
 	}
 
 	/**
@@ -287,7 +287,11 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_in_reply_to_review_text' );
 		$method->setAccessible( true );
 
-		$review = $this->factory()->comment->create_and_get();
+		$review = $this->factory()->comment->create_and_get(
+			[
+				'comment_parent' => 0,
+			]
+		);
 
 		$output = $method->invokeArgs( $list_table, [ $review ] );
 


### PR DESCRIPTION
## Summary

Adds the review/reply content column output.

### Story: [MWC 5339](https://jira.godaddy.com/browse/MWC-5339)

### Base PR: #13 

## Details

If we are to handle this like in Product Reviews Pro, probably we need to add an ability to trim very long reviews automatically, with a JS toggle to read more. This could be done when we implement our JS. If so need to write or update follow up story.

WIP some tests as I finally managed to get the tests suite running...


## QA

- [x] Code review
- [x] Unit tests pass

### User testing

1. Have products, reviews and replies in your installation
1. Head over the Products > Reviews page
    - [x] You should see each review or reply content output in the corresponding column
    - [x] Replies begin with "In reply to..." with a link to the parent review comment author name

## Before merge

- [x] #13 is reviewed and merged first