### PR TITLE
Implement the product reviews type filter in the Product Reviews page

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -89,7 +89,9 @@ class Reviews {
 	 * @return void
 	 */
 	public function render_reviews_list_table() {
+
 		$this->reviews_list_table->prepare_items();
+
 		?>
 		<div class="wrap">
 			<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
@@ -98,7 +100,7 @@ class Reviews {
 
 			<form id="reviews-filter" method="get">
 
-				<input type="hidden" name="page" value="product-reviews" />
+				<input type="hidden" name="page" value="<?php echo esc_html( static::MENU_SLUG ); ?>" />
 
 				<?php $this->reviews_list_table->search_box( __( 'Search reviews', 'woocommerce' ), 'reviews' ); ?>
 

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -99,8 +99,10 @@ class Reviews {
 			<?php $this->reviews_list_table->views(); ?>
 
 			<form id="reviews-filter" method="get">
+				<?php $page = isset( $_REQUEST['page'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) : static::MENU_SLUG; ?>
 
-				<input type="hidden" name="page" value="<?php echo esc_html( static::MENU_SLUG ); ?>" />
+				<input type="hidden" name="page" value="<?php echo esc_attr( $page ); ?>" />
+				<input type="hidden" name="post_type" value="product" />
 
 				<?php $this->reviews_list_table->search_box( __( 'Search reviews', 'woocommerce' ), 'reviews' ); ?>
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -35,7 +35,6 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param array|string $args Array or string of arguments.
 	 */
 	public function __construct( $args = [] ) {
-
 		parent::__construct( $args );
 
 		$this->current_user_can_moderate_reviews = current_user_can( 'moderate_comments' );

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -144,7 +144,7 @@ class ReviewsListTable extends WP_List_Table {
 	protected function get_filter_type_arguments() : array {
 
 		$args      = [];
-		$item_type = isset( $_REQUEST['item_type'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['item_type'] ) ) : 'all';
+		$item_type = isset( $_REQUEST['review_type'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['review_type'] ) ) : 'all';
 
 		switch ( $item_type ) {
 
@@ -168,6 +168,7 @@ class ReviewsListTable extends WP_List_Table {
 
 			// Reviews and other review types.
 			case 'review':
+			default:
 				$args['comment_type'] = $item_type;
 				$args['parent__in']   = [ 0 ];
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -49,6 +49,7 @@ class ReviewsListTable extends WP_List_Table {
 	public function prepare_items() {
 
 		$this->set_review_status();
+		$this->set_item_type();
 
 		$args = [
 			'post_type' => 'product',
@@ -81,6 +82,23 @@ class ReviewsListTable extends WP_List_Table {
 
 		if ( ! in_array( $comment_status, [ 'all', 'moderated', 'approved', 'spam', 'trash' ], true ) ) {
 			$comment_status = 'all'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+	}
+
+	/**
+	 * Sets the `$comment_type` global based on the current request.
+	 *
+	 * @global string $comment_type
+	 *
+	 * @return void
+	 */
+	protected function set_item_type() {
+		global $comment_type;
+
+		$item_type = sanitize_text_field( wp_unslash( $_REQUEST['item_type'] ?? 'all' ) );
+
+		if ( 'all' !== $item_type ) {
+			$comment_type = $item_type; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 	}
 
@@ -150,8 +168,8 @@ class ReviewsListTable extends WP_List_Table {
 
 			// Reviews and other review types.
 			case 'review':
-			default:
 				$args['comment_type'] = $item_type;
+				$args['parent__in']   = [ 0 ];
 
 				break;
 		}

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -567,10 +567,26 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Displays a comment type drop-down for filtering on the Comments list table.
 	 *
-	 * @param string $comment_type The current comment type slug.
+	 * @see WP_Comments_List_Table::comment_type_dropdown() for consistency.
+	 *
+	 * @param string $item_type The current comment item type slug.
 	 */
-	protected function comment_type_dropdown( $comment_type ) {
-		// @TODO Implement the Type filter - MWC-5343 {dmagalhaes 2022-04-13}
-		echo '&nbsp;';
+	protected function comment_type_dropdown( $item_type ) {
+
+		$item_types = [
+			'all'    => __( 'All', 'woocommerce' ),
+			'reply'  => __( 'Replies', 'woocommerce' ),
+			'review' => __( 'Reviews', 'woocommerce' ),
+		];
+
+		?>
+		<label class="screen-reader-text" for="filter-by-item-type"><?php esc_html_e( 'Filter by type', 'woocommerce' ); ?></label>
+		<select id="filter-by-item-type" name="item_type">
+			<?php foreach ( $item_types as $type => $label ) : ?>
+				<option value="<?php echo esc_attr( $type ); ?>" <?php selected( $type, $item_type ); ?>><?php echo esc_html( $label ); ?></option>
+			<?php endforeach; ?>
+		</select>
+		<?php
 	}
+
 }

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -646,7 +646,7 @@ class ReviewsListTable extends WP_List_Table {
 	protected function review_type_dropdown( $item_type ) {
 
 		$item_types = [
-			'all'     => __( 'All', 'woocommerce' ),
+			'all'     => __( 'All types', 'woocommerce' ),
 			'comment' => __( 'Replies', 'woocommerce' ),
 			'review'  => __( 'Reviews', 'woocommerce' ),
 		];

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -95,10 +95,10 @@ class ReviewsListTable extends WP_List_Table {
 	protected function set_review_type() {
 		global $comment_type;
 
-		$item_type = sanitize_text_field( wp_unslash( $_REQUEST['review_type'] ?? 'all' ) );
+		$review_type = sanitize_text_field( wp_unslash( $_REQUEST['review_type'] ?? 'all' ) );
 
-		if ( 'all' !== $item_type ) {
-			$comment_type = $item_type; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		if ( 'all' !== $review_type && ! empty( $review_type ) ) {
+			$comment_type = $review_type; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -49,7 +49,7 @@ class ReviewsListTable extends WP_List_Table {
 	public function prepare_items() {
 
 		$this->set_review_status();
-		$this->set_item_type();
+		$this->set_review_type();
 
 		$args = [
 			'post_type' => 'product',
@@ -92,10 +92,10 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	protected function set_item_type() {
+	protected function set_review_type() {
 		global $comment_type;
 
-		$item_type = sanitize_text_field( wp_unslash( $_REQUEST['item_type'] ?? 'all' ) );
+		$item_type = sanitize_text_field( wp_unslash( $_REQUEST['review_type'] ?? 'all' ) );
 
 		if ( 'all' !== $item_type ) {
 			$comment_type = $item_type; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -610,7 +610,7 @@ class ReviewsListTable extends WP_List_Table {
 
 			ob_start();
 
-			$this->comment_type_dropdown( $comment_type );
+			$this->review_type_dropdown( $comment_type );
 
 			$output = ob_get_clean();
 
@@ -643,7 +643,7 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @param string $item_type The current comment item type slug.
 	 */
-	protected function comment_type_dropdown( $item_type ) {
+	protected function review_type_dropdown( $item_type ) {
 
 		$item_types = [
 			'all'     => __( 'All', 'woocommerce' ),
@@ -652,8 +652,8 @@ class ReviewsListTable extends WP_List_Table {
 		];
 
 		?>
-		<label class="screen-reader-text" for="filter-by-item-type"><?php esc_html_e( 'Filter by type', 'woocommerce' ); ?></label>
-		<select id="filter-by-item-type" name="item_type">
+		<label class="screen-reader-text" for="filter-by-review-type"><?php esc_html_e( 'Filter by review type', 'woocommerce' ); ?></label>
+		<select id="filter-by-review-type" name="review_type">
 			<?php foreach ( $item_types as $type => $label ) : ?>
 				<option value="<?php echo esc_attr( $type ); ?>" <?php selected( $type, $item_type ); ?>><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -637,11 +637,12 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Displays a comment type drop-down for filtering on the Comments list table.
+	 * Displays a review type drop-down for filtering reviews in the Product Reviews list table.
 	 *
 	 * @see WP_Comments_List_Table::comment_type_dropdown() for consistency.
 	 *
 	 * @param string $item_type The current comment item type slug.
+	 * @return void
 	 */
 	protected function review_type_dropdown( $item_type ) {
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -136,7 +136,7 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Builds the `comment_type` and `parent__in` arguments based on the current request.
+	 * Builds the `type` argument based on the current request.
 	 *
 	 * @return array
 	 */
@@ -145,34 +145,11 @@ class ReviewsListTable extends WP_List_Table {
 		$args      = [];
 		$item_type = isset( $_REQUEST['review_type'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['review_type'] ) ) : 'all';
 
-		switch ( $item_type ) {
-
-			case 'all':
-				break;
-
-			// Review replies.
-			case 'comment':
-				$parents = get_comments(
-					[
-						'type'   => 'review',
-						'fields' => 'ids',
-						'paged'  => -1,
-					]
-				);
-
-				$args['comment_type'] = 'comment';
-				$args['parent__in']   = ! empty( $parents ) ? (array) $parents : [ 0 ];
-
-				break;
-
-			// Reviews and other review types.
-			case 'review':
-			default:
-				$args['comment_type'] = $item_type;
-				$args['parent__in']   = [ 0 ];
-
-				break;
+		if ( 'all' === $item_type ) {
+			return $args;
 		}
+
+		$args['type'] = $item_type;
 
 		return $args;
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1095,9 +1095,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( '<select id="filter-by-review-type" name="review_type">', $output );
 
 		if ( ! in_array( $chosen_type, [ 'all', 'comment', 'review' ], true ) ) {
-			$this->assertStringNotContainsString( '<option value="' . $chosen_type . '" selected', $output );
+			$this->assertStringNotContainsString( '<option value="' . $chosen_type . '"  selected', $output );
 		} else {
-			$this->assertStringContainsString( '<option value="' . $chosen_type . '" selected', $output );
+			$this->assertStringContainsString( '<option value="' . $chosen_type . '"  selected', $output );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -7,7 +7,6 @@ use Generator;
 use ReflectionClass;
 use ReflectionException;
 use WC_Unit_Test_Case;
-use WP_Comment;
 
 /**
  * Tests that product reviews page handler.
@@ -625,10 +624,12 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 */
 	public function test_set_review_type( $review_type, $expected_review_type ) {
 		$list_table = $this->get_reviews_list_table();
-		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'set_review_status' );
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'set_review_type' );
 		$method->setAccessible( true );
 
-		$_REQUEST['review_type'] = $review_type;
+		if ( null !== $review_type ) {
+			$_REQUEST['review_type'] = $review_type;
+		}
 
 		$method->invoke( $list_table );
 
@@ -639,7 +640,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 	/** @see test_set_review_type */
 	public function data_provider_set_review_type() : Generator {
-		yield 'Type not set' => [ null, 'all' ];
+		yield 'Type not set' => [ null, null ];
+		yield 'All types'    => [ 'all', null ];
 		yield 'Replies'      => [ 'comment', 'comment' ];
 		yield 'Reviews'      => [ 'review', 'review' ];
 		yield 'Other'        => [ 'other', 'other' ];

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -646,6 +646,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		if ( null !== $review_type ) {
 			$_REQUEST['review_type'] = $review_type;
+		} else {
+			unset( $_REQUEST['review_type'] );
 		}
 
 		$method->invoke( $list_table );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -671,8 +671,10 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers       \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_sort_arguments()
-	 * @dataProvider provider_get_sort_arguments
+	 * Tests that can get the sort arguments for the current request.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_sort_arguments()
+	 * @dataProvider data_provider_get_sort_arguments
 	 *
 	 * @param string|null $orderby       The orderby value that's set in the request.
 	 * @param string|null $order         The order value that's set in the request.
@@ -685,13 +687,13 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_sort_arguments' );
 		$method->setAccessible( true );
 
-		if ( ! is_null( $orderby ) ) {
+		if ( null !== $orderby ) {
 			$_REQUEST['orderby'] = $orderby;
 		} else {
 			unset( $_REQUEST['orderby'] );
 		}
 
-		if ( ! is_null( $order ) ) {
+		if ( null !== $order ) {
 			$_REQUEST['order'] = $order;
 		} else {
 			unset( $_REQUEST['order'] );
@@ -701,7 +703,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/** @see test_get_sort_arguments */
-	public function provider_get_sort_arguments() : Generator {
+	public function data_provider_get_sort_arguments() : Generator {
 		yield 'order by comment_author desc' => [
 			'comment_author',
 			'desc',
@@ -765,6 +767,40 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 				'order'   => 'desc',
 			],
 		];
+	}
+
+	/**
+	 * Tests that can get the comment type argument for the current request.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_filter_type_arguments()
+	 * @dataProvider data_provider_get_filter_type_arguments
+	 *
+	 * @param string $review_type  The requested review type.
+	 * @param string $comment_type The resulting comment type.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_filter_type_arguments( $review_type, $comment_type ) {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_filter_type_arguments' );
+		$method->setAccessible( true );
+
+		if ( null !== ( $review_type ) ) {
+			$_REQUEST['review_type'] = $review_type;
+		}
+
+		$args = $method->invoke( $list_table );
+
+		$this->assertSame( $comment_type, $args['comment_type'] ?? null );
+	}
+
+	/** @see test_get_filter_type_arguments */
+	public function data_provider_get_filter_type_arguments() : Generator {
+		yield 'No requested type' => [ null, null ];
+		yield 'All types'         => [ 'all', null ];
+		yield 'Replies'           => [ 'comment', 'comment' ];
+		yield 'Reviews'           => [ 'review', 'review' ];
+		yield 'Other'             => [ 'other', 'other' ];
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -504,6 +504,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can get the product reviews bulk actions.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_bulk_actions()
 	 * @dataProvider provider_get_bulk_actions
 	 *
 	 * @param string $current_comment_status Currently set status.
@@ -512,7 +515,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * @throws ReflectionException If the method doesn't exist.
 	 */
 	public function test_get_bulk_actions( string $current_comment_status, array $expected_actions ) {
-		$list_table = new ReviewsListTable( [ 'screen' => 'product_page_product-reviews' ] );
+		$list_table = $this->get_reviews_list_table();
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_bulk_actions' );
 		$method->setAccessible( true );
 
@@ -574,6 +577,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can set the review status when preparing items.
+	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::set_review_status()
 	 * @dataProvider provider_set_review_status
 	 *
@@ -583,7 +588,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * @throws ReflectionException If the method doesn't exist.
 	 */
 	public function test_set_review_status( ?string $request_status, string $expected_comment_status ) {
-		$list_table = new ReviewsListTable( [ 'screen' => 'product_page_product-reviews' ] );
+		$list_table = $this->get_reviews_list_table();
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'set_review_status' );
 		$method->setAccessible( true );
 
@@ -605,6 +610,39 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		yield 'approved status' => [ 'approved', 'approved' ];
 		yield 'spam status' => [ 'spam', 'spam' ];
 		yield 'trash status' => [ 'trash', 'trash' ];
+	}
+
+	/**
+	 * Tests that can set the review type when preparing items.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::set_review_type()
+	 * @dataProvider data_provider_set_review_type
+	 *
+	 * @param string $review_type          Review type.
+	 * @param string $expected_review_type Expected review type to be set.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_set_review_type( $review_type, $expected_review_type ) {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'set_review_status' );
+		$method->setAccessible( true );
+
+		$_REQUEST['review_type'] = $review_type;
+
+		$method->invoke( $list_table );
+
+		global $comment_type;
+
+		$this->assertSame( $expected_review_type, $comment_type );
+	}
+
+	/** @see test_set_review_type */
+	public function data_provider_set_review_type() : Generator {
+		yield 'Type not set' => [ null, 'all' ];
+		yield 'Replies'      => [ 'comment', 'comment' ];
+		yield 'Reviews'      => [ 'review', 'review' ];
+		yield 'Other'        => [ 'other', 'other' ];
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -814,7 +814,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$args = $method->invoke( $list_table );
 
-		$this->assertSame( $comment_type, $args['comment_type'] ?? null );
+		$this->assertSame( $comment_type, $args['type'] ?? null );
 	}
 
 	/** @see test_get_filter_type_arguments */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -808,6 +808,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		if ( null !== ( $review_type ) ) {
 			$_REQUEST['review_type'] = $review_type;
+		} else {
+			unset( $_REQUEST['review_type'] );
 		}
 
 		$args = $method->invoke( $list_table );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -520,7 +520,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Tests that can get the product reviews bulk actions.
+	 * Tests that can get the bulk actions for the product reviews page.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_bulk_actions()
 	 * @dataProvider data_provider_get_bulk_actions


### PR DESCRIPTION
# Summary

Implements the extra nav filter dropdown to list reviews by type.

### Story: [MWC 5343](https://jira.godaddy.com/browse/MWC-5343)

## QA

- [x] Code review
- [x] Unit tests pass

### User testing

1. Have multiple reviews and replies in your installation
1. Go to the Products > Reviews page
    - [x] By default, all reviews and replies are visible and "All types" is the default type in the dropdown
1. Filter by "Replies"
    - [x] Only replies are shown 
    - [x] The sorting order is preserved
    - [x] The dropdown value is "Replies"
1. Filter by "Reviews"
    - [x] Only reviews are shown 
    - [x] The sorting order is preserved
    - [x] The dropdown value is "Reviews"
1. Switch back to "All types"
    - [x] All items are shown
    - [x] The sorting order is preserved
    - [x] The dropdown value is "All types"