### PR TITLE
Implement reviews row actions for the Product reviews page table

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -148,6 +148,213 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Generate and display row actions links.
+	 *
+	 * @see WP_Comments_List_Table::handle_row_actions() for consistency.
+	 *
+	 * @global string $comment_status Status for the current listed comments.
+	 *
+	 * @param WP_Comment $review         The product review or reply in context.
+	 * @param string     $column_name    Current column name.
+	 * @param string     $primary_column Primary column name.
+	 * @return string
+	 */
+	protected function handle_row_actions( $review, $column_name, $primary_column ) {
+		global $comment_status;
+
+		if ( $primary_column !== $column_name || ! $this->current_user_can_edit_review ) {
+			return '';
+		}
+
+		$review_status = wp_get_comment_status( $review );
+
+		$del_nonce     = esc_html( '_wpnonce=' . wp_create_nonce( "delete-comment_$review->comment_ID" ) );
+		$approve_nonce = esc_html( '_wpnonce=' . wp_create_nonce( "approve-comment_$review->comment_ID" ) );
+
+		$url = "comment.php?c=$review->comment_ID";
+
+		$approve_url   = esc_url( $url . "&action=approvecomment&$approve_nonce" );
+		$unapprove_url = esc_url( $url . "&action=unapprovecomment&$approve_nonce" );
+		$spam_url      = esc_url( $url . "&action=spamcomment&$del_nonce" );
+		$unspam_url    = esc_url( $url . "&action=unspamcomment&$del_nonce" );
+		$trash_url     = esc_url( $url . "&action=trashcomment&$del_nonce" );
+		$untrash_url   = esc_url( $url . "&action=untrashcomment&$del_nonce" );
+		$delete_url    = esc_url( $url . "&action=deletecomment&$del_nonce" );
+
+		// Pre-ordered actions: Approve/Unapprove | Reply | Quick Edit | Edit | Spam/Unspam | Trash/Untrash/Delete Permanently.
+		$actions = [
+			'approve'   => '',
+			'unapprove' => '',
+			'reply'     => '',
+			'quickedit' => '',
+			'edit'      => '',
+			'spam'      => '',
+			'unspam'    => '',
+			'trash'     => '',
+			'untrash'   => '',
+			'delete'    => '',
+		];
+
+		if ( $comment_status && 'all' !== $comment_status ) {
+			if ( 'approved' === $review_status ) {
+				$actions['unapprove'] = sprintf(
+					'<a href="%s" data-wp-lists="%s" class="vim-u vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+					$unapprove_url,
+					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved",
+					esc_attr__( 'Unapprove this review', 'woocommerce' ),
+					__( 'Unapprove', 'woocommerce' )
+				);
+			} elseif ( 'unapproved' === $review_status ) {
+				$actions['approve'] = sprintf(
+					'<a href="%s" data-wp-lists="%s" class="vim-a vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+					$approve_url,
+					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved",
+					esc_attr__( 'Approve this review', 'woocommerce' ),
+					__( 'Approve', 'woocommerce' )
+				);
+			}
+		} else {
+			$actions['approve'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-a aria-button-if-js" aria-label="%s">%s</a>',
+				$approve_url,
+				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved",
+				esc_attr__( 'Approve this review', 'woocommerce' ),
+				__( 'Approve', 'woocommerce' )
+			);
+
+			$actions['unapprove'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-u aria-button-if-js" aria-label="%s">%s</a>',
+				$unapprove_url,
+				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved",
+				esc_attr__( 'Unapprove this review', 'woocommerce' ),
+				__( 'Unapprove', 'woocommerce' )
+			);
+		}
+
+		if ( 'spam' !== $review_status ) {
+			$actions['spam'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-s vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				$spam_url,
+				"delete:the-comment-list:comment-{$review->comment_ID}::spam=1",
+				esc_attr__( 'Mark this review as spam', 'woocommerce' ),
+				/* translators: "Mark as spam" link. */
+				_x( 'Spam', 'verb', 'woocommerce' )
+			);
+		} else {
+			$actions['unspam'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				$unspam_url,
+				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:unspam=1",
+				esc_attr__( 'Restore this review from the spam', 'woocommerce' ),
+				_x( 'Not Spam', 'review', 'woocommerce' )
+			);
+		}
+
+		if ( 'trash' === $review_status ) {
+			$actions['untrash'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				$untrash_url,
+				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:untrash=1",
+				esc_attr__( 'Restore this review from the Trash', 'woocommerce' ),
+				__( 'Restore', 'woocommerce' )
+			);
+		}
+
+		if ( 'spam' === $review_status || 'trash' === $review_status || ! EMPTY_TRASH_DAYS ) {
+			$actions['delete'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				$delete_url,
+				"delete:the-comment-list:comment-{$review->comment_ID}::delete=1",
+				esc_attr__( 'Delete this review permanently', 'woocommerce' ),
+				__( 'Delete Permanently', 'woocommerce' )
+			);
+		} else {
+			$actions['trash'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				$trash_url,
+				"delete:the-comment-list:comment-{$review->comment_ID}::trash=1",
+				esc_attr__( 'Move this review to the Trash', 'woocommerce' ),
+				_x( 'Trash', 'verb', 'woocommerce' )
+			);
+		}
+
+		if ( 'spam' !== $review_status && 'trash' !== $review_status ) {
+			$actions['edit'] = sprintf(
+				'<a href="%s" aria-label="%s">%s</a>',
+				"comment.php?action=editcomment&amp;c={$review->comment_ID}",
+				esc_attr__( 'Edit this review', 'woocommerce' ),
+				__( 'Edit', 'woocommerce' )
+			);
+
+			$format = '<button type="button" data-comment-id="%d" data-post-id="%d" data-action="%s" class="%s button-link" aria-expanded="false" aria-label="%s">%s</button>';
+
+			$actions['quickedit'] = sprintf(
+				$format,
+				$review->comment_ID,
+				$review->comment_post_ID,
+				'edit',
+				'vim-q comment-inline',
+				esc_attr__( 'Quick edit this review inline', 'woocommerce' ),
+				__( 'Quick&nbsp;Edit', 'woocommerce' )
+			);
+
+			$actions['reply'] = sprintf(
+				$format,
+				$review->comment_ID,
+				$review->comment_post_ID,
+				'replyto',
+				'vim-r comment-inline',
+				esc_attr__( 'Reply to this review', 'woocommerce' ),
+				__( 'Reply', 'woocommerce' )
+			);
+		}
+
+		/** This filter is documented in wp-admin/includes/dashboard.php */
+		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $review );
+
+		$always_visible = false;
+
+		$mode = get_user_setting( 'posts_list_mode', 'list' );
+
+		if ( 'excerpt' === $mode ) {
+			$always_visible = true;
+		}
+
+		$output = '<div class="' . ( $always_visible ? 'row-actions visible' : 'row-actions' ) . '">';
+
+		$i = 0;
+
+		foreach ( $actions as $action => $link ) {
+			++$i;
+
+			if ( ( ( 'approve' === $action || 'unapprove' === $action ) && 2 === $i ) || 1 === $i ) {
+				$sep = '';
+			} else {
+				$sep = ' | ';
+			}
+
+			// Reply and quickedit need a hide-if-no-js span when not added with Ajax.
+			if ( ( 'reply' === $action || 'quickedit' === $action ) && ! wp_doing_ajax() ) {
+				$action .= ' hide-if-no-js';
+			} elseif ( ( 'untrash' === $action && 'trash' === $review_status ) || ( 'unspam' === $action && 'spam' === $review_status ) ) {
+				if ( '1' === get_comment_meta( $review->comment_ID, '_wp_trash_meta_status', true ) ) {
+					$action .= ' approve';
+				} else {
+					$action .= ' unapprove';
+				}
+			}
+
+			$output .= "<span class='$action'>$sep$link</span>";
+		}
+
+		$output .= '</div>';
+
+		$output .= '<button type="button" class="toggle-row"><span class="screen-reader-text">' . __( 'Show more details', 'woocommerce' ) . '</span></button>';
+
+		return $output;
+	}
+
+	/**
 	 * Returns the columns for the table.
 	 *
 	 * @return array Table columns and their headings.

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -290,7 +290,12 @@ class ReviewsListTable extends WP_List_Table {
 		$del_nonce     = esc_html( '_wpnonce=' . wp_create_nonce( "delete-comment_$review->comment_ID" ) );
 		$approve_nonce = esc_html( '_wpnonce=' . wp_create_nonce( "approve-comment_$review->comment_ID" ) );
 
-		$url = "comment.php?c=$review->comment_ID";
+		$url = add_query_arg(
+			[
+				'c' => urlencode( $review->comment_ID ),
+			],
+			admin_url( 'comment.php' )
+		);
 
 		$approve_url   = $url . "&action=approvecomment&$approve_nonce";
 		$unapprove_url = $url . "&action=unapprovecomment&$approve_nonce";

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -181,7 +181,6 @@ class ReviewsListTable extends WP_List_Table {
 		$untrash_url   = esc_url( $url . "&action=untrashcomment&$del_nonce" );
 		$delete_url    = esc_url( $url . "&action=deletecomment&$del_nonce" );
 
-		// Pre-ordered actions: Approve/Unapprove | Reply | Quick Edit | Edit | Spam/Unspam | Trash/Untrash/Delete Permanently.
 		$actions = [
 			'approve'   => '',
 			'unapprove' => '',
@@ -312,13 +311,7 @@ class ReviewsListTable extends WP_List_Table {
 		/** This filter is documented in wp-admin/includes/dashboard.php */
 		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $review );
 
