### PR TITLE
Implement the product column in the Reviews page

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -228,12 +228,12 @@ class ReviewsListTable extends WP_List_Table {
 
 			if ( current_user_can( 'edit_product', $product_post->ID ) ) :
 				$post_link  = "<a href='" . esc_url( get_edit_post_link( $product_post->ID ) ) . "' class='comments-edit-item-link'>";
-				$post_link .= esc_html( get_the_title( $product_post->ID ) ) . '</a>';
+				$post_link .= get_the_title( $product_post->ID ) . '</a>';
 			else :
-				$post_link = esc_html( get_the_title( $product_post->ID ) );
+				$post_link = get_the_title( $product_post->ID );
 			endif;
 
-			echo $post_link; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo esc_html( $post_link );
 
 			$post_type_object = get_post_type_object( $product_post->post_type );
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -233,7 +233,7 @@ class ReviewsListTable extends WP_List_Table {
 				$post_link = get_the_title( $product_post->ID );
 			endif;
 
-			echo wp_kses( $post_link, [ 'a' => [ 'href', 'class' ] ] );
+			echo esc_html( $post_link );
 
 			$post_type_object = get_post_type_object( $product_post->post_type );
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -212,6 +212,8 @@ class ReviewsListTable extends WP_List_Table {
 	 * Renders the product column.
 	 *
 	 * @see WP_Comments_List_Table::column_response() for consistency.
+	 *
+	 * @return void
 	 */
 	protected function column_response() {
 		$product_post = get_post();

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -19,7 +19,7 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @var bool
 	 */
-	private $current_user_can_edit = false;
+	private $current_user_can_edit_review = false;
 
 	/**
 	 * Prepares reviews for display.
@@ -55,7 +55,7 @@ class ReviewsListTable extends WP_List_Table {
 		// Sets the post for the product in context.
 		$post = get_post( $comment->comment_post_ID ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
-		$this->current_user_can_edit = current_user_can( 'edit_comment', $comment->comment_ID );
+		$this->current_user_can_edit_review = current_user_can( 'edit_comment', $comment->comment_ID );
 
 		?>
 		<tr id="comment-<?php echo esc_attr( $comment->comment_ID ); ?>" class="<?php echo esc_attr( $the_comment_class ); ?>">
@@ -134,7 +134,7 @@ class ReviewsListTable extends WP_List_Table {
 
 		endif;
 
-		if ( $this->current_user_can_edit ) :
+		if ( $this->current_user_can_edit_review ) :
 
 			if ( ! empty( $item->comment_author_email ) ) :
 				/** This filter is documented in wp-includes/comment-template.php */
@@ -211,10 +211,39 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Renders the product column.
 	 *
-	 * @param object|array $item Review or reply being rendered.
+	 * @see WP_Comments_List_Table::column_response() for consistency.
 	 */
-	protected function column_response( $item ) {
-		// @TODO Implement in MWC-5337 {agibson 2022-04-12}
+	protected function column_response() {
+		$product_post = get_post();
+
+		if ( ! $product_post ) {
+			return;
+		}
+
+		?>
+		<div class="response-links">
+			<?php
+
+			if ( current_user_can( 'edit_post', $product_post->ID ) ) :
+				$post_link  = "<a href='" . get_edit_post_link( $product_post->ID ) . "' class='comments-edit-item-link'>";
+				$post_link .= esc_html( get_the_title( $product_post->ID ) ) . '</a>';
+			else :
+				$post_link = esc_html( get_the_title( $product_post->ID ) );
+			endif;
+
+			echo $post_link; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+			$post_type_object = get_post_type_object( $product_post->post_type );
+
+			?>
+			<a href="<?php echo esc_url( get_permalink( $product_post->ID ) ); ?>" class="comments-view-item-link">
+				<?php echo esc_html( $post_type_object->labels->view_item ); ?>
+			</a>
+			<span class="post-com-count-wrapper post-com-count-<?php echo esc_attr( $product_post->ID ); ?>">
+				<?php $this->comments_bubble( $product_post->ID, get_pending_comments_num( $product_post->ID ) ); ?>
+			</span>
+		</div>
+		<?php
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -233,7 +233,7 @@ class ReviewsListTable extends WP_List_Table {
 				$post_link = get_the_title( $product_post->ID );
 			endif;
 
-			echo esc_html( $post_link );
+			echo wp_kses( $post_link, [ 'a' => [ 'href', 'class' ] ] );
 
 			$post_type_object = get_post_type_object( $product_post->post_type );
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -228,12 +228,12 @@ class ReviewsListTable extends WP_List_Table {
 
 			if ( current_user_can( 'edit_product', $product_post->ID ) ) :
 				$post_link  = "<a href='" . esc_url( get_edit_post_link( $product_post->ID ) ) . "' class='comments-edit-item-link'>";
-				$post_link .= get_the_title( $product_post->ID ) . '</a>';
+				$post_link .= esc_html( get_the_title( $product_post->ID ) ) . '</a>';
 			else :
-				$post_link = get_the_title( $product_post->ID );
+				$post_link = esc_html( get_the_title( $product_post->ID ) );
 			endif;
 
-			echo esc_html( $post_link );
+			echo $post_link; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 			$post_type_object = get_post_type_object( $product_post->post_type );
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -227,7 +227,7 @@ class ReviewsListTable extends WP_List_Table {
 			<?php
 
 			if ( current_user_can( 'edit_product', $product_post->ID ) ) :
-				$post_link  = "<a href='" . get_edit_post_link( $product_post->ID ) . "' class='comments-edit-item-link'>";
+				$post_link  = "<a href='" . esc_url( get_edit_post_link( $product_post->ID ) ) . "' class='comments-edit-item-link'>";
 				$post_link .= esc_html( get_the_title( $product_post->ID ) ) . '</a>';
 			else :
 				$post_link = esc_html( get_the_title( $product_post->ID ) );

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -226,7 +226,7 @@ class ReviewsListTable extends WP_List_Table {
 		<div class="response-links">
 			<?php
 
-			if ( current_user_can( 'edit_post', $product_post->ID ) ) :
+			if ( current_user_can( 'edit_product', $product_post->ID ) ) :
 				$post_link  = "<a href='" . get_edit_post_link( $product_post->ID ) . "' class='comments-edit-item-link'>";
 				$post_link .= esc_html( get_the_title( $product_post->ID ) ) . '</a>';
 			else :

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -230,6 +230,38 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that it will output the product information for the corresponding review column.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_response()
+	 *
+	 * @throws ReflectionException If the method does not exist.
+	 */
+	public function test_column_response() {
+		global $post;
+
+		$product = $this->factory()->post->create_and_get(
+			[
+				'post_title' => 'Test product',
+				'post_type'  => 'product',
+			]
+		);
+
+		$post = $product; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'column_response' );
+		$method->setAccessible( true );
+
+		ob_start();
+
+		$method->invoke( $list_table );
+
+		$product_output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Test product', $product_output );
+	}
+
+	/**
 	 * Returns a new instance of the {@see ReviewsListTable} class.
 	 *
 	 * @return ReviewsListTable


### PR DESCRIPTION
## Summary

Adds date/time output for the "Submitted on" column in the product reviews page.

### Story: [MWC 5338](https://jira.godaddy.com/browse/MWC-5338)

### Depends on #13 

## Details

Based on the mockup provided, I figure the output should be similar to `WP_Comments_List_Table::column_response()` which I have replicated here.

## QA

- [x] Code review
- [ ] Unit tests pass

### User testing

1. Have multiple products, reviews and replies in your installation
1. Visit the Products > Reviews page
    - [x] Each item in the table should have the Product column populated accordingly
    
## Before merge

- [x] #13 is reviewed and merged