### PR TITLE
Add the status filter links

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -601,9 +601,11 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Renders the available status filters.
+	 * Returns the available status filters.
 	 *
 	 * @see WP_Comments_List_Table::get_views() for consistency.
+	 * @return array An associative array of fully-formed comment status links. Includes 'All', 'Pending',
+	 *               'Approved', 'Spam', and 'Trash'.
 	 */
 	protected function get_views() {
 		global $post_id, $comment_status, $comment_type;

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -87,6 +87,8 @@ class ReviewsListTable extends WP_List_Table {
 		$args = wp_parse_args( $this->get_filter_rating_arguments(), $args );
 		// Handle the review product filter.
 		$args = wp_parse_args( $this->get_filter_product_arguments(), $args );
+		// Include the review status arguments.
+		$args = wp_parse_args( $this->get_status_arguments(), $args );
 
 		$comments = get_comments( $args );
 
@@ -233,6 +235,23 @@ class ReviewsListTable extends WP_List_Table {
 
 		if ( $this->current_product_for_reviews instanceof WC_Product ) {
 			$args['post_id'] = $this->current_product_for_reviews->get_id();
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Gets the `status` argument based on the current request.
+	 *
+	 * @return array
+	 */
+	protected function get_status_arguments() : array {
+		$args = [];
+
+		global $comment_status;
+
+		if ( ! empty( $comment_status ) && 'all' !== $comment_status && array_key_exists( $comment_status, $this->get_status_filters() ) ) {
+			$args['status'] = $this->convert_status_to_query_value( $comment_status );
 		}
 
 		return $args;

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -379,7 +379,7 @@ class ReviewsListTable extends WP_List_Table {
 		return (int) get_comments(
 			[
 				'type__in'  => [ 'review', 'comment' ],
-				'status'    => $this->convert_status_string_to_comment_approved( $status ),
+				'status'    => $this->convert_status_to_query_value( $status ),
 				'post_type' => 'product',
 				'post_id'   => $product_id,
 				'count'     => true,
@@ -393,7 +393,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param string $status Status key from {@see ReviewsListTable::get_status_filters()}.
 	 * @return string
 	 */
-	protected function convert_status_string_to_comment_approved( string $status ) : string {
+	protected function convert_status_to_query_value( string $status ) : string {
 		// These keys exactly match the database column.
 		if ( in_array( $status, [ 'spam', 'trash' ], true ) ) {
 			return $status;

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -344,6 +344,32 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Returns the base URL for a view, excluding the status (that should be appended).
+	 *
+	 * @param string $comment_type Comment type filter.
+	 * @param int    $post_id      Current post ID.
+	 * @return string
+	 */
+	protected function get_view_url( $comment_type, $post_id ) : string {
+		$link = add_query_arg(
+			[
+				'post_type' => 'product',
+				'page'      => Reviews::MENU_SLUG,
+			],
+			admin_url( 'edit.php' )
+		);
+
+		if ( ! empty( $comment_type ) && 'all' !== $comment_type ) {
+			$link = add_query_arg( 'comment_type', urlencode( $comment_type ), $link );
+		}
+		if ( ! empty( $post_id ) ) {
+			$link = add_query_arg( 'p', absint( $post_id ), $link );
+		}
+
+		return $link;
+	}
+
+	/**
 	 * Renders the available status filters.
 	 *
 	 * @see WP_Comments_List_Table::get_views() for consistency.
@@ -359,20 +385,7 @@ class ReviewsListTable extends WP_List_Table {
 			unset( $status_labels['trash'] );
 		}
 
-		$link = add_query_arg(
-			[
-				'post_type' => 'product',
-				'page'      => Reviews::MENU_SLUG,
-			],
-			admin_url( 'edit.php' )
-		);
-
-		if ( ! empty( $comment_type ) && 'all' !== $comment_type ) {
-			$link = add_query_arg( 'comment_type', urlencode( $comment_type ), $link );
-		}
-		if ( ! empty( $post_id ) ) {
-			$link = add_query_arg( 'p', absint( $post_id ), $link );
-		}
+		$link = $this->get_view_url( $comment_type, $post_id );
 
 		foreach ( $status_labels as $status => $label ) {
 			$current_link_attributes = '';

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -305,11 +305,41 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	protected function get_status_filters() : array {
 		return [
-			'all'       => _x( 'All', 'product reviews', 'woocommerce' ),
-			'moderated' => _x( 'Pending', 'product reviews', 'woocommerce' ),
-			'approved'  => _x( 'Approved', 'product reviews', 'woocommerce' ),
-			'spam'      => _x( 'Spam', 'product reviews', 'woocommerce' ),
-			'trash'     => _x( 'Trash', 'product reviews', 'woocommerce' ),
+			/* translators: %s: Number of reviews. */
+			'all'       => _nx_noop(
+				'All <span class="count">(%s)</span>',
+				'All <span class="count">(%s)</span>',
+				'product reviews',
+				'woocommerce'
+			),
+			/* translators: %s: Number of reviews. */
+			'moderated' => _nx_noop(
+				'Pending <span class="count">(%s)</span>',
+				'Pending <span class="count">(%s)</span>',
+				'product reviews',
+				'woocommerce'
+			),
+			/* translators: %s: Number of reviews. */
+			'approved'  => _nx_noop(
+				'Approved <span class="count">(%s)</span>',
+				'Approved <span class="count">(%s)</span>',
+				'product reviews',
+				'woocommerce'
+			),
+			/* translators: %s: Number of reviews. */
+			'spam'      => _nx_noop(
+				'Spam <span class="count">(%s)</span>',
+				'Spam <span class="count">(%s)</span>',
+				'product reviews',
+				'woocommerce'
+			),
+			/* translators: %s: Number of reviews. */
+			'trash'     => _nx_noop(
+				'Trash <span class="count">(%s)</span>',
+				'Trash <span class="count">(%s)</span>',
+				'product reviews',
+				'woocommerce'
+			),
 		];
 	}
 
@@ -323,10 +353,10 @@ class ReviewsListTable extends WP_List_Table {
 
 		$status_links = [];
 
-		$status_link_labels = $this->get_status_filters();
+		$status_labels = $this->get_status_filters();
 
 		if ( ! EMPTY_TRASH_DAYS ) {
-			unset( $status_link_labels['trash'] );
+			unset( $status_labels['trash'] );
 		}
 
 		$link = add_query_arg(
@@ -340,27 +370,28 @@ class ReviewsListTable extends WP_List_Table {
 		if ( ! empty( $comment_type ) && 'all' !== $comment_type ) {
 			$link = add_query_arg( 'comment_type', urlencode( $comment_type ), $link );
 		}
+		if ( ! empty( $post_id ) ) {
+			$link = add_query_arg( 'p', absint( $post_id ), $link );
+		}
 
-		foreach ( $status_link_labels as $status => $label ) {
+		foreach ( $status_labels as $status => $label ) {
 			$current_link_attributes = '';
 
 			if ( $status === $comment_status ) {
 				$current_link_attributes = ' class="current" aria-current="page"';
 			}
 
-			$link = add_query_arg( 'comment_status', $status, $link );
+			$link = add_query_arg( 'comment_status', urlencode( $status ), $link );
 
-			if ( $post_id ) {
-				$link = add_query_arg( 'p', absint( $post_id ), $link );
-			}
+			$number_reviews_for_status = $this->get_review_count( $status, (int) $post_id );
 
 			$count_html = sprintf(
-				'<span class="count">(<span class="%s-count">%s</span>)</span>',
+				'<span class="%s-count">%s</span>',
 				( 'moderated' === $status ) ? 'pending' : $status,
-				number_format_i18n( $this->get_review_count( $status, (int) $post_id ) )
+				number_format_i18n( $number_reviews_for_status )
 			);
 
-			$status_links[ $status ] = '<a href="' . esc_url( $link ) . '"' . $current_link_attributes . '>' . $label . ' ' . $count_html . '</a>';
+			$status_links[ $status ] = '<a href="' . esc_url( $link ) . '"' . $current_link_attributes . '>' . sprintf( translate_nooped_plural( $label, $number_reviews_for_status ), $count_html ) . '</a>';
 		}
 
 		/** This filter is documented in wp-admin/includes/class-wp-comments-list-table.php */

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -394,15 +394,16 @@ class ReviewsListTable extends WP_List_Table {
 	 * @return string
 	 */
 	protected function convert_status_string_to_comment_approved( string $status ) : string {
+		// These keys exactly match the database column.
+		if ( in_array( $status, [ 'spam', 'trash' ], true ) ) {
+			return $status;
+		}
+
 		switch ( $status ) {
 			case 'moderated':
 				return '0';
 			case 'approved':
 				return '1';
-			case 'spam':
-				return 'spam';
-			case 'trash':
-				return 'trash';
 			default:
 				return 'all';
 		}

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -581,7 +581,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param int    $post_id      Current post ID.
 	 * @return string
 	 */
-	protected function get_view_url( $comment_type, $post_id ) : string {
+	protected function get_view_url( string $comment_type, int $post_id ) : string {
 		$link = add_query_arg(
 			[
 				'post_type' => 'product',
@@ -616,7 +616,7 @@ class ReviewsListTable extends WP_List_Table {
 			unset( $status_labels['trash'] );
 		}
 
-		$link = $this->get_view_url( $comment_type, $post_id );
+		$link = $this->get_view_url( (string) $comment_type, (int) $post_id );
 
 		foreach ( $status_labels as $status => $label ) {
 			$current_link_attributes = '';

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -305,11 +305,11 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	protected function get_status_filters() : array {
 		return [
-			'all' => _x( 'All', 'product reviews', 'woocommerce' ),
+			'all'       => _x( 'All', 'product reviews', 'woocommerce' ),
 			'moderated' => _x( 'Pending', 'product reviews', 'woocommerce' ),
-			'approved' => _x( 'Approved', 'product reviews', 'woocommerce' ),
-			'spam' => _x( 'Spam', 'product reviews', 'woocommerce' ),
-			'trash' => _x( 'Trash', 'product reviews', 'woocommerce' ),
+			'approved'  => _x( 'Approved', 'product reviews', 'woocommerce' ),
+			'spam'      => _x( 'Spam', 'product reviews', 'woocommerce' ),
+			'trash'     => _x( 'Trash', 'product reviews', 'woocommerce' ),
 		];
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -834,8 +834,7 @@ class ReviewsListTable extends WP_List_Table {
 			$status_links[ $status ] = '<a href="' . esc_url( $link ) . '"' . $current_link_attributes . '>' . sprintf( translate_nooped_plural( $label, $number_reviews_for_status ), $count_html ) . '</a>';
 		}
 
-		/** This filter is documented in wp-admin/includes/class-wp-comments-list-table.php */
-		return apply_filters( 'comment_status_links', $status_links );
+		return $status_links;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -368,6 +368,29 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_status_filters()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_status_filters() {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_status_filters' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			[
+				'all'       => 'All',
+				'moderated' => 'Pending',
+				'approved'  => 'Approved',
+				'spam'      => 'Spam',
+				'trash'     => 'Trash',
+			],
+			$method->invoke( $list_table )
+		);
+	}
+
+	/**
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::convert_status_to_query_value()
 	 * @dataProvider provider_convert_status_string_to_comment_approved
 	 *

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1600,4 +1600,34 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_status_arguments()
+	 * @dataProvider provider_get_status_arguments
+	 *
+	 * @param string $status        Current status for the request.
+	 * @param array  $expected_args Expected result of the method.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_status_arguments( string $status, array $expected_args ) {
+		global $comment_status;
+		$comment_status = $status; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_status_arguments' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected_args, $method->invoke( $list_table ) );
+	}
+
+	/** @see test_get_status_arguments */
+	public function provider_get_status_arguments() : Generator {
+		yield 'all statuses' => [ 'all', [] ];
+		yield 'moderated status' => [ 'moderated', [ 'status' => '0' ] ];
+		yield 'approved status' => [ 'approved', [ 'status' => '1' ] ];
+		yield 'spam status' => [ 'spam', [ 'status' => 'spam' ] ];
+		yield 'trash status' => [ 'trash', [ 'status' => 'trash' ] ];
+		yield 'invalid status' => [ 'not-valid', [] ];
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -380,11 +380,51 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$this->assertSame(
 			[
-				'all'       => 'All',
-				'moderated' => 'Pending',
-				'approved'  => 'Approved',
-				'spam'      => 'Spam',
-				'trash'     => 'Trash',
+				'all'       => [
+					'All <span class="count">(%s)</span>',
+					'All <span class="count">(%s)</span>',
+					'product reviews',
+					'singular' => 'All <span class="count">(%s)</span>',
+					'plural'   => 'All <span class="count">(%s)</span>',
+					'context'  => 'product reviews',
+					'domain'   => 'woocommerce',
+				],
+				'moderated' => [
+					'Pending <span class="count">(%s)</span>',
+					'Pending <span class="count">(%s)</span>',
+					'product reviews',
+					'singular' => 'Pending <span class="count">(%s)</span>',
+					'plural'   => 'Pending <span class="count">(%s)</span>',
+					'context'  => 'product reviews',
+					'domain'   => 'woocommerce',
+				],
+				'approved'  => [
+					'Approved <span class="count">(%s)</span>',
+					'Approved <span class="count">(%s)</span>',
+					'product reviews',
+					'singular' => 'Approved <span class="count">(%s)</span>',
+					'plural'   => 'Approved <span class="count">(%s)</span>',
+					'context'  => 'product reviews',
+					'domain'   => 'woocommerce',
+				],
+				'spam'      => [
+					'Spam <span class="count">(%s)</span>',
+					'Spam <span class="count">(%s)</span>',
+					'product reviews',
+					'singular' => 'Spam <span class="count">(%s)</span>',
+					'plural'   => 'Spam <span class="count">(%s)</span>',
+					'context'  => 'product reviews',
+					'domain'   => 'woocommerce',
+				],
+				'trash'     => [
+					'Trash <span class="count">(%s)</span>',
+					'Trash <span class="count">(%s)</span>',
+					'product reviews',
+					'singular' => 'Trash <span class="count">(%s)</span>',
+					'plural'   => 'Trash <span class="count">(%s)</span>',
+					'context'  => 'product reviews',
+					'domain'   => 'woocommerce',
+				],
 			],
 			$method->invoke( $list_table )
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -431,6 +431,54 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_view_url()
+	 * @dataProvider provider_get_view_url
+	 *
+	 * @param string $comment_type Current type filter.
+	 * @param int    $post_id      Current post ID filter.
+	 * @param string $expected     Expected URL from the method.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_view_url( string $comment_type, int $post_id, string $expected ) {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_view_url' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			$expected,
+			$method->invoke( $list_table, $comment_type, $post_id )
+		);
+	}
+
+	/** @see test_get_view_url */
+	public function provider_get_view_url() : Generator {
+		yield 'empty type, empty post ID' => [
+			'comment_type' => '',
+			'post_id'      => 0,
+			'expected'     => 'http://example.org/wp-admin/edit.php?post_type=product&page=product-reviews',
+		];
+
+		yield 'review type, empty post ID' => [
+			'comment_type' => 'review',
+			'post_id'      => 0,
+			'expected'     => 'http://example.org/wp-admin/edit.php?post_type=product&page=product-reviews&comment_type=review',
+		];
+
+		yield 'reply type, with post ID' => [
+			'comment_type' => 'reply',
+			'post_id'      => 123,
+			'expected'     => 'http://example.org/wp-admin/edit.php?post_type=product&page=product-reviews&comment_type=reply&p=123',
+		];
+
+		yield 'all type, with post ID' => [
+			'comment_type' => 'all',
+			'post_id'      => 123,
+			'expected'     => 'http://example.org/wp-admin/edit.php?post_type=product&page=product-reviews&p=123',
+		];
+	}
+
+	/**
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::convert_status_to_query_value()
 	 * @dataProvider provider_convert_status_string_to_comment_approved
 	 *

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -367,4 +367,31 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		return ! empty( $reviews ) ? current( $reviews ) : null;
 	}
 
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::convert_status_to_query_value()
+	 * @dataProvider provider_convert_status_string_to_comment_approved
+	 *
+	 * @param string $status              Status to pass in to the method.
+	 * @param string $expected_conversion Expected result.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_convert_status_string_to_comment_approved( string $status, string $expected_conversion ) {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'convert_status_to_query_value' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected_conversion, $method->invoke( $list_table, $status ) );
+	}
+
+	/** @see test_convert_status_string_to_comment_approved */
+	public function provider_convert_status_string_to_comment_approved() : Generator {
+		yield 'spam' => [ 'spam', 'spam' ];
+		yield 'trash' => [ 'trash', 'trash' ];
+		yield 'moderated' => [ 'moderated', '0' ];
+		yield 'approved' => [ 'approved', '1' ];
+		yield 'all' => [ 'all', 'all' ];
+		yield 'empty string' => [ '', 'all' ];
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1214,4 +1214,30 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$this->assertSame( 5, $method->invoke( $list_table, 'all', $product_id ) );
 	}
 
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_views()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_views() {
+		global $comment_status;
+		$comment_status = 'all'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_views' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			[
+				'all'       => '<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews&#038;comment_status=all" class="current" aria-current="page">All <span class="count">(<span class="all-count">0</span>)</span></a>',
+				'moderated' => '<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews&#038;comment_status=moderated">Pending <span class="count">(<span class="pending-count">0</span>)</span></a>',
+				'approved'  => '<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews&#038;comment_status=approved">Approved <span class="count">(<span class="approved-count">0</span>)</span></a>',
+				'spam'      => '<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews&#038;comment_status=spam">Spam <span class="count">(<span class="spam-count">0</span>)</span></a>',
+				'trash'     => '<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews&#038;comment_status=trash">Trash <span class="count">(<span class="trash-count">0</span>)</span></a>',
+			],
+			$method->invoke( $list_table )
+		);
+	}
+
 }


### PR DESCRIPTION
## Overview

This adds the different status filter links at the top of the Reviews page, with the appropriate number for each status.

## Story: [MWC-5341](https://jira.godaddy.com/browse/MWC-5341)

## QA

1. Go to Products > Reviews
    - [x] You see 5 links at the top: All, Pending, Approved, Spam, and Trash
    - [x] "All" is currently in bold.
    - [x] Each status shows the correct count for the number of reviews you have. (Note: "All" does NOT include "Spam" or "Trash"; it's basically a combination of "Pending" + "Approved".)
2. Click through each status.
    - [x] The `comment_status` query arg in the URL changes to the correct value.
    - [x] The status you clicked becomes bold.
    - [x] The results in the table update accordingly.

~**Note: It's normal that the actual results in the table do not change, as that is not part of this story.**~ **EDIT:** Results will now change.