-		$always_visible = false;
-
-		$mode = get_user_setting( 'posts_list_mode', 'list' );
-
-		if ( 'excerpt' === $mode ) {
-			$always_visible = true;
-		}
+		$always_visible = 'excerpt' === get_user_setting( 'posts_list_mode', 'list' );
 
 		$output = '<div class="' . ( $always_visible ? 'row-actions visible' : 'row-actions' ) . '">';
 
@@ -333,7 +326,6 @@ class ReviewsListTable extends WP_List_Table {
 				$sep = ' | ';
 			}
 
-			// Reply and quickedit need a hide-if-no-js span when not added with Ajax.
 			if ( ( 'reply' === $action || 'quickedit' === $action ) && ! wp_doing_ajax() ) {
 				$action .= ' hide-if-no-js';
 			} elseif ( ( 'untrash' === $action && 'trash' === $review_status ) || ( 'unspam' === $action && 'spam' === $review_status ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -320,7 +320,7 @@ class ReviewsListTable extends WP_List_Table {
 					$unapprove_url,
 					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved",
 					esc_attr__( 'Unapprove this review', 'woocommerce' ),
-					__( 'Unapprove', 'woocommerce' )
+					esc_html__( 'Unapprove', 'woocommerce' )
 				);
 			} elseif ( 'unapproved' === $review_status ) {
 				$actions['approve'] = sprintf(
@@ -328,7 +328,7 @@ class ReviewsListTable extends WP_List_Table {
 					$approve_url,
 					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved",
 					esc_attr__( 'Approve this review', 'woocommerce' ),
-					__( 'Approve', 'woocommerce' )
+					esc_html__( 'Approve', 'woocommerce' )
 				);
 			}
 		} else {
@@ -337,7 +337,7 @@ class ReviewsListTable extends WP_List_Table {
 				$approve_url,
 				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved",
 				esc_attr__( 'Approve this review', 'woocommerce' ),
-				__( 'Approve', 'woocommerce' )
+				esc_html__( 'Approve', 'woocommerce' )
 			);
 
 			$actions['unapprove'] = sprintf(
@@ -345,7 +345,7 @@ class ReviewsListTable extends WP_List_Table {
 				$unapprove_url,
 				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved",
 				esc_attr__( 'Unapprove this review', 'woocommerce' ),
-				__( 'Unapprove', 'woocommerce' )
+				esc_html__( 'Unapprove', 'woocommerce' )
 			);
 		}
 
@@ -356,7 +356,7 @@ class ReviewsListTable extends WP_List_Table {
 				"delete:the-comment-list:comment-{$review->comment_ID}::spam=1",
 				esc_attr__( 'Mark this review as spam', 'woocommerce' ),
 				/* translators: "Mark as spam" link. */
-				_x( 'Spam', 'verb', 'woocommerce' )
+				esc_html_x( 'Spam', 'verb', 'woocommerce' )
 			);
 		} else {
 			$actions['unspam'] = sprintf(
@@ -364,7 +364,7 @@ class ReviewsListTable extends WP_List_Table {
 				$unspam_url,
 				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:unspam=1",
 				esc_attr__( 'Restore this review from the spam', 'woocommerce' ),
-				_x( 'Not Spam', 'review', 'woocommerce' )
+				esc_html_x( 'Not Spam', 'review', 'woocommerce' )
 			);
 		}
 
@@ -374,7 +374,7 @@ class ReviewsListTable extends WP_List_Table {
 				$untrash_url,
 				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:untrash=1",
 				esc_attr__( 'Restore this review from the Trash', 'woocommerce' ),
-				__( 'Restore', 'woocommerce' )
+				esc_html__( 'Restore', 'woocommerce' )
 			);
 		}
 
@@ -384,7 +384,7 @@ class ReviewsListTable extends WP_List_Table {
 				$delete_url,
 				"delete:the-comment-list:comment-{$review->comment_ID}::delete=1",
 				esc_attr__( 'Delete this review permanently', 'woocommerce' ),
-				__( 'Delete Permanently', 'woocommerce' )
+				esc_html__( 'Delete Permanently', 'woocommerce' )
 			);
 		} else {
 			$actions['trash'] = sprintf(
@@ -392,7 +392,7 @@ class ReviewsListTable extends WP_List_Table {
 				$trash_url,
 				"delete:the-comment-list:comment-{$review->comment_ID}::trash=1",
 				esc_attr__( 'Move this review to the Trash', 'woocommerce' ),
-				_x( 'Trash', 'verb', 'woocommerce' )
+				esc_html_x( 'Trash', 'verb', 'woocommerce' )
 			);
 		}
 
@@ -401,29 +401,29 @@ class ReviewsListTable extends WP_List_Table {
 				'<a href="%s" aria-label="%s">%s</a>',
 				"comment.php?action=editcomment&amp;c={$review->comment_ID}",
 				esc_attr__( 'Edit this review', 'woocommerce' ),
-				__( 'Edit', 'woocommerce' )
+				esc_html__( 'Edit', 'woocommerce' )
 			);
 
 			$format = '<button type="button" data-comment-id="%d" data-post-id="%d" data-action="%s" class="%s button-link" aria-expanded="false" aria-label="%s">%s</button>';
 
 			$actions['quickedit'] = sprintf(
 				$format,
-				$review->comment_ID,
-				$review->comment_post_ID,
+				esc_attr( $review->comment_ID ),
+				esc_attr( $review->comment_post_ID ),
 				'edit',
 				'vim-q comment-inline',
 				esc_attr__( 'Quick edit this review inline', 'woocommerce' ),
-				__( 'Quick&nbsp;Edit', 'woocommerce' )
+				esc_html__( 'Quick Edit', 'woocommerce' )
 			);
 
 			$actions['reply'] = sprintf(
 				$format,
-				$review->comment_ID,
-				$review->comment_post_ID,
+				esc_attr( $review->comment_ID ),
+				esc_attr( $review->comment_post_ID ),
 				'replyto',
 				'vim-r comment-inline',
 				esc_attr__( 'Reply to this review', 'woocommerce' ),
-				__( 'Reply', 'woocommerce' )
+				esc_html__( 'Reply', 'woocommerce' )
 			);
 		}
 
