### PR TITLE
Customize the “no items” text

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -39,6 +39,21 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
+	 * The text to display when there are no reviews to display.
+	 *
+	 * @see WP_List_Table::no_items()
+	 */
+	public function no_items() {
+		global $comment_status;
+
+		if ( 'moderated' === $comment_status ) {
+			esc_html_e( 'No reviews awaiting moderation.', 'woocommerce' );
+		} else {
+			esc_html_e( 'No reviews found.', 'woocommerce' );
+		}
+	}
+
+	/**
 	 * Renders the checkbox column.
 	 *
 	 * @param object|array $item Review or reply being rendered.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -157,6 +157,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		ob_start();
 
+		$this->get_reviews_list_table()->no_items();
+
 		$this->assertSame( $expected, ob_get_clean() );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -142,4 +142,28 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			'2.5 stars (rounds down)' => [ '2.5', '<span aria-label="2 out of 5">&#9733;&#9733;&#9734;&#9734;&#9734;</span>' ],
 		];
 	}
+
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::no_items()
+	 * @dataProvider provider_no_items
+	 *
+	 * @param string $status   Filtered status.
+	 * @param string $expected Expected text.
+	 * @return void
+	 */
+	public function test_no_items( string $status, string $expected ) {
+		global $comment_status;
+		$comment_status = $status; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		ob_start();
+
+		$this->assertSame( $expected, ob_get_clean() );
+	}
+
+	/** @see test_no_items */
+	public function provider_no_items() : \Generator {
+		yield 'moderated filter' => [ 'moderated', 'No reviews awaiting moderation.' ];
+		yield 'no filter' => [ '', 'No reviews found.' ];
+		yield 'spam filter' => [ 'spam', 'No reviews found.' ];
+	}
 }


### PR DESCRIPTION
## Summary

Customizes the text that appears when there are no items.

## Story: [MWC-5351](https://jira.godaddy.com/browse/MWC-5351)

## QA

### Set up

- Either delete all your reviews or:
- Update the `prepare_items()` method to set `$this->items = []`

### Steps

- Go to Products > Reviews.
    - [x] Text reads: `No reviews found.`

We can't really properly QA the moderated version, as manually adding the query arg doesn't do anything yet (implemented in https://github.com/godaddy-wordpress/woocommerce/pull/9). So you can either wait until that PR is merged, or [manually copy these lines](https://github.com/godaddy-wordpress/woocommerce/blob/11a13a85c015ded844ffc84a62ac6a3845b9e7c6/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php#L138-L144) into the `prepare_items()` method. Make sure you still have the `$this->items = []` override. Then:

- On Products > Reviews page, add this query arg to the end: `&comment_status=moderated`
    - [x] Text reads: `No reviews awaiting moderation.`