### PR TITLE
Make columns sortable

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -157,7 +157,7 @@ class ReviewsListTable extends WP_List_Table {
 
 		$args = [];
 
-		if ( ! in_array( strtolower( $orderby ), $this->get_sortable_columns(), true ) ) {
+		if ( ! in_array( $orderby, $this->get_sortable_columns(), true ) ) {
 			$orderby = 'comment_date_gmt';
 		}
 
@@ -174,7 +174,7 @@ class ReviewsListTable extends WP_List_Table {
 		return wp_parse_args(
 			[
 				'orderby' => $orderby,
-				'order'   => $order,
+				'order'   => strtolower( $order ),
 			],
 			$args
 		);

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -130,6 +130,22 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Returns a list of sortable columns. Key is the column ID and value is which database column
+	 * we perform the sorting on.
+	 *
+	 * @return array
+	 */
+	protected function get_sortable_columns() {
+		return [
+			'author'   => 'comment_author',
+			'response' => 'comment_post_ID',
+			'date'     => 'comment_date',
+			'type'     => 'comment_type',
+			'rating'   => 'meta_value_num',
+		];
+	}
+
+	/**
 	 * Prepares reviews for display.
 	 */
 	public function prepare_items() {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -4,7 +4,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Admin;
 
 use Automattic\WooCommerce\Internal\Admin\ReviewsListTable;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper;
-use Gettext\Generators\Generator;
+use Generator;
 use ReflectionClass;
 use ReflectionException;
 use WC_Helper_Product;
@@ -199,7 +199,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/** @see test_get_sort_arguments */
-	public function provider_get_sort_arguments() : \Generator {
+	public function provider_get_sort_arguments() : Generator {
 		yield 'order by comment_author desc' => [
 			'comment_author',
 			'desc',

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Admin;
 use Automattic\WooCommerce\Internal\Admin\ReviewsListTable;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper;
 use ReflectionClass;
+use ReflectionException;
 use WC_Helper_Product;
 use WC_Unit_Test_Case;
 
@@ -141,5 +142,28 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			'5 stars' => [ '5', '<span aria-label="5 out of 5">&#9733;&#9733;&#9733;&#9733;&#9733;</span>' ],
 			'2.5 stars (rounds down)' => [ '2.5', '<span aria-label="2 out of 5">&#9733;&#9733;&#9734;&#9734;&#9734;</span>' ],
 		];
+	}
+
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_sortable_columns()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_sortable_columns() {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_sortable_columns' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			[
+				'author'   => 'comment_author',
+				'response' => 'comment_post_ID',
+				'date'     => 'comment_date',
+				'type'     => 'comment_type',
+				'rating'   => 'meta_value_num',
+			],
+			$method->invoke( $list_table )
+		);
 	}
 }


### PR DESCRIPTION
## Summary

- Registers the columns that are sortable.
- Updates `prepare_items()` to include the relevant orderby / order arguments in the query.

## Story: [MWC-5340](https://jira.godaddy.com/browse/MWC-5340)

## Details

There is an [open question](https://docs.google.com/document/d/1oMku-8Fqzj6PCSmXh5j3ElE2hsxABp6TQ3ayuQ-Or8Q/edit?disco=AAAAWoMZUZA) about whether we need to support sorting on the columns other than type and rating. I did it anyway since it wasn't much extra effort, and I feel like we should do it. Otherwise it's a regression from the previous page.

I created a new method `get_sort_arguments()` that _just_ returns the arguments for sorting. This method is then called from `prepare_items()`. This separation makes testing easier, as I think it's sufficient just to test which arguments we end up with rather than the actual result of the query.

## QA

### Set up

- Have a couple reviews submitted with different ratings.
- Have at least one or two replies.

### Steps

- Go to Products > Reviews.
    - [x] The following columns can be clicked on for sorting: `Type`, `Author`, `Rating`, `Product`, `Submitted on`
- Click on "Type"
    - [x] If ascending, then replies should appear first.
- Click on "Type" again to change to descending.
    - [x] Reviews should now appear first.
- Click on "Author"
    - [x] If ascending, then reviews should be ordered by author name A-Z
- Click on "Author" again to change to descending.
    - [x] Reviews are ordered by author name Z-A
- Click on "Rating"
    - [x] If ascending, then the lower rating should appear first.
- Click on "Rating" again to change to descending.
    - [x] Higher rating should now appear first.
- Click on "Submitted on"
    - [x] If ascending, then reviews should be ordered by oldest first
- Click on "Submitted on" again to change to descending.
    - [x] Reviews are ordered by date, with newest first