@@ -460,7 +460,7 @@ class ReviewsListTable extends WP_List_Table {
 
 		$output .= '</div>';
 
-		$output .= '<button type="button" class="toggle-row"><span class="screen-reader-text">' . __( 'Show more details', 'woocommerce' ) . '</span></button>';
+		$output .= '<button type="button" class="toggle-row"><span class="screen-reader-text">' . esc_html__( 'Show more details', 'woocommerce' ) . '</span></button>';
 
 		return $output;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -318,7 +318,7 @@ class ReviewsListTable extends WP_List_Table {
 				$actions['unapprove'] = sprintf(
 					'<a href="%s" data-wp-lists="%s" class="vim-u vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 					esc_url( $unapprove_url ),
-					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved",
+					esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved" ),
 					esc_attr__( 'Unapprove this review', 'woocommerce' ),
 					esc_html__( 'Unapprove', 'woocommerce' )
 				);
@@ -326,7 +326,7 @@ class ReviewsListTable extends WP_List_Table {
 				$actions['approve'] = sprintf(
 					'<a href="%s" data-wp-lists="%s" class="vim-a vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 					esc_url( $approve_url ),
-					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved",
+					esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved" ),
 					esc_attr__( 'Approve this review', 'woocommerce' ),
 					esc_html__( 'Approve', 'woocommerce' )
 				);
@@ -335,7 +335,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['approve'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-a aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $approve_url ),
-				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved",
+				esc_attr( "dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved" ),
 				esc_attr__( 'Approve this review', 'woocommerce' ),
 				esc_html__( 'Approve', 'woocommerce' )
 			);
@@ -343,7 +343,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['unapprove'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-u aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $unapprove_url ),
-				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved",
+				esc_attr( "dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved" ),
 				esc_attr__( 'Unapprove this review', 'woocommerce' ),
 				esc_html__( 'Unapprove', 'woocommerce' )
 			);
@@ -353,7 +353,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['spam'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-s vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $spam_url ),
-				"delete:the-comment-list:comment-{$review->comment_ID}::spam=1",
+				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}::spam=1" ),
 				esc_attr__( 'Mark this review as spam', 'woocommerce' ),
 				/* translators: "Mark as spam" link. */
 				esc_html_x( 'Spam', 'verb', 'woocommerce' )
