### PR TITLE
Implement the submitted on column in the Reviews page

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Internal\Admin;
 
 use WP_Comment;
+use WP_Comments_List_Table;
 use WP_List_Table;
 
 /**
@@ -195,10 +196,38 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the "submitted on" column.
 	 *
-	 * @param object|array $item Review or reply being rendered.
+	 * Note that the output is consistent with {@see WP_Comments_List_Table::column_date()}.
+	 *
+	 * @param WP_Comment $item Review or reply being rendered.
 	 */
 	protected function column_date( $item ) {
-		// @TODO Implement in MWC-5338 {agibson 2022-04-12}
+
+		$submitted = sprintf(
+			/* translators: 1 - Comment date, 2: Comment time. */
+			__( '%1$s at %2$s', 'woocommerce' ),
+			/* translators: Comment date format. See https://www.php.net/manual/datetime.format.php */
+			get_comment_date( __( 'Y/m/d', 'woocommerce' ), $item ),
+			/* translators: Comment time format. See https://www.php.net/manual/datetime.format.php */
+			get_comment_date( __( 'g:i a', 'woocommerce' ), $item )
+		);
+
+		?>
+		<div class="submitted-on">
+			<?php
+
+			if ( 'approved' === wp_get_comment_status( $item ) && ! empty( $item->comment_post_ID ) ) :
+				printf(
+					'<a href="%s">%s</a>',
+					esc_url( get_comment_link( $item ) ),
+					esc_html( $submitted )
+				);
+			else :
+				echo esc_html( $submitted );
+			endif;
+
+			?>
+		</div>
+		<?php
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -93,7 +93,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the checkbox column.
 	 *
-	 * @param object|array $item Review or reply being rendered.
+	 * @param WP_Comment $item Review or reply being rendered.
 	 */
 	protected function column_cb( $item ) {
 		// @TODO Implement in MWC-5335 {agibson 2022-04-12}
@@ -248,7 +248,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the type column.
 	 *
-	 * @param object|array $item Review or reply being rendered.
+	 * @param WP_Comment $item Review or reply being rendered.
 	 */
 	protected function column_type( $item ) {
 		echo esc_html(
@@ -261,7 +261,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the rating column.
 	 *
-	 * @param object|array $item Review or reply being rendered.
+	 * @param WP_Comment $item Review or reply being rendered.
 	 */
 	protected function column_rating( $item ) {
 		$rating = get_comment_meta( $item->comment_ID, 'rating', true );
@@ -284,8 +284,8 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders any custom columns.
 	 *
-	 * @param object|array $item        Review or reply being rendered.
-	 * @param string       $column_name Name of the column being rendered.
+	 * @param WP_Comment $item        Review or reply being rendered.
+	 * @param string     $column_name Name of the column being rendered.
 	 */
 	protected function column_default( $item, $column_name ) {
 		// @TODO Implement in MWC-5362 {agibson 2022-04-12}

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -205,6 +205,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * Note that the output is consistent with {@see WP_Comments_List_Table::column_date()}.
 	 *
 	 * @param WP_Comment $item Review or reply being rendered.
+	 * @return void
 	 */
 	protected function column_date( $item ) {
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -209,11 +209,11 @@ class ReviewsListTable extends WP_List_Table {
 	protected function column_date( $item ) {
 
 		$submitted = sprintf(
-			/* translators: 1 - Comment date, 2: Comment time. */
+			/* translators: 1 - Product review date, 2: Product review time. */
 			__( '%1$s at %2$s', 'woocommerce' ),
-			/* translators: Comment date format. See https://www.php.net/manual/datetime.format.php */
+			/* translators: Review date format. See https://www.php.net/manual/datetime.format.php */
 			get_comment_date( __( 'Y/m/d', 'woocommerce' ), $item ),
-			/* translators: Comment time format. See https://www.php.net/manual/datetime.format.php */
+			/* translators: Review time format. See https://www.php.net/manual/datetime.format.php */
 			get_comment_date( __( 'g:i a', 'woocommerce' ), $item )
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -223,7 +223,7 @@ class ReviewsListTable extends WP_List_Table {
 
 			if ( 'approved' === wp_get_comment_status( $item ) && ! empty( $item->comment_post_ID ) ) :
 				printf(
-					'<a href="%s">%s</a>',
+					'<a href="%1$s">%2$s</a>',
 					esc_url( get_comment_link( $item ) ),
 					esc_html( $submitted )
 				);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -261,7 +261,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$submitted_on = sprintf(
 			'%1$s at %2$s',
 			get_comment_date( 'Y/m/d', $review ),
-			get_comment_date( 'g:i a', $review ),
+			get_comment_date( 'g:i a', $review )
 		);
 
 		$this->assertStringContainsString( $submitted_on, $date_output );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -235,11 +235,11 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_date()
 	 * @dataProvider data_provider_test_column_date
 	 *
-	 * @param bool $has_product      Whether the review is for a valid product object.
-	 * @param int  $comment_approved The review (comment) approved flag.
+	 * @param bool $has_product   Whether the review is for a valid product object.
+	 * @param int  $approved_flag The review (comment) approved flag.
 	 * @throws ReflectionException If the method does not exist.
 	 */
-	public function test_column_date( $has_product, $comment_approved ) {
+	public function test_column_date( $has_product, $approved_flag ) {
 		$list_table = $this->get_reviews_list_table();
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'column_date' );
 		$method->setAccessible( true );
@@ -248,8 +248,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$review = $this->factory()->comment->create_and_get(
 			[
 				'comment_post_ID'  => $post_id,
-				'comment_date'     => gmdate( 'Y-m-d H:i:s', time() ),
-				'comment_approved' => $comment_approved,
+				'comment_approved' => (string) $approved_flag,
 			]
 		);
 
@@ -265,15 +264,13 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			get_comment_date( 'g:i a', $review ),
 		);
 
-		if ( $post_id && $comment_approved ) {
-			$submitted_on = sprintf(
-				'<a href="%1$s">%2$s</a>',
-				get_comment_link( $review ),
-				$submitted_on
-			);
-		}
+		$this->assertStringContainsString( $submitted_on, $date_output );
 
-		$this->assertSame( $submitted_on, $date_output );
+		if ( $has_product && $approved_flag ) {
+			$this->assertStringContainsString( get_comment_link( $review ), $date_output );
+		} else {
+			$this->assertStringNotContainsString( get_comment_link( $review ), $date_output );
+		}
 	}
 
 	/** @see test_column_date() */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -235,11 +235,11 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_date()
 	 * @dataProvider data_provider_test_column_date
 	 *
-	 * @param bool   $has_product    Whether the review is for a valid product object.
-	 * @param string $comment_status The review (comment) status.
+	 * @param bool $has_product      Whether the review is for a valid product object.
+	 * @param int  $comment_approved The review (comment) approved flag.
 	 * @throws ReflectionException If the method does not exist.
 	 */
-	public function test_column_date( $has_product, $comment_status ) {
+	public function test_column_date( $has_product, $comment_approved ) {
 		$list_table = $this->get_reviews_list_table();
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'column_date' );
 		$method->setAccessible( true );
@@ -248,9 +248,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$review = $this->factory()->comment->create_and_get(
 			[
 				'comment_post_ID'  => $post_id,
-				'comment_date'     => '2022-13-04 13:53:00',
-				'comment_status'   => $comment_status,
-				'comment_approved' => (int) 'approved' === $comment_status,
+				'comment_date'     => gmdate( 'Y-m-d H:i:s', time() ),
+				'comment_approved' => $comment_approved,
 			]
 		);
 
@@ -266,9 +265,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			get_comment_date( 'g:i a', $review ),
 		);
 
-		if ( $post_id && 'approved' === $comment_status ) {
+		if ( $post_id && $comment_approved ) {
 			$submitted_on = sprintf(
-				'<a href="%s">%s</a>',
+				'<a href="%1$s">%2$s</a>',
 				get_comment_link( $review ),
 				$submitted_on
 			);
@@ -280,9 +279,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/** @see test_column_date() */
 	public function data_provider_test_column_date() {
 		return [
-			'No product' => [ false, 'approved' ],
-			'Not approved' => [ true, 'hold' ],
-			'Approved' => [ true, 'approved' ],
+			'No product' => [ false, 1 ],
+			'Not approved' => [ true, 0 ],
+			'Approved' => [ true, 1 ],
 		];
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -230,6 +230,63 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can output the review or reply date column.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_date()
+	 * @dataProvider data_provider_test_column_date
+	 *
+	 * @param bool   $has_product    Whether the review is for a valid product object.
+	 * @param string $comment_status The review (comment) status.
+	 * @throws ReflectionException If the method does not exist.
+	 */
+	public function test_column_date( $has_product, $comment_status ) {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'column_date' );
+		$method->setAccessible( true );
+
+		$post_id = $has_product ? $this->factory()->post->create() : 0;
+		$review = $this->factory()->comment->create_and_get(
+			[
+				'comment_post_ID'  => $post_id,
+				'comment_date'     => '2022-13-04 13:53:00',
+				'comment_status'   => $comment_status,
+				'comment_approved' => (int) 'approved' === $comment_status,
+			]
+		);
+
+		ob_start();
+
+		$method->invokeArgs( $list_table, [ $review ] );
+
+		$date_output = ob_get_clean();
+
+		$submitted_on = sprintf(
+			'%1$s at %2$s',
+			get_comment_date( 'Y/m/d', $review ),
+			get_comment_date( 'g:i a', $review ),
+		);
+
+		if ( $post_id && 'approved' === $comment_status ) {
+			$submitted_on = sprintf(
+				'<a href="%s">%s</a>',
+				get_comment_link( $review ),
+				$submitted_on
+			);
+		}
+
+		$this->assertSame( $submitted_on, $date_output );
+	}
+
+	/** @see test_column_date() */
+	public function data_provider_test_column_date() {
+		return [
+			'No product' => [ false, 'approved' ],
+			'Not approved' => [ true, 'hold' ],
+			'Approved' => [ true, 'approved' ],
+		];
+	}
+
+	/**
 	 * Returns a new instance of the {@see ReviewsListTable} class.
 	 *
 	 * @return ReviewsListTable


### PR DESCRIPTION
## Summary

Adds date/time output for the "Submitted on" column in the product reviews page.

### Story: [MWC 5338](https://jira.godaddy.com/browse/MWC-5338)

## Details

I have formatted the date/time as shown in the pitch and the comments date column for consistency.

Product Reviews Pro has a slight different handling.

## QA

- [x] Code review
- [x] Unit tests pass

### User testing

1. Have multiple products, reviews and replies in your installation
1. Visit the Products > Reviews page
    - [x] Each item in the table should have the date-time output accordingly

## Before merge

- [x] #13 is reviewed & merged