### PR TITLE
Implement the product reviews product filter in the Product Reviews page

### DIFF
--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -29,6 +29,7 @@ function wc_get_screen_ids() {
 		'product_page_product_attributes',
 		'product_page_product_exporter',
 		'product_page_product_importer',
+		'product_page_product-reviews',
 		'edit-product',
 		'product',
 		'edit-shop_coupon',

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -724,7 +724,7 @@ class ReviewsListTable extends WP_List_Table {
 			data-action="woocommerce_json_search_products"
 			data-allow_clear="true">
 			<?php if ( $current_product instanceof WC_Product ) : ?>
-				<option value="<?php echo esc_attr( $current_product ); ?>" selected="selected"><?php echo esc_html( $current_product->get_formatted_name() ); ?></option>
+				<option value="<?php echo esc_attr( $current_product->get_id() ); ?>" selected="selected"><?php echo esc_html( $current_product->get_formatted_name() ); ?></option>
 			<?php endif; ?>
 		</select>
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -84,7 +84,7 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function set_review_product() {
+	protected function set_review_product() {
 
 		$product_id = isset( $_REQUEST['product_id'] ) ? absint( $_REQUEST['product_id'] ) : null;
 		$product = $product_id ? wc_get_product( $product_id ) : null;

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1198,8 +1198,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( '<label class="screen-reader-text" for="filter-by-product">Filter by product</label>', $output );
-		$this->assertStringContainsString( '<select id="filter-by-product" name="product_id">', $output );
-		$this->assertStringContainsString( '<option value="' . $product->get_id() . '"  selected', $output );
+		$this->assertStringContainsString( '<option value="' . $product->get_id() . '"', $output );
 	}
 
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -882,7 +882,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$product = WC_Helper_Product::create_simple_product( true );
 
-		$property->setValue( $product );
+		$property->setValue( $list_table, $product );
 
 		$this->assertSame( [ 'post_id' => $product->get_id() ], $method->invoke( $list_table ) );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1175,4 +1175,30 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		yield 'Replies'      => [ 'comment' ];
 		yield 'Reviews'      => [ 'review' ];
 	}
+
+	/**
+	 * Tests that can output a product search field for the product in context.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::product_search()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method is not defined.
+	 */
+	public function test_product_search() {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'product_search' );
+		$method->setAccessible( true );
+
+		$product = WC_Helper_Product::create_simple_product( false );
+
+		ob_start();
+
+		$method->invokeArgs( $list_table, [ $product ] );
+
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<label class="screen-reader-text" for="filter-by-product">Filter by product</label>', $output );
+		$this->assertStringContainsString( '<select id="filter-by-product" name="product_id">', $output );
+		$this->assertStringContainsString( '<option value="' . $product->get_id() . '"  selected', $output );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -624,6 +624,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$this->assertSame( $product->get_id(), $property->getValue( $list_table )->get_id() );
 
 		WC_Helper_Product::delete_product( $product->get_id() );
+
+		unset( $_REQUEST['product_id'] );
 	}
 
 	/**
@@ -858,6 +860,33 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		yield 'Replies'           => [ 'comment', 'comment' ];
 		yield 'Reviews'           => [ 'review', 'review' ];
 		yield 'Other'             => [ 'other', 'other' ];
+	}
+
+	/**
+	 * Tests that can get the post ID argument for the current request.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_filter_product_arguments()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method or the property don't exist.
+	 */
+	public function test_get_filter_product_arguments() {
+		$list_table = $this->get_reviews_list_table();
+		$reflection = new ReflectionClass( $list_table );
+		$method = $reflection->getMethod( 'get_filter_product_arguments' );
+		$method->setAccessible( true );
+		$property = $reflection->getProperty( 'current_product_for_reviews' );
+		$property->setAccessible( true );
+
+		$this->assertSame( [], $method->invoke( $list_table ) );
+
+		$product = WC_Helper_Product::create_simple_product( true );
+
+		$property->setValue( $product );
+
+		$this->assertSame( [ 'post_id' => $product->get_id() ], $method->invoke( $list_table ) );
+
+		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\Internal\Admin\ReviewsListTable;
 use Generator;
 use ReflectionClass;
 use ReflectionException;
+use WC_Helper_Product;
 use WC_Unit_Test_Case;
 
 /**
@@ -590,6 +591,39 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 				'delete',
 			],
 		];
+	}
+
+	/**
+	 * Tests that can set the product to filter reviews by.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::set_review_product()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method or the property do not exist.
+	 */
+	public function test_set_review_product() {
+		$list_table = $this->get_reviews_list_table();
+		$reflection = new ReflectionClass( $list_table );
+		$method = $reflection->getMethod( 'set_review_product' );
+		$method->setAccessible( true );
+		$property = $reflection->getProperty( 'current_product_for_reviews' );
+		$property->setAccessible( true );
+
+		$_REQUEST['product_id'] = 0;
+
+		$method->invoke( $list_table );
+
+		$this->assertNull( $property->getValue( $list_table ) );
+
+		$product = WC_Helper_Product::create_simple_product( true );
+
+		$_REQUEST['product_id'] = $product->get_id();
+
+		$method->invoke( $list_table );
+
+		$this->assertSame( $product->get_id(), $property->getValue( $list_table )->get_id() );
+
+		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1201,4 +1201,5 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( '<select id="filter-by-product" name="product_id">', $output );
 		$this->assertStringContainsString( '<option value="' . $product->get_id() . '"  selected', $output );
 	}
+
 }


### PR DESCRIPTION
# Summary

Implements the extra nav filter dropdown to list reviews by product.

### Story: [MWC 5345](https://jira.godaddy.com/browse/MWC-5345)

### Base PR #23 

## Details

To enable select2 on the product reviews page I needed to add the page ID to the list of WC screens.

## QA

- [x] Code review
- [x] Unit tests pass

### User testing

1. Have at least 2 or more products in your installation
1. Have multiple reviews and replies in your installation for each product
1. Go to the Products > Reviews page
    - [x] By default, all reviews and replies are visible and the product search field is "Search for a product..."
1. Search for a product and filter the reviews
    - [x] Only reviews/replies for the given product are shown
    - [x] Other filter parameters are also honored
    - [x] Sorting order is preserved

## Before merge

- [x] #22 is reviewed and merged first