@@ -362,7 +362,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['unspam'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $unspam_url ),
-				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:unspam=1",
+				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:66cc66:unspam=1" ),
 				esc_attr__( 'Restore this review from the spam', 'woocommerce' ),
 				esc_html_x( 'Not Spam', 'review', 'woocommerce' )
 			);
@@ -372,7 +372,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['untrash'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $untrash_url ),
-				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:untrash=1",
+				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:66cc66:untrash=1" ),
 				esc_attr__( 'Restore this review from the Trash', 'woocommerce' ),
 				esc_html__( 'Restore', 'woocommerce' )
 			);
@@ -382,7 +382,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['delete'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $delete_url ),
-				"delete:the-comment-list:comment-{$review->comment_ID}::delete=1",
+				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}::delete=1" ),
 				esc_attr__( 'Delete this review permanently', 'woocommerce' ),
 				esc_html__( 'Delete Permanently', 'woocommerce' )
 			);
@@ -390,7 +390,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['trash'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $trash_url ),
-				"delete:the-comment-list:comment-{$review->comment_ID}::trash=1",
+				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}::trash=1" ),
 				esc_attr__( 'Move this review to the Trash', 'woocommerce' ),
 				esc_html_x( 'Trash', 'verb', 'woocommerce' )
 			);
@@ -399,7 +399,15 @@ class ReviewsListTable extends WP_List_Table {
 		if ( 'spam' !== $review_status && 'trash' !== $review_status ) {
 			$actions['edit'] = sprintf(
 				'<a href="%s" aria-label="%s">%s</a>',
-				esc_url( "comment.php?action=editcomment&amp;c={$review->comment_ID}" ),
+				esc_url(
+					add_query_arg(
+						[
+							'action' => 'editcomment',
+							'c'      => urlencode( $review->comment_ID ),
+						],
+						admin_url( 'comment.php' )
+					)
+				),
 				esc_attr__( 'Edit this review', 'woocommerce' ),
 				esc_html__( 'Edit', 'woocommerce' )
 			);

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -456,9 +456,6 @@ class ReviewsListTable extends WP_List_Table {
 			);
 		}
 
-		/** This filter is documented in wp-admin/includes/dashboard.php */
-		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $item );
-
 		$always_visible = 'excerpt' === get_user_setting( 'posts_list_mode', 'list' );
 
 		$output = '<div class="' . ( $always_visible ? 'row-actions visible' : 'row-actions' ) . '">';
