### PR TITLE
Process bulk actions

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -81,6 +81,7 @@ class Reviews {
 	 */
 	public function load_reviews_screen() {
 		$this->reviews_list_table = new ReviewsListTable( [ 'screen' => $this->reviews_page_hook ] );
+		$this->reviews_list_table->process_bulk_action();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -731,9 +731,7 @@ class ReviewsListTable extends WP_List_Table {
 			return;
 		}
 
-		$do_action = $this->current_action();
-
-		if ( $do_action ) {
+		if ( $this->current_action() ) {
 			check_admin_referer( 'bulk-product-reviews' );
 
 			$query_string = remove_query_arg( [ 'page', '_wpnonce' ], wp_unslash( ( $_SERVER['QUERY_STRING'] ?? '' ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -42,7 +42,15 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param array|string $args Array or string of arguments.
 	 */
 	public function __construct( $args = [] ) {
-		parent::__construct( $args );
+		parent::__construct(
+			wp_parse_args(
+				$args,
+				[
+					'plural'   => 'product-reviews',
+					'singular' => 'product-review',
+				]
+			)
+		);
 
 		$this->current_user_can_moderate_reviews = current_user_can( 'moderate_comments' );
 	}
@@ -711,6 +719,37 @@ class ReviewsListTable extends WP_List_Table {
 			<?php endforeach; ?>
 		</select>
 		<?php
+	}
+
+	/**
+	 * Processes the bulk actions.
+	 *
+	 * @return void
+	 */
+	public function process_bulk_action() {
+		if ( ! $this->current_user_can_moderate_reviews ) {
+			return;
+		}
+
+		$do_action = $this->current_action();
+
+		if ( $do_action ) {
+			check_admin_referer( 'bulk-product-reviews' );
+
+			$query_string = remove_query_arg( [ 'page', '_wpnonce' ], wp_unslash( ( $_SERVER['QUERY_STRING'] ?? '' ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+			// Replace current nonce with bulk-comments nonce.
+			$comments_nonce = wp_create_nonce( 'bulk-comments' );
+			$query_string   = add_query_arg( '_wpnonce', $comments_nonce, $query_string );
+
+			// Redirect to edit-comments.php, which will handle processing the action for us.
+			wp_safe_redirect( esc_url_raw( admin_url( 'edit-comments.php?' . $query_string ) ) );
+			exit;
+		} elseif ( ! empty( $_GET['_wp_http_referer'] ) ) {
+
+			wp_redirect( remove_query_arg( [ '_wp_http_referer', '_wpnonce' ] ) );
+			exit;
+		}
 	}
 
 }

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -747,7 +747,7 @@ class ReviewsListTable extends WP_List_Table {
 			exit;
 		} elseif ( ! empty( $_GET['_wp_http_referer'] ) ) {
 
-			wp_redirect( remove_query_arg( [ '_wp_http_referer', '_wpnonce' ] ) );
+			wp_safe_redirect( remove_query_arg( [ '_wp_http_referer', '_wpnonce' ] ) );
 			exit;
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -804,8 +804,8 @@ class ReviewsListTable extends WP_List_Table {
 			wp_safe_redirect( remove_query_arg( [ '_wp_http_referer', '_wpnonce' ] ) );
 			exit;
 		}
-  }
-    
+	}
+
 	/**
 	 * Displays a product search input for filtering reviews by product in the Product Reviews list table.
 	 *


### PR DESCRIPTION
## Summary

Implements the method to process bulk actions.

## Story: [MWC-5347](https://jira.godaddy.com/browse/MWC-5347) and [MWC-5348](https://jira.godaddy.com/browse/MWC-5348)

I meant to just do [MWC-5347](https://jira.godaddy.com/browse/MWC-5347), but accidentally added [MWC-5348](https://jira.godaddy.com/browse/MWC-5348) as well, which was just 1 line. Seemed silly to remove it, especially because you can't really QA one without the other. 🤷 

## Details

I have not written a test for it as I'm not quite sure how without mocking. If I'm missing something, let me know.

## QA

This can be QAed, but it's slightly tricky/annoying without:

1. There's no styling to indicate a review requires moderation (I'm making a story for this). So it's hard to tell that approve/unapprove worked.
2. https://github.com/godaddy-wordpress/woocommerce/pull/19 being merged would make it easier.

But anyway, here's what I'm doing:

1. Pick out a review (or two) in your list and note the ID number (can be found by inspecting the bulk action checkbox value).
2. Select your review(s) and select "Unapprove" from the bulk action dropdown.
3. Click "Apply".
4. Run this query: `select comment_ID, comment_approved from wp_comments where comment_ID IN(7);` (replace `7` with your comment ID)
    - [x] The `comment_approved` value is `0`
    - [x] Page refreshes and you're back where you were before.
5. Select the same two reviews, this time do bulk action "Approve".
4. Run this query: `select comment_ID, comment_approved from wp_comments where comment_ID IN(7);` (replace `7` with your comment ID)
    - [x] The `comment_approved` value is `1`
5. Rinse and repeat with other statuses (trash and spam are more annoying to QA because they're removed from the page afterwards)
    - [x] The `comment_approved` value is updated correctly
6. Next: set one of the dropdown filters (rating and/or type filter). Pick one that will still show at least one review.
7. Select the review's checkbox and perform any bulk action.
    - [x] When the page refreshes, your selected filter is preserved.