### PR TITLE
Add the container for the dropdown filters

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -25,14 +25,14 @@ class Reviews {
 	/**
 	 * Reviews page hook name.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	protected $reviews_page_hook;
 
 	/**
 	 * Reviews list table instance.
 	 *
-	 * @var ReviewsListTable
+	 * @var ReviewsListTable|null
 	 */
 	protected $reviews_list_table;
 
@@ -57,7 +57,7 @@ class Reviews {
 	}
 
 	/**
-	 * Registers the Reviews submenu page.
+	 * Registers the Product Reviews submenu page.
 	 *
 	 * @return void
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -8,6 +8,7 @@ namespace Automattic\WooCommerce\Internal\Admin;
 use WP_Comment;
 use WP_Comments_List_Table;
 use WP_List_Table;
+use WP_Post;
 
 /**
  * Handles the Product Reviews page.
@@ -41,6 +42,8 @@ class ReviewsListTable extends WP_List_Table {
 
 	/**
 	 * Sets the `$comment_status` global based on the current request.
+	 *
+	 * @global string $comment_status
 	 *
 	 * @return void
 	 */
@@ -118,6 +121,9 @@ class ReviewsListTable extends WP_List_Table {
 
 	/**
 	 * Render a single row HTML.
+	 *
+	 * @global WP_Post $post
+	 * @global WP_Comment $comment
 	 *
 	 * @param WP_Comment $item Review or reply being rendered.
 	 * @return void
@@ -220,6 +226,8 @@ class ReviewsListTable extends WP_List_Table {
 
 	/**
 	 * The text to display when there are no reviews to display.
+	 *
+	 * @global string $comment_status
 	 *
 	 * @see WP_List_Table::no_items()
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -493,4 +493,55 @@ class ReviewsListTable extends WP_List_Table {
 		// @TODO Implement in MWC-5362 {agibson 2022-04-12}
 	}
 
+	/**
+	 * Renders the extra controls to be displayed between bulk actions and pagination.
+	 *
+	 * @global string $comment_status
+	 * @global string $comment_type
+	 *
+	 * @param string $which Unused.
+	 */
+	protected function extra_tablenav( $which ) {
+		global $comment_status, $comment_type;
+		static $has_items;
+
+		if ( ! isset( $has_items ) ) {
+			$has_items = $this->has_items();
+		}
+
+		echo '<div class="alignleft actions">';
+
+		if ( 'top' === $which ) {
+			ob_start();
+
+			$this->comment_type_dropdown( $comment_type );
+
+			$output = ob_get_clean();
+
+			if ( ! empty( $output ) && $this->has_items() ) {
+				echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				submit_button( __( 'Filter', 'woocommerce' ), '', 'filter_action', false, [ 'id' => 'post-query-submit' ] );
+			}
+		}
+
+		if ( ( 'spam' === $comment_status || 'trash' === $comment_status ) && $has_items
+			&& current_user_can( 'moderate_comments' )
+		) {
+			wp_nonce_field( 'bulk-destroy', '_destroy_nonce' );
+			$title = ( 'spam' === $comment_status ) ? esc_attr__( 'Empty Spam', 'woocommerce' ) : esc_attr__( 'Empty Trash', 'woocommerce' );
+			submit_button( $title, 'apply', 'delete_all', false );
+		}
+
+		echo '</div>';
+	}
+
+	/**
+	 * Displays a comment type drop-down for filtering on the Comments list table.
+	 *
+	 * @param string $comment_type The current comment type slug.
+	 */
+	protected function comment_type_dropdown( $comment_type ) {
+		// @TODO Implement the Type filter - MWC-5343 {dmagalhaes 2022-04-13}
+		echo '&nbsp;';
+	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -22,6 +22,24 @@ class ReviewsListTable extends WP_List_Table {
 	private $current_user_can_edit_review = false;
 
 	/**
+	 * Memoization flag to determine if the current user can moderate reviews.
+	 *
+	 * @var bool
+	 */
+	private $current_user_can_moderate_reviews;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array|string $args Array or string of arguments.
+	 */
+	public function __construct( $args = [] ) {
+		parent::__construct( $args );
+
+		$this->current_user_can_moderate_reviews = current_user_can( 'moderate_comments' );
+	}
+
+	/**
 	 * Sets the `$comment_status` global based on the current request.
 	 *
 	 * @return void
@@ -499,15 +517,10 @@ class ReviewsListTable extends WP_List_Table {
 	 * @global string $comment_status
 	 * @global string $comment_type
 	 *
-	 * @param string $which Unused.
+	 * @param string $which Position (top or bottom).
 	 */
 	protected function extra_tablenav( $which ) {
 		global $comment_status, $comment_type;
-		static $has_items;
-
-		if ( ! isset( $has_items ) ) {
-			$has_items = $this->has_items();
-		}
 
 		echo '<div class="alignleft actions">';
 
@@ -524,9 +537,7 @@ class ReviewsListTable extends WP_List_Table {
 			}
 		}
 
-		if ( ( 'spam' === $comment_status || 'trash' === $comment_status ) && $has_items
-			&& current_user_can( 'moderate_comments' )
-		) {
+		if ( ( 'spam' === $comment_status || 'trash' === $comment_status ) && $this->has_items() && $this->current_user_can_moderate_reviews ) {
 			wp_nonce_field( 'bulk-destroy', '_destroy_nonce' );
 			$title = ( 'spam' === $comment_status ) ? esc_attr__( 'Empty Spam', 'woocommerce' ) : esc_attr__( 'Empty Trash', 'woocommerce' );
 			submit_button( $title, 'apply', 'delete_all', false );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -711,4 +711,220 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		yield 'spam filter' => [ 'spam', 'No reviews found.' ];
 	}
 
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::extra_tablenav()
+	 * @dataProvider provider_test_extra_tablenav()
+	 *
+	 * @param string   $position                  Position (top or bottom).
+	 * @param bool     $has_items                 Whether the table has items.
+	 * @param bool     $current_user_can_moderate Whether the current user has the capability to moderate comments.
+	 * @param string   $status                    Filtered status.
+	 * @param string   $expected_start            Output should start with this string.
+	 * @param string[] $expected_elements         Output should contain these elements.
+	 * @param string   $expected_end              Output should end with this string.
+	 * @param string[] $not_expected_elements     Output should not contain these elements.
+	 */
+	public function test_extra_tablenav( string $position, bool $has_items, bool $current_user_can_moderate, string $status, string $expected_start, array $expected_elements, string $expected_end, array $not_expected_elements ) {
+		global $comment_status;
+		$comment_status = $status; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'extra_tablenav' );
+		$method->setAccessible( true );
+
+		$review = $this->factory()->comment->create_and_get();
+		$property = ( new ReflectionClass( $list_table ) )->getProperty( 'items' );
+		$property->setAccessible( true );
+		$property->setValue( $list_table, $has_items ? [ $review ] : [] );
+
+		$property = ( new ReflectionClass( $list_table ) )->getProperty( 'current_user_can_moderate_reviews' );
+		$property->setAccessible( true );
+		$property->setValue( $list_table, $current_user_can_moderate );
+
+		ob_start();
+
+		$method->invokeArgs( $list_table, [ $position ] );
+
+		$output = ob_get_clean();
+
+		$this->assertStringStartsWith( $expected_start, $output );
+
+		foreach ( $expected_elements as $element ) {
+			$this->assertStringContainsString( $element, $output );
+		}
+
+		foreach ( $not_expected_elements as $element ) {
+			$this->assertStringNotContainsString( $element, $output );
+		}
+
+		$this->assertStringEndsWith( $expected_end, $output );
+	}
+
+	/** @see test_extra_tablenav() */
+	public function provider_test_extra_tablenav() : Generator {
+		yield 'no items top' => [
+			'position' => 'top',
+			'has_items' => false,
+			'current_user_can_moderate' => true,
+			'status' => '',
+			'expected_start' => '<div class="alignleft actions">',
+			'expected_elements' => [],
+			'expected_end' => '</div>',
+			'not_expected_elements' => [
+				'<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter"',
+				'<input type="hidden" id="_destroy_nonce" name="_destroy_nonce"',
+				'<input type="hidden" name="_wp_http_referer"',
+				'<input type="submit" name="delete_all" id="delete_all" class="button apply"',
+			],
+		];
+
+		yield 'no items bottom' => [
+			'position' => 'bottom',
+			'has_items' => false,
+			'current_user_can_moderate' => true,
+			'status' => '',
+			'expected_start' => '<div class="alignleft actions">',
+			'expected_elements' => [],
+			'expected_end' => '</div>',
+			'not_expected_elements' => [
+				'<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter"',
+				'<input type="hidden" id="_destroy_nonce" name="_destroy_nonce"',
+				'<input type="hidden" name="_wp_http_referer"',
+				'<input type="submit" name="delete_all" id="delete_all" class="button apply"',
+			],
+		];
+
+		yield 'unfiltered with items top' => [
+			'position' => 'top',
+			'has_items' => true,
+			'current_user_can_moderate' => true,
+			'status' => '',
+			'expected_start' => '<div class="alignleft actions">',
+			'expected_elements' => [
+				'<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter"',
+			],
+			'expected_end' => '</div>',
+			'not_expected_elements' => [
+				'<input type="hidden" id="_destroy_nonce" name="_destroy_nonce"',
+				'<input type="hidden" name="_wp_http_referer"',
+				'<input type="submit" name="delete_all" id="delete_all" class="button apply"',
+			],
+		];
+
+		yield 'unfiltered with items bottom' => [
+			'position' => 'bottom',
+			'has_items' => true,
+			'current_user_can_moderate' => true,
+			'status' => '',
+			'expected_start' => '<div class="alignleft actions">',
+			'expected_elements' => [],
+			'expected_end' => '</div>',
+			'not_expected_elements' => [
+				'<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter"',
+				'<input type="hidden" id="_destroy_nonce" name="_destroy_nonce"',
+				'<input type="hidden" name="_wp_http_referer"',
+				'<input type="submit" name="delete_all" id="delete_all" class="button apply"',
+			],
+		];
+
+		yield 'spam with items top' => [
+			'position' => 'top',
+			'has_items' => true,
+			'current_user_can_moderate' => true,
+			'status' => 'spam',
+			'expected_start' => '<div class="alignleft actions">',
+			'expected_elements' => [
+				'<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter"',
+				'<input type="hidden" id="_destroy_nonce" name="_destroy_nonce"',
+				'<input type="hidden" name="_wp_http_referer"',
+				'<input type="submit" name="delete_all" id="delete_all" class="button apply" value="Empty Spam"',
+			],
+			'expected_end' => '</div>',
+			'not_expected_elements' => [],
+		];
+
+		yield 'spam with items bottom' => [
+			'position' => 'bottom',
+			'has_items' => true,
+			'current_user_can_moderate' => true,
+			'status' => 'spam',
+			'expected_start' => '<div class="alignleft actions">',
+			'expected_elements' => [
+				'<input type="hidden" id="_destroy_nonce" name="_destroy_nonce"',
+				'<input type="hidden" name="_wp_http_referer"',
+				'<input type="submit" name="delete_all" id="delete_all" class="button apply" value="Empty Spam"',
+			],
+			'expected_end' => '</div>',
+			'not_expected_elements' => [
+				'<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter"',
+			],
+		];
+
+		yield 'trash with items top' => [
+			'position' => 'top',
+			'has_items' => true,
+			'current_user_can_moderate' => true,
+			'status' => 'trash',
+			'expected_start' => '<div class="alignleft actions">',
+			'expected_elements' => [
+				'<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter"',
+				'<input type="hidden" id="_destroy_nonce" name="_destroy_nonce"',
+				'<input type="hidden" name="_wp_http_referer"',
+				'<input type="submit" name="delete_all" id="delete_all" class="button apply" value="Empty Trash"',
+			],
+			'expected_end' => '</div>',
+			'not_expected_elements' => [],
+		];
+
+		yield 'trash with items bottom' => [
+			'position' => 'bottom',
+			'has_items' => true,
+			'current_user_can_moderate' => true,
+			'status' => 'trash',
+			'expected_start' => '<div class="alignleft actions">',
+			'expected_elements' => [
+				'<input type="hidden" id="_destroy_nonce" name="_destroy_nonce"',
+				'<input type="hidden" name="_wp_http_referer"',
+				'<input type="submit" name="delete_all" id="delete_all" class="button apply" value="Empty Trash"',
+			],
+			'expected_end' => '</div>',
+			'not_expected_elements' => [
+				'<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter"',
+			],
+		];
+
+		yield 'trash with items top and user cannot moderate' => [
+			'position' => 'top',
+			'has_items' => true,
+			'current_user_can_moderate' => false,
+			'status' => 'trash',
+			'expected_start' => '<div class="alignleft actions">',
+			'expected_elements' => [
+				'<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter"',
+			],
+			'expected_end' => '</div>',
+			'not_expected_elements' => [
+				'<input type="hidden" id="_destroy_nonce" name="_destroy_nonce"',
+				'<input type="hidden" name="_wp_http_referer"',
+				'<input type="submit" name="delete_all" id="delete_all" class="button apply"',
+			],
+		];
+
+		yield 'trash with items bottom and user cannot moderate' => [
+			'position' => 'bottom',
+			'has_items' => true,
+			'current_user_can_moderate' => false,
+			'status' => 'trash',
+			'expected_start' => '<div class="alignleft actions">',
+			'expected_elements' => [],
+			'expected_end' => '</div>',
+			'not_expected_elements' => [
+				'<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter"',
+				'<input type="hidden" id="_destroy_nonce" name="_destroy_nonce"',
+				'<input type="hidden" name="_wp_http_referer"',
+				'<input type="submit" name="delete_all" id="delete_all" class="button apply"',
+			],
+		];
+	}
+
 }


### PR DESCRIPTION
## Summary

Renders the extra controls (container for the filters and Empty Spam/Trash buttons).

## Story: [MWC-5342](https://jira.godaddy.com/browse/MWC-5342)

## QA

### Setup

- Have at least one product review 

### Steps

1. Navigate to Products > Reviews
    - [x] The Filter button is displayed next to the bulk actions at the top
1. Update the URL adding `&comment_status=spam`
    - [x] The Filter button is displayed next to the bulk actions at the top
    - [x] The Empty Spam button is displayed next to the Filter button at the top
    - [x] The Empty Spam button is displayed next to the bulk actions at the bottom
1. Update the URL adding `&comment_status=trash`
    - [x] The Filter button is displayed next to the bulk actions at the top
    - [x] The Empty Trash button is displayed next to the Filter button at the top
    - [x] The Empty Trash button is displayed next to the bulk actions at the bottom