@@ -713,13 +710,12 @@ class ReviewsListTable extends WP_List_Table {
 
 		if ( $this->current_user_can_edit_review ) :
 
-			if ( ! empty( $item->comment_author_email ) ) :
-				/** This filter is documented in wp-includes/comment-template.php */
-				$email = apply_filters( 'comment_email', $item->comment_author_email, $item );
+			if ( ! empty( $item->comment_author_email ) && is_email( $item->comment_author_email ) ) :
 
-				if ( ! empty( $email ) && '@' !== $email ) {
-					printf( '<a href="%1$s">%2$s</a><br />', esc_url( 'mailto:' . $email ), esc_html( $email ) );
-				}
+				?>
+				<a href="mailto:<?php echo esc_attr( $item->comment_author_email ); ?>"><?php echo esc_html( $item->comment_author_email ); ?></a>
+				<?php
+
 			endif;
 
 			$link = add_query_arg(

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -286,8 +286,6 @@ class ReviewsListTable extends WP_List_Table {
 		}
 
 		$review_status = wp_get_comment_status( $item );
-		$del_nonce     = esc_html( '_wpnonce=' . wp_create_nonce( "delete-comment_$item->comment_ID" ) );
-		$approve_nonce = esc_html( '_wpnonce=' . wp_create_nonce( "approve-comment_$item->comment_ID" ) );
 
 		$url = add_query_arg(
 			[
@@ -296,13 +294,13 @@ class ReviewsListTable extends WP_List_Table {
 			admin_url( 'comment.php' )
 		);
 
-		$approve_url   = $url . "&action=approvecomment&$approve_nonce";
-		$unapprove_url = $url . "&action=unapprovecomment&$approve_nonce";
-		$spam_url      = $url . "&action=spamcomment&$del_nonce";
-		$unspam_url    = $url . "&action=unspamcomment&$del_nonce";
-		$trash_url     = $url . "&action=trashcomment&$del_nonce";
-		$untrash_url   = $url . "&action=untrashcomment&$del_nonce";
-		$delete_url    = $url . "&action=deletecomment&$del_nonce";
+		$approve_url   = wp_nonce_url( add_query_arg( 'action', 'approvecomment', $url ), "approve-comment_$item->comment_ID" );
+		$unapprove_url = wp_nonce_url( add_query_arg( 'action', 'unapprovecomment', $url ), "approve-comment_$item->comment_ID" );
+		$spam_url      = wp_nonce_url( add_query_arg( 'action', 'spamcomment', $url ), "delete-comment_$item->comment_ID" );
+		$unspam_url    = wp_nonce_url( add_query_arg( 'action', 'unspamcomment', $url ), "delete-comment_$item->comment_ID" );
+		$trash_url     = wp_nonce_url( add_query_arg( 'action', 'trashcomment', $url ), "delete-comment_$item->comment_ID" );
+		$untrash_url   = wp_nonce_url( add_query_arg( 'action', 'untrashcomment', $url ), "delete-comment_$item->comment_ID" );
+		$delete_url    = wp_nonce_url( add_query_arg( 'action', 'deletecomment', $url ), "delete-comment_$item->comment_ID" );
 
 		$actions = [
 			'approve'   => '',

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -273,26 +273,25 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @global string $comment_status Status for the current listed comments.
 	 *
-	 * @param WP_Comment $review         The product review or reply in context.
-	 * @param string     $column_name    Current column name.
-	 * @param string     $primary_column Primary column name.
+	 * @param WP_Comment $item        The product review or reply in context.
+	 * @param string     $column_name Current column name.
+	 * @param string     $primary     Primary column name.
 	 * @return string
 	 */
-	protected function handle_row_actions( $review, $column_name, $primary_column ) {
+	protected function handle_row_actions( $item, $column_name, $primary ) {
 		global $comment_status;
 
-		if ( $primary_column !== $column_name || ! $this->current_user_can_edit_review ) {
+		if ( $primary !== $column_name || ! $this->current_user_can_edit_review ) {
 			return '';
 		}
 
-		$review_status = wp_get_comment_status( $review );
-
-		$del_nonce     = esc_html( '_wpnonce=' . wp_create_nonce( "delete-comment_$review->comment_ID" ) );
-		$approve_nonce = esc_html( '_wpnonce=' . wp_create_nonce( "approve-comment_$review->comment_ID" ) );
+		$review_status = wp_get_comment_status( $item );
+		$del_nonce     = esc_html( '_wpnonce=' . wp_create_nonce( "delete-comment_$item->comment_ID" ) );
+		$approve_nonce = esc_html( '_wpnonce=' . wp_create_nonce( "approve-comment_$item->comment_ID" ) );
 
 		$url = add_query_arg(
 			[
-				'c' => urlencode( $review->comment_ID ),
+				'c' => urlencode( $item->comment_ID ),
 			],
 			admin_url( 'comment.php' )
 		);
@@ -323,7 +322,7 @@ class ReviewsListTable extends WP_List_Table {
 				$actions['unapprove'] = sprintf(
 					'<a href="%s" data-wp-lists="%s" class="vim-u vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 					esc_url( $unapprove_url ),
-					esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved" ),
+					esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved" ),
 					esc_attr__( 'Unapprove this review', 'woocommerce' ),
 					esc_html__( 'Unapprove', 'woocommerce' )
 				);
@@ -331,7 +330,7 @@ class ReviewsListTable extends WP_List_Table {
 				$actions['approve'] = sprintf(
 					'<a href="%s" data-wp-lists="%s" class="vim-a vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 					esc_url( $approve_url ),
-					esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved" ),
+					esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved" ),
 					esc_attr__( 'Approve this review', 'woocommerce' ),
 					esc_html__( 'Approve', 'woocommerce' )
 				);
@@ -340,7 +339,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['approve'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-a aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $approve_url ),
-				esc_attr( "dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved" ),
+				esc_attr( "dim:the-comment-list:comment-{$item->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved" ),
 				esc_attr__( 'Approve this review', 'woocommerce' ),
 				esc_html__( 'Approve', 'woocommerce' )
 			);
@@ -348,7 +347,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['unapprove'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-u aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $unapprove_url ),
-				esc_attr( "dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved" ),
+				esc_attr( "dim:the-comment-list:comment-{$item->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved" ),
 				esc_attr__( 'Unapprove this review', 'woocommerce' ),
 				esc_html__( 'Unapprove', 'woocommerce' )
 			);
@@ -358,7 +357,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['spam'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-s vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $spam_url ),
-				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}::spam=1" ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}::spam=1" ),
 				esc_attr__( 'Mark this review as spam', 'woocommerce' ),
 				/* translators: "Mark as spam" link. */
 				esc_html_x( 'Spam', 'verb', 'woocommerce' )
@@ -367,7 +366,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['unspam'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $unspam_url ),
-				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:66cc66:unspam=1" ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:66cc66:unspam=1" ),
 				esc_attr__( 'Restore this review from the spam', 'woocommerce' ),
 				esc_html_x( 'Not Spam', 'review', 'woocommerce' )
 			);
@@ -377,7 +376,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['untrash'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $untrash_url ),
-				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}:66cc66:untrash=1" ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:66cc66:untrash=1" ),
 				esc_attr__( 'Restore this review from the Trash', 'woocommerce' ),
 				esc_html__( 'Restore', 'woocommerce' )
 			);
@@ -387,7 +386,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['delete'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $delete_url ),
-				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}::delete=1" ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}::delete=1" ),
 				esc_attr__( 'Delete this review permanently', 'woocommerce' ),
 				esc_html__( 'Delete Permanently', 'woocommerce' )
 			);
