### PR TITLE
Add filter hooks to customize content of product reviews table columns

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -621,11 +621,18 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param WP_Comment $item Review or reply being rendered.
 	 */
 	protected function column_type( $item ) {
-		echo esc_html(
-			'review' === $item->comment_type ?
-			'&#9734;&nbsp;' . __( 'Review', 'woocommerce' ) :
-			__( 'Reply', 'woocommerce' )
-		);
+
+		$type = 'review' === $item->comment_type
+			? '&#9734;&nbsp;' . __( 'Review', 'woocommerce' )
+			: __( 'Reply', 'woocommerce' );
+
+		/**
+		 * Filters the type column content.
+		 *
+		 * @param string     $type Type column content.
+		 * @param WP_Comment $item Review or reply being rendered.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_table_column_type', esc_html( $type ), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -379,6 +379,9 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param WP_Comment $item Review or reply being rendered.
 	 */
 	protected function column_cb( $item ) {
+
+		ob_start();
+
 		if ( $this->current_user_can_edit_review ) {
 			?>
 			<label class="screen-reader-text" for="cb-select-<?php echo esc_attr( $item->comment_ID ); ?>"><?php esc_html_e( 'Select review', 'woocommerce' ); ?></label>
@@ -390,6 +393,14 @@ class ReviewsListTable extends WP_List_Table {
 			/>
 			<?php
 		}
+
+		/**
+		 * Filters the content of the product review checkbox column.
+		 *
+		 * @param string     $content The content of the checkbox column.
+		 * @param WP_Comment $item    Review or reply being rendered.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_table_colum_cb', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -705,7 +705,7 @@ class ReviewsListTable extends WP_List_Table {
 		 *
 		 * @param string $comment_id The review or reply ID as a numeric string.
 		 */
-		do_action( 'woocommerce_product_reviews_table_' . $column_name, $item );
+		do_action( 'woocommerce_product_reviews_table_column_' . $column_name, $item );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -636,19 +636,32 @@ class ReviewsListTable extends WP_List_Table {
 	protected function column_rating( $item ) {
 		$rating = get_comment_meta( $item->comment_ID, 'rating', true );
 
+		ob_start();
+
 		if ( ! empty( $rating ) && is_numeric( $rating ) ) {
 			$rating = (int) $rating;
+
 			$accessibility_label = sprintf(
 				/* translators: 1: number representing a rating */
 				__( '%1$s out of 5', 'woocommerce' ),
 				$rating
 			);
+
 			$stars = str_repeat( '&#9733;', $rating );
 			$stars .= str_repeat( '&#9734;', 5 - $rating );
+
 			?>
 			<span aria-label="<?php echo esc_attr( $accessibility_label ); ?>"><?php echo esc_html( $stars ); ?></span>
 			<?php
 		}
+
+		/**
+		 * Filters the review rating column content.
+		 *
+		 * @param string     $content Review rating column content.
+		 * @param WP_Comment $item    Review or reply being rendered.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_table_column_rating', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -660,12 +673,12 @@ class ReviewsListTable extends WP_List_Table {
 	protected function column_default( $item, $column_name ) {
 		/**
 		 * Fires when the default column output is displayed for a single row.
+		 *
 		 * This action can be used to render custom columns that have been added.
 		 *
-		 * @param string $column_name The custom column's name.
-		 * @param string $comment_id  The review ID as a numeric string.
+		 * @param string $comment_id The review or reply ID as a numeric string.
 		 */
-		do_action( 'woocommerce_product_reviews_table_custom_column', $column_name, $item->comment_ID );
+		do_action( 'woocommerce_product_reviews_table_' . $column_name, $item );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -394,13 +394,7 @@ class ReviewsListTable extends WP_List_Table {
 			<?php
 		}
 
-		/**
-		 * Filters the content of the product review checkbox column.
-		 *
-		 * @param string     $content The content of the checkbox column.
-		 * @param WP_Comment $item    Review or reply being rendered.
-		 */
-		echo apply_filters( 'woocommerce_product_reviews_table_colum_cb', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->filter_column_output( 'cb', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -428,13 +422,7 @@ class ReviewsListTable extends WP_List_Table {
 			'</div>'
 		);
 
-		/**
-		 * Filters the review content column.
-		 *
-		 * @param string     $content Review or reply content.
-		 * @param WP_Comment $item    Review or reply being rendered.
-		 */
-		echo apply_filters( 'woocommerce_product_reviews_table_column_comment', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->filter_column_output( 'comment', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -526,13 +514,7 @@ class ReviewsListTable extends WP_List_Table {
 
 		endif;
 
-		/**
-		 * Filters the product review author column content.
-		 *
-		 * @param string     $content The content of the column.
-		 * @param WP_Comment $item    The review or reply being rendered.
-		 */
-		echo apply_filters( 'woocommerce_product_reviews_table_column_author', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->filter_column_output( 'author', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -608,13 +590,7 @@ class ReviewsListTable extends WP_List_Table {
 		</div>
 		<?php
 
-		/**
-		 * Filters the product review date column content.
-		 *
-		 * @param string     $content The review date column content.
-		 * @param WP_Comment $item    The review or reply being rendered.
-		 */
-		echo apply_filters( 'woocommerce_product_reviews_table_column_date', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->filter_column_output( 'date', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -622,9 +598,10 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * @see WP_Comments_List_Table::column_response() for consistency.
 	 *
+	 * @param WP_Comment $item Review or reply being rendered.
 	 * @return void
 	 */
-	protected function column_response() {
+	protected function column_response( $item ) {
 		$product_post = get_post();
 
 		ob_start();
@@ -658,13 +635,7 @@ class ReviewsListTable extends WP_List_Table {
 
 		endif;
 
-		/**
-		 * Filters the product review response column content.
-		 *
-		 * @param string     $content The response column content.
-		 * @param WP_Comment $item    The review or reply being rendered.
-		 */
-		echo apply_filters( 'woocommerce_product_reviews_table_column_response', ob_get_clean(), get_comment() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->filter_column_output( 'response', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -678,13 +649,7 @@ class ReviewsListTable extends WP_List_Table {
 			? '&#9734;&nbsp;' . __( 'Review', 'woocommerce' )
 			: __( 'Reply', 'woocommerce' );
 
-		/**
-		 * Filters the type column content.
-		 *
-		 * @param string     $type Type column content.
-		 * @param WP_Comment $item Review or reply being rendered.
-		 */
-		echo apply_filters( 'woocommerce_product_reviews_table_column_type', esc_html( $type ), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->filter_column_output( 'type', esc_html( $type ), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -714,13 +679,7 @@ class ReviewsListTable extends WP_List_Table {
 			<?php
 		}
 
-		/**
-		 * Filters the product review rating column content.
-		 *
-		 * @param string     $content Review rating column content.
-		 * @param WP_Comment $item    Review or reply being rendered.
-		 */
-		echo apply_filters( 'woocommerce_product_reviews_table_column_rating', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->filter_column_output( 'rating', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -730,14 +689,38 @@ class ReviewsListTable extends WP_List_Table {
 	 * @param string     $column_name Name of the column being rendered.
 	 */
 	protected function column_default( $item, $column_name ) {
+
+		ob_start();
+
 		/**
 		 * Fires when the default column output is displayed for a single row.
 		 *
 		 * This action can be used to render custom columns that have been added.
 		 *
-		 * @param string $comment_id The review or reply ID as a numeric string.
+		 * @param WP_Comment $item The review or reply being rendered.
 		 */
 		do_action( 'woocommerce_product_reviews_table_column_' . $column_name, $item );
+
+		echo $this->filter_column_output( $column_name, ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	/**
+	 * Runs a filter hook for a given column content.
+	 *
+	 * @param string     $column_name The column being output.
+	 * @param string     $output      The output content (may include HTML).
+	 * @param WP_Comment $item        The review or reply being rendered.
+	 * @return string
+	 */
+	protected function filter_column_output( $column_name, $output, $item ) {
+
+		/**
+		 * Filters the output of a column.
+		 *
+		 * @param string     $output The column output.
+		 * @param WP_Comment $item   The product review being rendered.
+		 */
+		return apply_filters( 'woocommerce_product_reviews_table_column_' . $column_name, $output, $item );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -556,6 +556,8 @@ class ReviewsListTable extends WP_List_Table {
 			get_comment_date( __( 'g:i a', 'woocommerce' ), $item )
 		);
 
+		ob_start();
+
 		?>
 		<div class="submitted-on">
 			<?php
@@ -573,6 +575,14 @@ class ReviewsListTable extends WP_List_Table {
 			?>
 		</div>
 		<?php
+
+		/**
+		 * Filters the product review date column content.
+		 *
+		 * @param string     $content The review date column content.
+		 * @param WP_Comment $item    The review or reply being rendered.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_table_column_date', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -585,34 +595,44 @@ class ReviewsListTable extends WP_List_Table {
 	protected function column_response() {
 		$product_post = get_post();
 
-		if ( ! $product_post ) {
-			return;
-		}
+		ob_start();
 
-		?>
-		<div class="response-links">
-			<?php
-
-			if ( current_user_can( 'edit_product', $product_post->ID ) ) :
-				$post_link  = "<a href='" . esc_url( get_edit_post_link( $product_post->ID ) ) . "' class='comments-edit-item-link'>";
-				$post_link .= esc_html( get_the_title( $product_post->ID ) ) . '</a>';
-			else :
-				$post_link = esc_html( get_the_title( $product_post->ID ) );
-			endif;
-
-			echo $post_link; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-
-			$post_type_object = get_post_type_object( $product_post->post_type );
+		if ( $product_post ) :
 
 			?>
-			<a href="<?php echo esc_url( get_permalink( $product_post->ID ) ); ?>" class="comments-view-item-link">
-				<?php echo esc_html( $post_type_object->labels->view_item ); ?>
-			</a>
-			<span class="post-com-count-wrapper post-com-count-<?php echo esc_attr( $product_post->ID ); ?>">
-				<?php $this->comments_bubble( $product_post->ID, get_pending_comments_num( $product_post->ID ) ); ?>
-			</span>
-		</div>
-		<?php
+			<div class="response-links">
+				<?php
+
+				if ( current_user_can( 'edit_product', $product_post->ID ) ) :
+					$post_link  = "<a href='" . esc_url( get_edit_post_link( $product_post->ID ) ) . "' class='comments-edit-item-link'>";
+					$post_link .= esc_html( get_the_title( $product_post->ID ) ) . '</a>';
+				else :
+					$post_link = esc_html( get_the_title( $product_post->ID ) );
+				endif;
+
+				echo $post_link; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+				$post_type_object = get_post_type_object( $product_post->post_type );
+
+				?>
+				<a href="<?php echo esc_url( get_permalink( $product_post->ID ) ); ?>" class="comments-view-item-link">
+					<?php echo esc_html( $post_type_object->labels->view_item ); ?>
+				</a>
+				<span class="post-com-count-wrapper post-com-count-<?php echo esc_attr( $product_post->ID ); ?>">
+					<?php $this->comments_bubble( $product_post->ID, get_pending_comments_num( $product_post->ID ) ); ?>
+				</span>
+			</div>
+			<?php
+
+		endif;
+
+		/**
+		 * Filters the product review response column content.
+		 *
+		 * @param string     $content The response column content.
+		 * @param WP_Comment $item    The review or reply being rendered.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_table_column_response', ob_get_clean(), get_comment() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -663,7 +683,7 @@ class ReviewsListTable extends WP_List_Table {
 		}
 
 		/**
-		 * Filters the review rating column content.
+		 * Filters the product review rating column content.
 		 *
 		 * @param string     $content Review rating column content.
 		 * @param WP_Comment $item    Review or reply being rendered.

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -459,6 +459,8 @@ class ReviewsListTable extends WP_List_Table {
 			$author_avatar = '';
 		}
 
+		ob_start();
+
 		echo '<strong>' . $author_avatar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		comment_author();
 		echo '</strong><br>';
@@ -501,6 +503,14 @@ class ReviewsListTable extends WP_List_Table {
 			<?php
 
 		endif;
+
+		/**
+		 * Filters the product review author column content.
+		 *
+		 * @param string     $content The content of the column.
+		 * @param WP_Comment $item    The review or reply being rendered.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_table_column_author', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -401,7 +401,10 @@ class ReviewsListTable extends WP_List_Table {
 	 * @return void
 	 */
 	protected function column_comment( $item ) {
+
 		$in_reply_to = $this->get_in_reply_to_review_text( $item );
+
+		ob_start();
 
 		if ( $in_reply_to ) {
 			echo $in_reply_to . '<br><br>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -413,6 +416,14 @@ class ReviewsListTable extends WP_List_Table {
 			get_comment_text( $item->comment_ID ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			'</div>'
 		);
+
+		/**
+		 * Filters the review content column.
+		 *
+		 * @param string     $content Review or reply content.
+		 * @param WP_Comment $item    Review or reply being rendered.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_table_column_comment', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -720,7 +720,7 @@ class ReviewsListTable extends WP_List_Table {
 		 * @param string     $output The column output.
 		 * @param WP_Comment $item   The product review being rendered.
 		 */
-		return apply_filters( 'woocommerce_product_reviews_table_column_' . $column_name, $output, $item );
+		return apply_filters( 'woocommerce_product_reviews_table_column_' . $column_name . '_content', $output, $item );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1293,15 +1293,11 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method->setAccessible( true );
 
 		$review = $this->factory()->comment->create_and_get();
+		$callback = function( $review ) {
+			echo 'Custom content for "custom_column" for ID ' . esc_html( $review->comment_ID );
+		};
 
-		add_action(
-			'woocommerce_product_reviews_table_column_custom_column',
-			static function( $review ) {
-				echo 'Custom content for "custom_column" for ID ' . esc_html( $review->comment_ID );
-			},
-			10,
-			2
-		);
+		add_action( 'woocommerce_product_reviews_table_column_custom_column', $callback, 10, 2 );
 
 		ob_start();
 
@@ -1309,7 +1305,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 'Custom content for "custom_column" for ID ' . $review->comment_ID, ob_get_clean() );
 
-		remove_all_actions( 'woocommerce_product_reviews_table_column_custom_column' );
+		remove_action( 'woocommerce_product_reviews_table_column_custom_column', $callback );
 	}
 
 	/**
@@ -1326,23 +1322,19 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method->setAccessible( true );
 
 		$review = $this->factory()->comment->create_and_get();
+		$callback = function( $content, $review ) {
+			return 'Additional content to "' . $content . '" for test column belonging to review with ID: ' . esc_html( $review->comment_ID );
+		};
 
-		add_filter(
-			'woocommerce_product_reviews_table_column_test_content',
-			static function( $content, $review ) {
-				return 'Additional content to "' . $content . '" for test column belonging to review with ID: ' . $review->comment_ID; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			},
-			10,
-			2
-		);
+		add_filter( 'woocommerce_product_reviews_table_column_test_content', $callback, 10, 2 );
 
 		ob_start();
 
 		$method->invokeArgs( $list_table, [ 'test', 'test content', $review ] );
 
-		$this->assertSame( 'Additional content to "test content" for test column belonging to review with ID: ' . $review->comment_ID, ob_get_clean() );
+		$this->assertSame( 'Additional content to "test content" for test column belonging to review with ID: ' . (string) $review->comment_ID, ob_get_clean() );
 
-		remove_all_filters( 'woocommerce_product_reviews_table_column_test_content' );
+		remove_filter( 'woocommerce_product_reviews_table_column_test_content', $callback );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1325,10 +1325,12 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'filter_column_output' );
 		$method->setAccessible( true );
 
+		$review = $this->factory()->comment->create_and_get();
+
 		add_filter(
 			'woocommerce_product_reviews_table_column_test_content',
 			static function( $content, $review ) {
-				return 'Additional content to ' . $content . ' for test column for review with content: ' . $review->comment_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				return 'Additional content to "' . $content . '" for test column for review with ID: ' . $review->comment_ID; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			},
 			10,
 			2
@@ -1336,9 +1338,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		ob_start();
 
-		$method->invokeArgs( $list_table, [ 'test', '"example content"', $review ] );
+		$method->invokeArgs( $list_table, [ 'test', 'test content', $review ] );
 
-		$this->assertSame( 'Additional content to "example content" for review with content: ' . $review->comment_content, ob_get_clean() );
+		$this->assertSame( 'Additional content to "test content" for review with ID: ' . $review->comment_ID, ob_get_clean() );
 
 		remove_all_filters( 'woocommerce_product_reviews_table_column_test_content' );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1325,12 +1325,16 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'filter_column_output' );
 		$method->setAccessible( true );
 
-		$review = $this->factory()->comment->create_and_get();
+		$review = $this->factory()->comment->create_and_get(
+			[
+				'comment_content' => 'Test content',
+			]
+		);
 
 		add_filter(
 			'woocommerce_product_reviews_table_column_test_content',
 			static function( $content, $review ) {
-				return 'Additional content to ' . $content . ' for test column for review ID ' . $review->comment_ID; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				return 'Additional content to ' . $content . ' for test column for review with content: ' . $review->comment_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			},
 			10,
 			2
@@ -1340,7 +1344,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$method->invokeArgs( $list_table, [ 'test', '"example content"', $review ] );
 
-		$this->assertSame( 'Additional content to "example content" for review ID ' . $review->comment_ID, ob_get_clean() );
+		$this->assertSame( 'Additional content to "example content" for review with content: ' . $review->comment_content, ob_get_clean() );
 
 		remove_all_filters( 'woocommerce_product_reviews_table_column_test_content' );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1328,11 +1328,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		add_filter( 'woocommerce_product_reviews_table_column_test_content', $callback, 10, 2 );
 
-		ob_start();
+		$output = $method->invokeArgs( $list_table, [ 'test', 'test content', $review ] );
 
-		$method->invokeArgs( $list_table, [ 'test', 'test content', $review ] );
-
-		$this->assertSame( 'Additional content to "test content" for test column belonging to review with ID: ' . (string) $review->comment_ID, ob_get_clean() );
+		$this->assertSame( 'Additional content to "test content" for test column belonging to review with ID: ' . (string) $review->comment_ID, $output );
 
 		remove_filter( 'woocommerce_product_reviews_table_column_test_content', $callback );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1328,9 +1328,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$review = $this->factory()->comment->create_and_get();
 
 		add_filter(
-			'woocommerce_product_reviews_table_column_test',
+			'woocommerce_product_reviews_table_column_test_content',
 			static function( $content, $review ) {
-				return 'Additional content to ' . $content . ' for test column for review ID ' . esc_html( $review->comment_ID );
+				return 'Additional content to ' . $content . ' for test column for review ID ' . $review->comment_ID; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			},
 			10,
 			2
@@ -1342,7 +1342,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 'Additional content to "example content" for review ID ' . $review->comment_ID, ob_get_clean() );
 
-		remove_all_filters( 'woocommerce_product_reviews_table_column_test' );
+		remove_all_filters( 'woocommerce_product_reviews_table_column_test_content' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1330,7 +1330,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		add_filter(
 			'woocommerce_product_reviews_table_column_test_content',
 			static function( $content, $review ) {
-				return 'Additional content to "' . $content . '" for test column for review with ID: ' . $review->comment_ID; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				return 'Additional content to "' . $content . '" for test column belonging to review with ID: ' . $review->comment_ID; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			},
 			10,
 			2
@@ -1340,7 +1340,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$method->invokeArgs( $list_table, [ 'test', 'test content', $review ] );
 
-		$this->assertSame( 'Additional content to "test content" for review with ID: ' . $review->comment_ID, ob_get_clean() );
+		$this->assertSame( 'Additional content to "test content" for test column belonging to review with ID: ' . $review->comment_ID, ob_get_clean() );
 
 		remove_all_filters( 'woocommerce_product_reviews_table_column_test_content' );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1296,7 +1296,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$review = $this->factory()->comment->create_and_get();
 
 		add_action(
-			'woocommerce_product_reviews_table_custom_column',
+			'woocommerce_product_reviews_table_column_custom_column',
 			static function( $review ) {
 				echo 'Custom content for "custom_column" for ID ' . esc_html( $review->comment_ID );
 			},


### PR DESCRIPTION
## Summary

Adds a filter at the end of each product review column so that the content of that column can be filtered.

### Story: [MWC-5359](https://jira.godaddy.com/browse/MWC-5359)

## Details

I have renamed the action hook for the custom column to align the naming to the rest of the hooks (but also, that's a pattern I've seen before in WC, to dynamically build the hook name with the column being rendered).

## QA

- [x] Code review
- [x] Unit tests pass

### User testing

Add some snippet to tweak the content of a column, such as:

```
add_filter( 'woocommerce_product_reviews_table_column_author_content', static function ( $content, $review ) {
	return 'test review' . $review->comment_ID;
}, 10, 2);
```

and check if it produces the expected result