### PR TITLE
Add the reviews menu notification bubble

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -65,13 +65,35 @@ class Reviews {
 		$this->reviews_page_hook = add_submenu_page(
 			'edit.php?post_type=product',
 			__( 'Reviews', 'woocommerce' ),
-			__( 'Reviews', 'woocommerce' ),
+			__( 'Reviews', 'woocommerce' ) . $this->get_pending_count_bubble(),
 			'moderate_comments',
 			static::MENU_SLUG,
 			[ $this, 'render_reviews_list_table' ]
 		);
 
 		add_action( "load-{$this->reviews_page_hook}", [ $this, 'load_reviews_screen' ] );
+	}
+
+	/**
+	 * Counts the number of pending product reviews/replies, and returns the notification bubble if there's more than zero.
+	 *
+	 * @return string Empty string if there are no pending reviews, or bubble HTML if there are.
+	 */
+	protected function get_pending_count_bubble() : string {
+		$count = (int) get_comments(
+			[
+				'type__in'  => [ 'review', 'comment' ],
+				'status'    => '0',
+				'post_type' => 'product',
+				'count'     => true,
+			]
+		);
+
+		if ( empty( $count ) ) {
+			return '';
+		}
+
+		return ' <span class="awaiting-mod count-' . esc_attr( $count ) . '"><span class="pending-count">' . esc_html( $count ) . '</span></span>';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This adds the bubble with the number of pending reviews to the Products > Reviews menu.

## Story: [MWC-5350](https://jira.godaddy.com/browse/MWC-5350)

## Details

Note that review counts are still incorrectly being included in the main "Comments" menu. I don't think fixing that was meant to be done in this story? [I've created a new story](https://docs.google.com/document/d/1oMku-8Fqzj6PCSmXh5j3ElE2hsxABp6TQ3ayuQ-Or8Q/edit#bookmark=id.whj9fpoel6wn) to handle that separately.

## QA

1. Start with no reviews pending moderation. (I ran this query: `update wp_comments set comment_approved = '1' where comment_approved = '0';`)
2. Check the Products > Reviews submenu.
    - [x] There is no bubble.
3. Set at least one or two reviews as pending. (I ran this query: `update wp_comments set comment_approved = '0' where comment_approved = '1' and comment_type = 'review' limit 2;`
2. Check the Products > Reviews submenu.
    - [x] There is a bubble containing the correct number of pending reviews.