@@ -395,7 +394,7 @@ class ReviewsListTable extends WP_List_Table {
 			$actions['trash'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
 				esc_url( $trash_url ),
-				esc_attr( "delete:the-comment-list:comment-{$review->comment_ID}::trash=1" ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}::trash=1" ),
 				esc_attr__( 'Move this review to the Trash', 'woocommerce' ),
 				esc_html_x( 'Trash', 'verb', 'woocommerce' )
 			);
@@ -408,7 +407,7 @@ class ReviewsListTable extends WP_List_Table {
 					add_query_arg(
 						[
 							'action' => 'editcomment',
-							'c'      => urlencode( $review->comment_ID ),
+							'c'      => urlencode( $item->comment_ID ),
 						],
 						admin_url( 'comment.php' )
 					)
@@ -421,8 +420,8 @@ class ReviewsListTable extends WP_List_Table {
 
 			$actions['quickedit'] = sprintf(
 				$format,
-				esc_attr( $review->comment_ID ),
-				esc_attr( $review->comment_post_ID ),
+				esc_attr( $item->comment_ID ),
+				esc_attr( $item->comment_post_ID ),
 				'edit',
 				'vim-q comment-inline',
 				esc_attr__( 'Quick edit this review inline', 'woocommerce' ),
@@ -431,8 +430,8 @@ class ReviewsListTable extends WP_List_Table {
 
 			$actions['reply'] = sprintf(
 				$format,
-				esc_attr( $review->comment_ID ),
-				esc_attr( $review->comment_post_ID ),
+				esc_attr( $item->comment_ID ),
+				esc_attr( $item->comment_post_ID ),
 				'replyto',
 				'vim-r comment-inline',
 				esc_attr__( 'Reply to this review', 'woocommerce' ),
@@ -441,7 +440,7 @@ class ReviewsListTable extends WP_List_Table {
 		}
 
 		/** This filter is documented in wp-admin/includes/dashboard.php */
-		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $review );
+		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $item );
 
 		$always_visible = 'excerpt' === get_user_setting( 'posts_list_mode', 'list' );
 
@@ -461,7 +460,7 @@ class ReviewsListTable extends WP_List_Table {
 			if ( ( 'reply' === $action || 'quickedit' === $action ) && ! wp_doing_ajax() ) {
 				$action .= ' hide-if-no-js';
 			} elseif ( ( 'untrash' === $action && 'trash' === $review_status ) || ( 'unspam' === $action && 'spam' === $review_status ) ) {
-				if ( '1' === get_comment_meta( $review->comment_ID, '_wp_trash_meta_status', true ) ) {
+				if ( '1' === get_comment_meta( $item->comment_ID, '_wp_trash_meta_status', true ) ) {
 					$action .= ' approve';
 				} else {
 					$action .= ' unapprove';

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -292,13 +292,13 @@ class ReviewsListTable extends WP_List_Table {
 
 		$url = "comment.php?c=$review->comment_ID";
 
-		$approve_url   = esc_url( $url . "&action=approvecomment&$approve_nonce" );
-		$unapprove_url = esc_url( $url . "&action=unapprovecomment&$approve_nonce" );
-		$spam_url      = esc_url( $url . "&action=spamcomment&$del_nonce" );
-		$unspam_url    = esc_url( $url . "&action=unspamcomment&$del_nonce" );
-		$trash_url     = esc_url( $url . "&action=trashcomment&$del_nonce" );
-		$untrash_url   = esc_url( $url . "&action=untrashcomment&$del_nonce" );
-		$delete_url    = esc_url( $url . "&action=deletecomment&$del_nonce" );
+		$approve_url   = $url . "&action=approvecomment&$approve_nonce";
+		$unapprove_url = $url . "&action=unapprovecomment&$approve_nonce";
+		$spam_url      = $url . "&action=spamcomment&$del_nonce";
+		$unspam_url    = $url . "&action=unspamcomment&$del_nonce";
+		$trash_url     = $url . "&action=trashcomment&$del_nonce";
+		$untrash_url   = $url . "&action=untrashcomment&$del_nonce";
+		$delete_url    = $url . "&action=deletecomment&$del_nonce";
 
 		$actions = [
 			'approve'   => '',
@@ -317,7 +317,7 @@ class ReviewsListTable extends WP_List_Table {
 			if ( 'approved' === $review_status ) {
 				$actions['unapprove'] = sprintf(
 					'<a href="%s" data-wp-lists="%s" class="vim-u vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
-					$unapprove_url,
+					esc_url( $unapprove_url ),
 					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved",
 					esc_attr__( 'Unapprove this review', 'woocommerce' ),
 					esc_html__( 'Unapprove', 'woocommerce' )
@@ -325,7 +325,7 @@ class ReviewsListTable extends WP_List_Table {
 			} elseif ( 'unapproved' === $review_status ) {
 				$actions['approve'] = sprintf(
 					'<a href="%s" data-wp-lists="%s" class="vim-a vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
-					$approve_url,
+					esc_url( $approve_url ),
 					"delete:the-comment-list:comment-{$review->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved",
 					esc_attr__( 'Approve this review', 'woocommerce' ),
 					esc_html__( 'Approve', 'woocommerce' )
@@ -334,7 +334,7 @@ class ReviewsListTable extends WP_List_Table {
 		} else {
 			$actions['approve'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-a aria-button-if-js" aria-label="%s">%s</a>',
-				$approve_url,
+				esc_url( $approve_url ),
 				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved",
 				esc_attr__( 'Approve this review', 'woocommerce' ),
 				esc_html__( 'Approve', 'woocommerce' )
@@ -342,7 +342,7 @@ class ReviewsListTable extends WP_List_Table {
 
 			$actions['unapprove'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-u aria-button-if-js" aria-label="%s">%s</a>',
-				$unapprove_url,
+				esc_url( $unapprove_url ),
 				"dim:the-comment-list:comment-{$review->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved",
 				esc_attr__( 'Unapprove this review', 'woocommerce' ),
 				esc_html__( 'Unapprove', 'woocommerce' )
@@ -352,7 +352,7 @@ class ReviewsListTable extends WP_List_Table {
 		if ( 'spam' !== $review_status ) {
 			$actions['spam'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-s vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
-				$spam_url,
+				esc_url( $spam_url ),
 				"delete:the-comment-list:comment-{$review->comment_ID}::spam=1",
 				esc_attr__( 'Mark this review as spam', 'woocommerce' ),
 				/* translators: "Mark as spam" link. */
@@ -361,7 +361,7 @@ class ReviewsListTable extends WP_List_Table {
 		} else {
 			$actions['unspam'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
-				$unspam_url,
+				esc_url( $unspam_url ),
 				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:unspam=1",
 				esc_attr__( 'Restore this review from the spam', 'woocommerce' ),
 				esc_html_x( 'Not Spam', 'review', 'woocommerce' )
@@ -371,7 +371,7 @@ class ReviewsListTable extends WP_List_Table {
 		if ( 'trash' === $review_status ) {
 			$actions['untrash'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
-				$untrash_url,
+				esc_url( $untrash_url ),
 				"delete:the-comment-list:comment-{$review->comment_ID}:66cc66:untrash=1",
 				esc_attr__( 'Restore this review from the Trash', 'woocommerce' ),
 				esc_html__( 'Restore', 'woocommerce' )
@@ -381,7 +381,7 @@ class ReviewsListTable extends WP_List_Table {
 		if ( 'spam' === $review_status || 'trash' === $review_status || ! EMPTY_TRASH_DAYS ) {
 			$actions['delete'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
-				$delete_url,
+				esc_url( $delete_url ),
 				"delete:the-comment-list:comment-{$review->comment_ID}::delete=1",
 				esc_attr__( 'Delete this review permanently', 'woocommerce' ),
 				esc_html__( 'Delete Permanently', 'woocommerce' )
@@ -389,7 +389,7 @@ class ReviewsListTable extends WP_List_Table {
 		} else {
 			$actions['trash'] = sprintf(
 				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
-				$trash_url,
+				esc_url( $trash_url ),
 				"delete:the-comment-list:comment-{$review->comment_ID}::trash=1",
 				esc_attr__( 'Move this review to the Trash', 'woocommerce' ),
 				esc_html_x( 'Trash', 'verb', 'woocommerce' )
@@ -399,7 +399,7 @@ class ReviewsListTable extends WP_List_Table {
 		if ( 'spam' !== $review_status && 'trash' !== $review_status ) {
 			$actions['edit'] = sprintf(
 				'<a href="%s" aria-label="%s">%s</a>',
-				"comment.php?action=editcomment&amp;c={$review->comment_ID}",
+				esc_url( "comment.php?action=editcomment&amp;c={$review->comment_ID}" ),
 				esc_attr__( 'Edit this review', 'woocommerce' ),
 				esc_html__( 'Edit', 'woocommerce' )
 			);
@@ -459,7 +459,6 @@ class ReviewsListTable extends WP_List_Table {
 		}
 
 		$output .= '</div>';
-
 		$output .= '<button type="button" class="toggle-row"><span class="screen-reader-text">' . esc_html__( 'Show more details', 'woocommerce' ) . '</span></button>';
 
 		return $output;

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -61,6 +61,80 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that can handle the row actions for a review in the Reviews page table.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::handle_row_actions()
+	 * @dataProvider data_provider_test_handle_row_actions
+	 *
+	 * @param string $review_status  The review status.
+	 * @param string $column_name    The current column name being output.
+	 * @param string $primary_column The primary colum name.
+	 * @param bool   $user_can_edit  Whether the current user can edit reviews.
+	 * @return void
+	 * @throws ReflectionException If the method does not exist.
+	 */
+	public function test_handle_row_actions( $review_status, $column_name, $primary_column, $user_can_edit ) {
+		global $comment_status;
+
+		$comment_status = 'test'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$list_table = $this->get_reviews_list_table();
+		$reflection = new ReflectionClass( $list_table );
+		$method = $reflection->getMethod( 'handle_row_actions' );
+		$method->setAccessible( true );
+		$property = $reflection->getProperty( 'current_user_can_edit_review' );
+		$property->setAccessible( true );
+
+		$property->setValue( $list_table, $user_can_edit );
+
+		$review = $this->factory()->comment->create_and_get(
+			[
+				'comment_approved' => $review_status,
+			]
+		);
+
+		$actions = $method->invokeArgs( $list_table, [ $review, $column_name, $primary_column ] );
+
+		if ( $column_name !== $primary_column || ! $user_can_edit ) {
+
+			$this->assertEmpty( $actions );
+
+		} else {
+
+			if ( '1' === $review_status ) {
+				$review_status = 'approved';
+			} elseif ( '0' === $review_status ) {
+				$review_status = 'unapproved';
+			}
+
+			if ( 'approved' === $review_status || 'unapproved' === $review_status ) {
+				$this->assertStringContainsString( 'approved' === $review_status ? 'Unapprove' : 'Approve', $actions );
+				$this->assertStringContainsString( 'Spam', $actions );
+			} elseif ( 'spam' === $review_status ) {
+				$this->assertStringContainsString( 'Not Spam', $actions );
+			} elseif ( 'trash' === $review_status ) {
+				$this->assertStringContainsString( 'Restore', $actions );
+			}
+
+			if ( 'trash' === $review_status || 'spam' === $review_status ) {
+				$this->assertStringContainsString( 'Delete Permanently', $actions );
+			} else {
+				$this->assertStringContainsString( 'Trash', $actions );
+			}
+		}
+	}
+
+	/** @see test_handle_row_actions */
+	public function data_provider_test_handle_row_actions() : Generator {
+		yield 'Not the primary column'   => [ 'foo', 'bar', 'baz', true ];
+		yield 'User cannot edit reviews' => [ 'test', 'foo', 'foo', false ];
+		yield 'Approved review'          => [ '1', 'foo', 'foo', true ];
+		yield 'Unapproved review'        => [ '0', 'foo', 'foo', true ];
+		yield 'Trashed review'           => [ 'trash', 'foo', 'foo', true ];
+		yield 'Spam review'              => [ 'spam', 'foo', 'foo', true ];
+	}
+
+	/**
 	 * Tests that can get the product reviews' page columns.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_columns()


### PR DESCRIPTION
# Summary

Implements the row actions for the product reviews page.

### Story: [MWC 5343](https://jira.godaddy.com/browse/MWC-5352)

## QA

- [x] Code review
- [x] Unit tests pass

## Details 

This is an almost exact copy of `WP_Comments_List_Table::handle_row_actions()` minus wording, and for that reason is not very pretty... and so the corresponding test. But I don't think we need to reinvent the wheel at this stage. 

The JS functionality will be addressed in [MWC-5352](https://jira.godaddy.com/browse/MWC-5352).

Also, we probably need a follow up story to ensure the menu item keeps focus when editing a review from the product reviews page. 

## QA

- [x] Code review
- [x] Unit tests pass

### User testing

1. Have multiple reviews and replies in your installation
1. Go to the Products > Reviews page
    - [x] Hovering on individual rows will display the actions 
    - [x] Clicking on the edit button will allow you to edit a review

The JS for quick edit and inline reply are expected not to work yet. 

When trashing or marking as spam a comment, to review the spambox or the bin you need to append `&comment_status=spam` or `&comment_status=trash` to your URL at the moment as well as changes from #22 