### PR TITLE
Add notice on the Comments list page

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -169,11 +169,19 @@ class WC_Admin_Notices {
 				wp_die( esc_html__( 'Action failed. Please refresh the page and retry.', 'woocommerce' ) );
 			}
 
-			if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			$hide_notice = sanitize_text_field( wp_unslash( $_GET['wc-hide-notice'] ) ); // WPCS: input var ok, CSRF ok.
+
+			/**
+			 * Filter the capability required to dismiss a given notice.
+			 *
+			 * @param string $default_capability The default required capability.
+			 * @param string $hide_notice The notice ID.
+			 */
+			$required_capability = apply_filters( 'woocommerce_dismiss_notice_capability', 'manage_woocommerce', $hide_notice );
+
+			if ( ! current_user_can( $required_capability ) ) {
 				wp_die( esc_html__( 'You don&#8217;t have permission to do this.', 'woocommerce' ) );
 			}
-
-			$hide_notice = sanitize_text_field( wp_unslash( $_GET['wc-hide-notice'] ) ); // WPCS: input var ok, CSRF ok.
 
 			self::hide_notice( $hide_notice );
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -169,28 +169,28 @@ class WC_Admin_Notices {
 				wp_die( esc_html__( 'Action failed. Please refresh the page and retry.', 'woocommerce' ) );
 			}
 
-			$hide_notice = sanitize_text_field( wp_unslash( $_GET['wc-hide-notice'] ) ); // WPCS: input var ok, CSRF ok.
+			$notice_name = sanitize_text_field( wp_unslash( $_GET['wc-hide-notice'] ) ); // WPCS: input var ok, CSRF ok.
 
 			/**
 			 * Filter the capability required to dismiss a given notice.
 			 *
 			 * @param string $default_capability The default required capability.
-			 * @param string $hide_notice The notice ID.
+			 * @param string $notice_name The notice name.
 			 */
-			$required_capability = apply_filters( 'woocommerce_dismiss_notice_capability', 'manage_woocommerce', $hide_notice );
+			$required_capability = apply_filters( 'woocommerce_dismiss_notice_capability', 'manage_woocommerce', $notice_name );
 
 			if ( ! current_user_can( $required_capability ) ) {
 				wp_die( esc_html__( 'You don&#8217;t have permission to do this.', 'woocommerce' ) );
 			}
 
