### PR TITLE
Implement the product reviews rating filter in the Product Reviews page

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -34,7 +34,7 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @var int
 	 */
-	private $current_rating = 0;
+	private $current_reviews_rating = 0;
 
 	/**
 	 * Constructor.
@@ -54,7 +54,7 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	public function prepare_items() {
 
-		$this->current_rating = isset( $_REQUEST['review_rating'] ) ? absint( $_REQUEST['review_rating'] ) : 0;
+		$this->current_reviews_rating = isset( $_REQUEST['review_rating'] ) ? absint( $_REQUEST['review_rating'] ) : 0;
 
 		$this->set_review_status();
 		$this->set_review_type();
@@ -192,18 +192,18 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @return array
 	 */
-	public function get_filter_rating_arguments() : array {
+	protected function get_filter_rating_arguments() : array {
 
 		$args = [];
 
-		if ( empty( $this->current_rating ) ) {
+		if ( empty( $this->current_reviews_rating ) ) {
 			return $args;
 		}
 
 		$args['meta_query'] = [
 			[
 				'key'     => 'rating',
-				'value'   => (int) $this->current_rating,
+				'value'   => (int) $this->current_reviews_rating,
 				'compare' => '=',
 				'type'    => 'NUMERIC',
 			],
@@ -646,7 +646,7 @@ class ReviewsListTable extends WP_List_Table {
 			ob_start();
 
 			$this->review_type_dropdown( $comment_type );
-			$this->review_rating_dropdown( $this->current_rating );
+			$this->review_rating_dropdown( $this->current_reviews_rating );
 
 			$output = ob_get_clean();
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -725,7 +725,7 @@ class ReviewsListTable extends WP_List_Table {
 					? $label
 					: sprintf(
 						/* translators: %s: Star rating. */
-						__( '%s-star reviews', 'woocommerce' ),
+						__( '%s-star rating', 'woocommerce' ),
 						$rating
 					);
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -646,8 +646,7 @@ class ReviewsListTable extends WP_List_Table {
 			ob_start();
 
 			$this->review_type_dropdown( $comment_type );
-
-			$this->rating_dropdown( $this->current_rating );
+			$this->review_rating_dropdown( $this->current_rating );
 
 			$output = ob_get_clean();
 
@@ -705,7 +704,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param int $current_rating Rating to display reviews for.
 	 * @return void
 	 */
-	public function rating_dropdown( $current_rating ) {
+	public function review_rating_dropdown( $current_rating ) {
 
 		$rating_options = [
 			'0' => __( 'All ratings', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -719,7 +719,18 @@ class ReviewsListTable extends WP_List_Table {
 		<label class="screen-reader-text" for="filter-by-review-rating"><?php esc_html_e( 'Filter by review rating', 'woocommerce' ); ?></label>
 		<select id="filter-by-review-rating" name="review_rating">
 			<?php foreach ( $rating_options as $rating => $label ) : ?>
-				<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $rating, (string) $current_rating ); ?>><?php echo esc_html( $label ); ?></option>
+				<?php
+
+				$title = 0 === (int) $rating
+					? $label
+					: sprintf(
+						/* translators: %s: Star rating. */
+						__( '%s-star reviews', 'woocommerce' ),
+						$rating
+					);
+
+				?>
+				<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $rating, (string) $current_rating ); ?> title="<?php echo esc_html( $title ); ?>"><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>
 		</select>
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -730,7 +730,7 @@ class ReviewsListTable extends WP_List_Table {
 					);
 
 				?>
-				<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $rating, (string) $current_rating ); ?> title="<?php echo esc_html( $title ); ?>"><?php echo esc_html( $label ); ?></option>
+				<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $rating, (string) $current_rating ); ?> title="<?php echo esc_attr( $title ); ?>"><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>
 		</select>
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -724,7 +724,7 @@ class ReviewsListTable extends WP_List_Table {
 				$title = 0 === (int) $rating
 					? $label
 					: sprintf(
-						/* translators: %s: Star rating. */
+						/* translators: %s: Star rating (1-5). */
 						__( '%s-star rating', 'woocommerce' ),
 						$rating
 					);

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -29,13 +29,12 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	private $current_user_can_moderate_reviews;
 
-
 	/**
 	 * Current rating of reviews to display.
 	 *
-	 * @var string
+	 * @var int
 	 */
-	private $current_rating = '0';
+	private $current_rating = 0;
 
 	/**
 	 * Constructor.
@@ -55,7 +54,7 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	public function prepare_items() {
 
-		$this->current_rating = (string) isset( $_REQUEST['rating'] ) ? wc_clean( wp_unslash( $_REQUEST['rating'] ) ) : 0;
+		$this->current_rating = isset( $_REQUEST['review_rating'] ) ? absint( $_REQUEST['review_rating'] ) : 0;
 
 		$this->set_review_status();
 		$this->set_review_type();
@@ -66,9 +65,10 @@ class ReviewsListTable extends WP_List_Table {
 
 		// Include the order & orderby arguments.
 		$args = wp_parse_args( $this->get_sort_arguments(), $args );
-
 		// Handle the review item types filter.
 		$args = wp_parse_args( $this->get_filter_type_arguments(), $args );
+		// Handle the reviews rating filter.
+		$args = wp_parse_args( $this->get_filter_rating_arguments(), $args );
 
 		$comments = get_comments( $args );
 
@@ -183,6 +183,31 @@ class ReviewsListTable extends WP_List_Table {
 
 				break;
 		}
+
+		return $args;
+	}
+
+	/**
+	 * Builds the `meta_query` arguments based on the current request.
+	 *
+	 * @return array
+	 */
+	public function get_filter_rating_arguments() : array {
+
+		$args = [];
+
+		if ( empty( $this->current_rating ) ) {
+			return $args;
+		}
+
+		$args['meta_query'] = [
+			[
+				'key'     => 'rating',
+				'value'   => (int) $this->current_rating,
+				'compare' => '=',
+				'type'    => 'NUMERIC',
+			],
+		];
 
 		return $args;
 	}
@@ -622,7 +647,7 @@ class ReviewsListTable extends WP_List_Table {
 
 			$this->review_type_dropdown( $comment_type );
 
-			$this->rating_dropdown();
+			$this->rating_dropdown( $this->current_rating );
 
 			$output = ob_get_clean();
 
@@ -653,10 +678,10 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @see WP_Comments_List_Table::comment_type_dropdown() for consistency.
 	 *
-	 * @param string $item_type The current comment item type slug.
+	 * @param string $current_type The current comment item type slug.
 	 * @return void
 	 */
-	protected function review_type_dropdown( $item_type ) {
+	protected function review_type_dropdown( $current_type ) {
 
 		$item_types = [
 			'all'     => __( 'All types', 'woocommerce' ),
@@ -668,7 +693,7 @@ class ReviewsListTable extends WP_List_Table {
 		<label class="screen-reader-text" for="filter-by-review-type"><?php esc_html_e( 'Filter by review type', 'woocommerce' ); ?></label>
 		<select id="filter-by-review-type" name="review_type">
 			<?php foreach ( $item_types as $type => $label ) : ?>
-				<option value="<?php echo esc_attr( $type ); ?>" <?php selected( $type, $item_type ); ?>><?php echo esc_html( $label ); ?></option>
+				<option value="<?php echo esc_attr( $type ); ?>" <?php selected( $type, $current_type ); ?>><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>
 		</select>
 		<?php
@@ -677,9 +702,10 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Displays a review rating drop-down for filtering reviews in the Product Reviews list table.
 	 *
+	 * @param int $current_rating Rating to display reviews for.
 	 * @return void
 	 */
-	public function rating_dropdown() {
+	public function rating_dropdown( $current_rating ) {
 
 		$rating_options = [
 			'0' => __( 'All ratings', 'woocommerce' ),
@@ -694,7 +720,7 @@ class ReviewsListTable extends WP_List_Table {
 		<label class="screen-reader-text" for="filter-by-review-rating"><?php esc_html_e( 'Filter by review rating', 'woocommerce' ); ?></label>
 		<select id="filter-by-review-rating" name="review_rating">
 			<?php foreach ( $rating_options as $rating => $label ) : ?>
-				<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $this->current_rating, $rating ); ?>><?php echo esc_html( $label ); ?></option>
+				<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $rating, (string) $current_rating ); ?>><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>
 		</select>
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -29,6 +29,14 @@ class ReviewsListTable extends WP_List_Table {
 	 */
 	private $current_user_can_moderate_reviews;
 
+
+	/**
+	 * Current rating of reviews to display.
+	 *
+	 * @var string
+	 */
+	private $current_rating = '0';
+
 	/**
 	 * Constructor.
 	 *
@@ -46,6 +54,8 @@ class ReviewsListTable extends WP_List_Table {
 	 * @return void
 	 */
 	public function prepare_items() {
+
+		$this->current_rating = (string) isset( $_REQUEST['rating'] ) ? wc_clean( wp_unslash( $_REQUEST['rating'] ) ) : 0;
 
 		$this->set_review_status();
 		$this->set_review_type();
@@ -612,6 +622,8 @@ class ReviewsListTable extends WP_List_Table {
 
 			$this->review_type_dropdown( $comment_type );
 
+			$this->rating_dropdown();
+
 			$output = ob_get_clean();
 
 			if ( ! empty( $output ) && $this->has_items() ) {
@@ -637,11 +649,12 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Displays a comment type drop-down for filtering on the Comments list table.
+	 * Displays a review type drop-down for filtering reviews in the Product Reviews list table.
 	 *
 	 * @see WP_Comments_List_Table::comment_type_dropdown() for consistency.
 	 *
 	 * @param string $item_type The current comment item type slug.
+	 * @return void
 	 */
 	protected function review_type_dropdown( $item_type ) {
 
@@ -656,6 +669,32 @@ class ReviewsListTable extends WP_List_Table {
 		<select id="filter-by-review-type" name="review_type">
 			<?php foreach ( $item_types as $type => $label ) : ?>
 				<option value="<?php echo esc_attr( $type ); ?>" <?php selected( $type, $item_type ); ?>><?php echo esc_html( $label ); ?></option>
+			<?php endforeach; ?>
+		</select>
+		<?php
+	}
+
+	/**
+	 * Displays a review rating drop-down for filtering reviews in the Product Reviews list table.
+	 *
+	 * @return void
+	 */
+	public function rating_dropdown() {
+
+		$rating_options = [
+			'0' => __( 'All ratings', 'woocommerce' ),
+			'1' => '&#9733;',
+			'2' => '&#9733;&#9733;',
+			'3' => '&#9733;&#9733;&#9733;',
+			'4' => '&#9733;&#9733;&#9733;&#9733;',
+			'5' => '&#9733;&#9733;&#9733;&#9733;&#9733;',
+		];
+
+		?>
+		<label class="screen-reader-text" for="filter-by-review-rating"><?php esc_html_e( 'Filter by review rating', 'woocommerce' ); ?></label>
+		<select id="filter-by-review-rating" name="review_rating">
+			<?php foreach ( $rating_options as $rating => $label ) : ?>
+				<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $this->current_rating, $rating ); ?>><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>
 		</select>
 		<?php

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1108,4 +1108,40 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		yield 'Replies'      => [ 'comment' ];
 		yield 'Reviews'      => [ 'review' ];
 	}
+
+	/**
+	 * Tests that can output a filter dropdown for review ratings.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::review_rating_dropdown()
+	 * @dataProvider data_provider_test_review_rating_dropdown
+	 *
+	 * @param string $chosen_rating The rating to filter reviews for.
+	 * @return void
+	 * @throws ReflectionException If the method is not defined.
+	 */
+	public function test_review_rating_dropdown( $chosen_rating ) {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'review_rating_dropdown' );
+		$method->setAccessible( true );
+
+		ob_start();
+
+		$method->invokeArgs( $list_table, [ $chosen_rating ] );
+
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<label class="screen-reader-text" for="filter-by-review-rating">Filter by review rating</label>', $output );
+		$this->assertStringContainsString( '<select id="filter-by-review-rating" name="review_rating">', $output );
+		$this->assertStringContainsString( '<option value="' . $chosen_rating . '"  selected', $output );
+	}
+
+	/** @see test_review_type_dropdown */
+	public function data_provider_test_review_rating_dropdown() : Generator {
+		yield 'All ratings'    => [ 0 ];
+		yield '1 star'         => [ 1 ];
+		yield '2 stars'        => [ 2 ];
+		yield '3 stars'        => [ 3 ];
+		yield '4 stars'        => [ 4 ];
+		yield '5 stars'        => [ 5 ];
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -844,7 +844,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( [], $args );
 
-		$property->setValue( $list_table, 1 );
+		$property->setValue( $list_table, 5 );
 
 		$args = $method->invoke( $list_table );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -823,6 +823,47 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can set the filter rating for the current request.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_filter_rating_arguments()
+	 *
+	 * @return void
+	 * @throws ReflectionException If reflected method or property don't exist.
+	 */
+	public function test_get_filter_rating_arguments() {
+		$list_table = $this->get_reviews_list_table();
+		$reflection = new ReflectionClass( $list_table );
+		$method = $reflection->getMethod( 'get_filter_rating_arguments' );
+		$method->setAccessible( true );
+		$property = $reflection->getProperty( 'current_reviews_rating' );
+		$property->setAccessible( true );
+
+		$property->setValue( $list_table, 0 );
+
+		$args = $method->invoke( $list_table );
+
+		$this->assertSame( [], $args );
+
+		$property->setValue( $list_table, 1 );
+
+		$args = $method->invoke( $list_table );
+
+		$this->assertEquals(
+			[
+				'meta_query' => [
+					[
+						'key'     => 'rating',
+						'value'   => 5,
+						'compare' => '=',
+						'type'    => 'NUMERIC',
+					],
+				],
+			],
+			$args
+		);
+	}
+
+	/**
 	 * Tests that can output the text for when no reviews are found.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::no_items()


### PR DESCRIPTION
# Summary

Implements the extra nav filter dropdown to list reviews by rating.

### Story: [MWC 5344](https://jira.godaddy.com/browse/MWC-5344)

### Base PR #23 

## Details

In PRP we list star ratings in the dropdown by adjectives equivalent (mediocre, good perfect etc.), but those labels are also utilized elsewhere in the site. The product document mentions:

>  “Rating” entries should be displayed out of 5 possible stars

So I wonder if we should use stars in the dropdown elements as well. I am aware that for accessibility stars html entities aren't great, so I have added a title element in each option.

## QA

- [x] Code review
- [x] Unit tests pass

### User testing

1. Have multiple reviews and replies in your installation - the reviews should have different rating levels
1. Go to the Products > Reviews page
    - [x] By default, all reviews and replies are visible and "All ratings" is the default type in the dropdown
1. For each star rating level, filter the reviews to show
    - [x] Comments are not included in the display (note this is the same behavior as PRP)
    - [x] The reviews matching the chosen rating are shown
    - [x] The sorting order is preserved

## Before merge

- [x] #22 is reviewed and merged first