### PR TITLE
Implement column_default() method to support rendering custom columns

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -526,7 +526,14 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param string     $column_name Name of the column being rendered.
 	 */
 	protected function column_default( $item, $column_name ) {
-		// @TODO Implement in MWC-5362 {agibson 2022-04-12}
+		/**
+		 * Fires when the default column output is displayed for a single row.
+		 * This action can be used to render custom columns that have been added.
+		 *
+		 * @param string $column_name The custom column's name.
+		 * @param string $comment_id  The review ID as a numeric string.
+		 */
+		do_action( 'woocommerce_manage_product_reviews_custom_column', $column_name, $item->comment_ID );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -657,7 +657,7 @@ class ReviewsListTable extends WP_List_Table {
 		 * @param string $column_name The custom column's name.
 		 * @param string $comment_id  The review ID as a numeric string.
 		 */
-		do_action( 'woocommerce_manage_product_reviews_custom_column', $column_name, $item->comment_ID );
+		do_action( 'woocommerce_product_reviews_table_custom_column', $column_name, $item->comment_ID );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1300,9 +1300,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		);
 
 		if ( ! empty( $hook_callback ) ) {
-			add_action( 'woocommerce_manage_product_reviews_custom_column', $hook_callback, 10, 2 );
+			add_action( 'woocommerce_product_reviews_table_custom_column', $hook_callback, 10, 2 );
 		} else {
-			remove_all_actions( 'woocommerce_manage_product_reviews_custom_column' );
+			remove_all_actions( 'woocommerce_product_reviews_table_custom_column' );
 		}
 
 		ob_start();


### PR DESCRIPTION
## Summary

Implements the `column_default()` method to fire a hook. This hook can be used to render the content for custom columns.

## Story: [MWC-5362](https://jira.godaddy.com/browse/MWC-5362)

## QA

- [x] Code review
- [x] Tests pass