-			self::hide_notice( $hide_notice );
+			self::hide_notice( $notice_name );
 		}
 	}
 
 	/**
 	 * Hide a single notice.
 	 *
-	 * @param $name Notice name.
+	 * @param string $name Notice name.
 	 */
 	private static function hide_notice( $name ) {
 		self::remove_notice( $name );
@@ -500,9 +500,9 @@ class WC_Admin_Notices {
 	 */
 	public static function download_directories_sync_complete() {
 		$notice_dismissed = apply_filters(
-				'woocommerce_hide_download_directories_sync_complete',
-				get_user_meta( get_current_user_id(), 'download_directories_sync_complete', true )
-			);
+			'woocommerce_hide_download_directories_sync_complete',
+			get_user_meta( get_current_user_id(), 'download_directories_sync_complete', true )
+		);
 
 		if ( $notice_dismissed ) {
 			self::remove_notice( 'download_directories_sync_complete' );

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -64,9 +64,7 @@ class ReviewsCommentsOverrides {
 			<p><?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?></p>
 			<p class="submit">
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a>
-				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button">
-					<?php esc_html_e( 'Dismiss', 'woocommerce' ); ?>
-				</a>
+				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
 			</p>
 		</div>
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -9,6 +9,8 @@ use WP_Comment_Query;
  */
 class ReviewsCommentsOverrides {
 
+	const REVIEWS_MOVED_NOTICE_ID = 'product_reviews_moved';
+
 	/**
 	 * Class instance.
 	 *
@@ -36,6 +38,11 @@ class ReviewsCommentsOverrides {
 			return;
 		}
 
+		// Do not display if the current user has dismissed this notice.
+		if ( get_user_meta( get_current_user_id(), 'dismissed_' . static::REVIEWS_MOVED_NOTICE_ID . '_notice', true ) ) {
+			return;
+		}
+
 		$this->display_reviews_moved_notice();
 	}
 
@@ -43,15 +50,10 @@ class ReviewsCommentsOverrides {
 	 * Renders an admin notice informing the user that reviews were moved to a new page.
 	 */
 	protected function display_reviews_moved_notice() {
-		$notice_name = 'product_reviews_moved';
-		if ( get_user_meta( get_current_user_id(), 'dismissed_' . $notice_name . '_notice', true ) ) {
-			return;
-		}
-
 		$dismiss_url = wp_nonce_url(
 			add_query_arg(
 				[
-					'wc-hide-notice' => urlencode( $notice_name ),
+					'wc-hide-notice' => urlencode( static::REVIEWS_MOVED_NOTICE_ID ),
 				]
 			),
 			'woocommerce_hide_notices_nonce',

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -43,7 +43,27 @@ class ReviewsCommentsOverrides {
 	 * Renders an admin notice informing the user that reviews were moved to a new page.
 	 */
 	public function display_reviews_moved_notice() {
+		?>
 
+		<div class="notice notice-info is-dismissible">
+			<p>
+				<strong><?php esc_html_e( 'Product reviews have moved!', 'woocommerce' ); ?></strong>
+			</p>
+			<p>
+				<?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?>
+			</p>
+			<p class="submit">
+				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary">
+					<?php esc_html_e( 'Visit new location', 'woocommerce' ); ?>
+				</a>
+				<?php // @TODO: update the URL ?>
+				<a href="#" class="button-secondary">
+					<?php esc_html_e( 'Learn more about product reviews', 'woocommerce' ); ?>
+				</a>
+			</p>
+		</div>
+
+		<?php
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -57,12 +57,12 @@ class ReviewsCommentsOverrides {
 	 */
 	protected function should_display_reviews_moved_notice() : bool {
 		// Do not display if the user does not have the capability  to see the new page.
-		if ( ! current_user_can( Reviews::get_capability() ) ) {
+		if ( ! WC()->call_function( 'current_user_can', Reviews::get_capability() ) ) {
 			return false;
 		}
 
 		// Do not display if the current user has dismissed this notice.
-		if ( get_user_meta( get_current_user_id(), 'dismissed_' . static::REVIEWS_MOVED_NOTICE_ID . '_notice', true ) ) {
+		if ( WC()->call_function( 'get_user_meta', get_current_user_id(), 'dismissed_' . static::REVIEWS_MOVED_NOTICE_ID . '_notice', true ) ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -25,6 +25,8 @@ class ReviewsCommentsOverrides {
 
 		add_action( 'admin_notices', [ $this, 'display_notices' ] );
 
+		add_filter( 'woocommerce_dismiss_notice_capability', [ $this, 'get_dismiss_capability' ], 10, 2 );
+
 		add_filter( 'comments_list_table_query_args', [ $this, 'exclude_reviews_from_comments' ] );
 	}
 
@@ -94,6 +96,20 @@ class ReviewsCommentsOverrides {
 		</div>
 
 		<?php
+	}
+
+	/**
+	 * Gets the capability required to dismiss the notice.
+	 *
+	 * This is required so that users who do not have the manage_woocommerce capability (e.g. Editors) can still dismiss
+	 * the notice displayed in the Comments page.
+	 *
+	 * @param string $default_capability The default required capability.
+	 * @param string $notice_id The notice ID.
+	 * @return string
+	 */
+	public function get_dismiss_capability( string $default_capability, string $notice_id ) {
+		return self::REVIEWS_MOVED_NOTICE_ID === $notice_id ? Reviews::get_capability() : $default_capability;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -29,7 +29,22 @@ class ReviewsCommentsOverrides {
 	/**
 	 * Renders admin notices.
 	 */
-	public function display_notices() {}
+	public function display_notices() {
+		$screen = get_current_screen();
+
+		if ( empty( $screen ) || 'edit-comments' !== $screen->base ) {
+			return;
+		}
+
+		$this->display_reviews_moved_notice();
+	}
+
+	/**
+	 * Renders an admin notice informing the user that reviews were moved to a new page.
+	 */
+	public function display_reviews_moved_notice() {
+
+	}
 
 	/**
 	 * Gets the class instance.

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -21,8 +21,15 @@ class ReviewsCommentsOverrides {
 	 */
 	public function __construct() {
 
+		add_action( 'admin_notices', [ $this, 'display_notices' ] );
+
 		add_filter( 'comments_list_table_query_args', [ $this, 'exclude_reviews_from_comments' ] );
 	}
+
+	/**
+	 * Renders admin notices.
+	 */
+	public function display_notices() {}
 
 	/**
 	 * Gets the class instance.

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -45,7 +45,7 @@ class ReviewsCommentsOverrides {
 	protected function display_reviews_moved_notice() {
 		?>
 
-		<div class="notice notice-info is-dismissible">
+		<div class="notice notice-info">
 			<p><strong><?php esc_html_e( 'Product reviews have moved!', 'woocommerce' ); ?></strong></p>
 			<p><?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?></p>
 			<p class="submit"><a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a></p>

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -38,12 +38,30 @@ class ReviewsCommentsOverrides {
 			return;
 		}
 
+		$this->maybe_display_reviews_moved_notice();
+	}
+
+	/**
+	 * May render an admin notice informing the user that reviews were moved to a new page.
+	 */
+	protected function maybe_display_reviews_moved_notice() {
+		if ( $this->should_display_reviews_moved_notice() ) {
+			$this->display_reviews_moved_notice();
+		}
+	}
+
+	/**
+	 * Checks if the admin notice informing the user that reviews were moved to a new page should be displayed.
+	 *
+	 * @return bool
+	 */
+	protected function should_display_reviews_moved_notice() : bool {
 		// Do not display if the current user has dismissed this notice.
 		if ( get_user_meta( get_current_user_id(), 'dismissed_' . static::REVIEWS_MOVED_NOTICE_ID . '_notice', true ) ) {
-			return;
+			return false;
 		}
 
-		$this->display_reviews_moved_notice();
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -42,7 +42,7 @@ class ReviewsCommentsOverrides {
 	/**
 	 * Renders an admin notice informing the user that reviews were moved to a new page.
 	 */
-	public function display_reviews_moved_notice() {
+	protected function display_reviews_moved_notice() {
 		?>
 
 		<div class="notice notice-info is-dismissible">

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -90,7 +90,7 @@ class ReviewsCommentsOverrides {
 			<p class="submit">
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a>
 			</p>
-			<button type="button" class="notice-dismiss" onclick="window.location = '<?php echo esc_url( $dismiss_url ); ?>';"><span class="screen-reader-text">Dismiss this notice.</span></button>
+			<button type="button" class="notice-dismiss" onclick="window.location = '<?php echo esc_url( $dismiss_url ); ?>';"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'woocommerce' ); ?></span></button>
 		</div>
 
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -46,21 +46,9 @@ class ReviewsCommentsOverrides {
 		?>
 
 		<div class="notice notice-info is-dismissible">
-			<p>
-				<strong><?php esc_html_e( 'Product reviews have moved!', 'woocommerce' ); ?></strong>
-			</p>
-			<p>
-				<?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?>
-			</p>
-			<p class="submit">
-				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary">
-					<?php esc_html_e( 'Visit new location', 'woocommerce' ); ?>
-				</a>
-				<?php // @TODO: update the URL ?>
-				<a href="#" class="button-secondary">
-					<?php esc_html_e( 'Learn more about product reviews', 'woocommerce' ); ?>
-				</a>
-			</p>
+			<p><strong><?php esc_html_e( 'Product reviews have moved!', 'woocommerce' ); ?></strong></p>
+			<p><?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?></p>
+			<p class="submit"><a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a></p>
 		</div>
 
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -84,13 +84,13 @@ class ReviewsCommentsOverrides {
 		);
 		?>
 
-		<div class="notice notice-info">
+		<div class="notice notice-info is-dismissible">
 			<p><strong><?php esc_html_e( 'Product reviews have moved!', 'woocommerce' ); ?></strong></p>
 			<p><?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?></p>
 			<p class="submit">
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a>
-				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
 			</p>
+			<button type="button" class="notice-dismiss" onclick="window.location = '<?php echo esc_url( $dismiss_url ); ?>';"><span class="screen-reader-text">Dismiss this notice.</span></button>
 		</div>
 
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -43,12 +43,31 @@ class ReviewsCommentsOverrides {
 	 * Renders an admin notice informing the user that reviews were moved to a new page.
 	 */
 	protected function display_reviews_moved_notice() {
+		$notice_name = 'product_reviews_moved';
+		if ( get_user_meta( get_current_user_id(), 'dismissed_' . $notice_name . '_notice', true ) ) {
+			return;
+		}
+
+		$dismiss_url = wp_nonce_url(
+			add_query_arg(
+				[
+					'wc-hide-notice' => urlencode( $notice_name ),
+				]
+			),
+			'woocommerce_hide_notices_nonce',
+			'_wc_notice_nonce'
+		);
 		?>
 
 		<div class="notice notice-info">
 			<p><strong><?php esc_html_e( 'Product reviews have moved!', 'woocommerce' ); ?></strong></p>
 			<p><?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?></p>
-			<p class="submit"><a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a></p>
+			<p class="submit">
+				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a>
+				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button">
+					<?php esc_html_e( 'Dismiss', 'woocommerce' ); ?>
+				</a>
+			</p>
 		</div>
 
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -56,6 +56,11 @@ class ReviewsCommentsOverrides {
 	 * @return bool
 	 */
 	protected function should_display_reviews_moved_notice() : bool {
+		// Do not display if the user does not have the capability  to see the new page.
+		if ( ! current_user_can( Reviews::get_capability() ) ) {
+			return false;
+		}
+
 		// Do not display if the current user has dismissed this notice.
 		if ( get_user_meta( get_current_user_id(), 'dismissed_' . static::REVIEWS_MOVED_NOTICE_ID . '_notice', true ) ) {
 			return false;

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -105,11 +105,11 @@ class ReviewsCommentsOverrides {
 	 * the notice displayed in the Comments page.
 	 *
 	 * @param string $default_capability The default required capability.
-	 * @param string $notice_id The notice ID.
+	 * @param string $notice_name The notice name.
 	 * @return string
 	 */
-	public function get_dismiss_capability( string $default_capability, string $notice_id ) {
-		return self::REVIEWS_MOVED_NOTICE_ID === $notice_id ? Reviews::get_capability() : $default_capability;
+	public function get_dismiss_capability( string $default_capability, string $notice_name ) {
+		return self::REVIEWS_MOVED_NOTICE_ID === $notice_name ? Reviews::get_capability() : $default_capability;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -13,6 +13,43 @@ use WC_Unit_Test_Case;
 class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 
 	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::display_notices()
+	 * @dataProvider provider_test_display_notices()
+	 * @param string $current_screen_base    The current WP_Screen base value.
+	 * @param bool   $should_display_notices Whether notices should be displayed.
+	 */
+	public function test_display_notices( string $current_screen_base, bool $should_display_notices ) {
+		$this->reset_legacy_proxy_mocks();
+
+		$this->register_legacy_proxy_function_mocks(
+			[
+				'get_current_screen' => function() use ( $current_screen_base ) {
+					$screen = new \stdClass();
+					$screen->base = $current_screen_base;
+					return $screen;
+				},
+			]
+		);
+
+		ob_start();
+
+		ReviewsCommentsOverrides::get_instance()->display_notices();
+
+		if ( $should_display_notices ) {
+			$this->assertNotEmpty( ob_get_clean() );
+		} else {
+			$this->assertEmpty( ob_get_clean() );
+		}
+	}
+
+	/** @see test_display_notices() */
+	public function provider_test_display_notices() : \Generator {
+		yield 'Comments page' => [ 'edit-comments', true ];
+		yield 'Posts page' => [ 'edit', false ];
+		yield 'Product Reviews page' => [ 'product_page_product-reviews', false ];
+	}
+
+	/**
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::exclude_reviews_from_comments()
 	 */
 	public function test_exclude_reviews_from_comments() {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -188,6 +188,23 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::get_dismiss_capability()
+	 * @dataProvider provider_test_get_dismiss_capability()
+	 * @param string $default_capability The default required capability.
+	 * @param string $notice_id The notice ID.
+	 * @param string $expected_capability The expected capability.
+	 */
+	public function test_get_dismiss_capability( string $default_capability, string $notice_id, string $expected_capability ) {
+		$this->assertSame( $expected_capability, ReviewsCommentsOverrides::get_instance()->get_dismiss_capability( $default_capability, $notice_id ) );
+	}
+
+	/** @see test_get_dismiss_capability() */
+	public function provider_test_get_dismiss_capability() : \Generator {
+		yield 'another notice' => [ 'manage_woocommerce', 'other_notice', 'manage_woocommerce' ];
+		yield 'product reviews moved notice' => [ 'manage_woocommerce', ReviewsCommentsOverrides::REVIEWS_MOVED_NOTICE_ID, 'moderate_comments' ];
+	}
+
+	/**
 	 * Tests that can exclude reviews from comments in the comments page.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::exclude_reviews_from_comments()

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -66,11 +66,16 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 
 		$output = trim( ob_get_clean() );
 
+		$nonce = wp_create_nonce( 'woocommerce_hide_notices_nonce' );
+
 		$this->assertSame(
 			'<div class="notice notice-info">
 			<p><strong>Product reviews have moved!</strong></p>
 			<p>Product reviews can now be managed from Products &gt; Reviews.</p>
-			<p class="submit"><a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">Visit new location</a></p>
+			<p class="submit">
+				<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">Visit new location</a>
+				<a href="?wc-hide-notice=product_reviews_moved&#038;_wc_notice_nonce=' . $nonce . '" class="button">Dismiss</a>
+			</p>
 		</div>',
 			$output
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -191,11 +191,11 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::get_dismiss_capability()
 	 * @dataProvider provider_test_get_dismiss_capability()
 	 * @param string $default_capability The default required capability.
-	 * @param string $notice_id The notice ID.
+	 * @param string $notice_name The notice name.
 	 * @param string $expected_capability The expected capability.
 	 */
-	public function test_get_dismiss_capability( string $default_capability, string $notice_id, string $expected_capability ) {
-		$this->assertSame( $expected_capability, ReviewsCommentsOverrides::get_instance()->get_dismiss_capability( $default_capability, $notice_id ) );
+	public function test_get_dismiss_capability( string $default_capability, string $notice_name, string $expected_capability ) {
+		$this->assertSame( $expected_capability, ReviewsCommentsOverrides::get_instance()->get_dismiss_capability( $default_capability, $notice_name ) );
 	}
 
 	/** @see test_get_dismiss_capability() */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -15,14 +15,13 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 
 	/**
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::display_notices()
+	 * @backupGlobals enabled
 	 * @dataProvider provider_test_display_notices()
 	 * @param string $current_screen_base    The current WP_Screen base value.
 	 * @param bool   $should_display_notices Whether notices should be displayed.
 	 */
 	public function test_display_notices( string $current_screen_base, bool $should_display_notices ) {
 		global $current_screen;
-
-		$current_screen_backup = $current_screen;
 
 		$screen = new \stdClass();
 		$screen->base = $current_screen_base;
@@ -40,9 +39,6 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 		} else {
 			$this->assertEmpty( $output );
 		}
-
-		// Restore the global variable.
-		$current_screen = $current_screen_backup; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 
 	/** @see test_display_notices() */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -22,6 +22,8 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	public function test_display_notices( string $current_screen_base, bool $should_display_notices ) {
 		global $current_screen;
 
+		$current_screen_backup = $current_screen;
+
 		$screen = new \stdClass();
 		$screen->base = $current_screen_base;
 
@@ -38,6 +40,9 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 		} else {
 			$this->assertEmpty( $output );
 		}
+
+		// Restore the global variable.
+		$current_screen = $current_screen_backup; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 
 	/** @see test_display_notices() */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -15,13 +15,14 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 
 	/**
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::display_notices()
-	 * @backupGlobals enabled
 	 * @dataProvider provider_test_display_notices()
 	 * @param string $current_screen_base    The current WP_Screen base value.
 	 * @param bool   $should_display_notices Whether notices should be displayed.
 	 */
 	public function test_display_notices( string $current_screen_base, bool $should_display_notices ) {
 		global $current_screen;
+
+		$current_screen_backup = $current_screen;
 
 		$screen = new \stdClass();
 		$screen->base = $current_screen_base;
@@ -39,6 +40,9 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 		} else {
 			$this->assertEmpty( $output );
 		}
+
+		// Restore the global variable (using the @backupGlobals annotation will cause a serialization error).
+		$current_screen = $current_screen_backup; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 
 	/** @see test_display_notices() */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -19,26 +19,23 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	 * @param bool   $should_display_notices Whether notices should be displayed.
 	 */
 	public function test_display_notices( string $current_screen_base, bool $should_display_notices ) {
-		$this->reset_legacy_proxy_mocks();
+		global $current_screen;
 
-		$this->register_legacy_proxy_function_mocks(
-			[
-				'get_current_screen' => function() use ( $current_screen_base ) {
-					$screen = new \stdClass();
-					$screen->base = $current_screen_base;
-					return $screen;
-				},
-			]
-		);
+		$screen = new \stdClass();
+		$screen->base = $current_screen_base;
+
+		$current_screen = $screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		ob_start();
 
 		ReviewsCommentsOverrides::get_instance()->display_notices();
 
+		$output = ob_get_clean();
+
 		if ( $should_display_notices ) {
-			$this->assertNotEmpty( ob_get_clean() );
+			$this->assertNotEmpty( $output );
 		} else {
-			$this->assertEmpty( ob_get_clean() );
+			$this->assertEmpty( $output );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -3,6 +3,7 @@
 namespace Automattic\WooCommerce\Tests\Internal\Admin;
 
 use Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides;
+use ReflectionClass;
 use WC_Unit_Test_Case;
 
 /**
@@ -44,6 +45,38 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 		yield 'Comments page' => [ 'edit-comments', true ];
 		yield 'Posts page' => [ 'edit', false ];
 		yield 'Product Reviews page' => [ 'product_page_product-reviews', false ];
+	}
+
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::display_reviews_moved_notice()
+	 */
+	public function test_display_reviews_moved_notice() {
+		$overrides = new ReviewsCommentsOverrides();
+		$method = ( new ReflectionClass( $overrides ) )->getMethod( 'display_reviews_moved_notice' );
+		$method->setAccessible( true );
+
+		ob_start();
+
+		$method->invoke( $overrides );
+
+		$output = trim( ob_get_clean() );
+
+		$this->assertSame(
+			'<div class="notice notice-info is-dismissible">
+			<p>
+				<strong>Product reviews have moved!</strong>
+			</p>
+			<p>
+				Product reviews can now be managed from Products &gt; Reviews.			</p>
+			<p class="submit">
+				<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">
+					Visit new location				</a>
+								<a href="#" class="button-secondary">
+					Learn more about product reviews				</a>
+			</p>
+		</div>',
+			$output
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -67,7 +67,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 		$output = trim( ob_get_clean() );
 
 		$this->assertSame(
-			'<div class="notice notice-info is-dismissible">
+			'<div class="notice notice-info">
 			<p><strong>Product reviews have moved!</strong></p>
 			<p>Product reviews can now be managed from Products &gt; Reviews.</p>
 			<p class="submit"><a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">Visit new location</a></p>

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -63,17 +63,9 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 
 		$this->assertSame(
 			'<div class="notice notice-info is-dismissible">
-			<p>
-				<strong>Product reviews have moved!</strong>
-			</p>
-			<p>
-				Product reviews can now be managed from Products &gt; Reviews.			</p>
-			<p class="submit">
-				<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">
-					Visit new location				</a>
-								<a href="#" class="button-secondary">
-					Learn more about product reviews				</a>
-			</p>
+			<p><strong>Product reviews have moved!</strong></p>
+			<p>Product reviews can now be managed from Products &gt; Reviews.</p>
+			<p class="submit"><a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">Visit new location</a></p>
 		</div>',
 			$output
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -175,13 +175,13 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 		$nonce = wp_create_nonce( 'woocommerce_hide_notices_nonce' );
 
 		$this->assertSame(
-			'<div class="notice notice-info">
+			'<div class="notice notice-info is-dismissible">
 			<p><strong>Product reviews have moved!</strong></p>
 			<p>Product reviews can now be managed from Products &gt; Reviews.</p>
 			<p class="submit">
 				<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">Visit new location</a>
-				<a href="?wc-hide-notice=product_reviews_moved&#038;_wc_notice_nonce=' . $nonce . '" class="button">Dismiss</a>
 			</p>
+			<button type="button" class="notice-dismiss" onclick="window.location = \'?wc-hide-notice=product_reviews_moved&#038;_wc_notice_nonce=' . $nonce . '\';"><span class="screen-reader-text">Dismiss this notice.</span></button>
 		</div>',
 			$output
 		);


### PR DESCRIPTION
## Summary

Renders a notice on the Comments list page.

## Story: [MWC-5356](https://jira.godaddy.com/browse/MWC-5356)

## Details

@agibson-godaddy 's [PR](https://github.com/godaddy-wordpress/woocommerce/pull/35) to make the notice dismissible was merged into this one. I've tweaked the HTML a bit so we could use the standard dismiss icon instead of a button.

## QA

### Setup

- Have a Contributor user on your site
- Have an Editor user on your site

### Steps

#### Administrator

1. Login as an admin user
1. Navigate to the Comments page
    - [x] A notice like the one on the image below is displayed
        
    ![Image 2022-04-20 at 4 07 20 PM](https://user-images.githubusercontent.com/72819637/164339163-348e873d-d136-4e36-bd6a-81c3dc7e7a09.jpg)

1. Click the "Visit new location" button
    - [x] You are redirected to the Product > Reviews page
1. Navigate back to the Comments page
1. Click the "Dismiss" button
    - [x] The notice is not displayed
1. Reload the page
    - [x] The notice is not displayed

#### Contributor

1. Login as a Contributor user
1. Navigate to the Comments page
    - [x] The notice is not displayed

#### Editor 

1. Login as an Editor user
1. Navigate to the Comments page
    - [x] The notice is displayed
1. Click the "Visit new location" button
    - [x] You are redirected to the Product > Reviews page
1. Navigate back to the Comments page
1. Click the "Dismiss" button
    - [x] The notice is not displayed
1. Reload the page
    - [x] The notice is not displayed