### PR TITLE
Make the contents of the reviews list table filterable

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -115,6 +115,8 @@ class Reviews {
 
 		$this->reviews_list_table->prepare_items();
 
+		ob_start();
+
 		?>
 		<div class="wrap">
 			<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
@@ -133,6 +135,14 @@ class Reviews {
 			</form>
 		</div>
 		<?php
+
+		/**
+		 * Filters the contents of the product reviews list table output.
+		 *
+		 * @param string           $output             The HTML output of the list table.
+		 * @param ReviewsListTable $reviews_list_table The reviews list table instance.
+		 */
+		echo apply_filters( 'woocommerce_product_reviews_list_table', ob_get_clean(), $this->reviews_list_table ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 }


### PR DESCRIPTION
## Summary

Adds a filter at the end of `Reviews::render_reviews_list_table()` to filter the entire content of the products reviews page.

### Story: [MWC-5358](https://jira.godaddy.com/browse/MWC-5358)

## Details

At first I thought it would make more sense to have actions before/after the actual table, but it seems this is what product asked specifically.

## QA

- [x] Code review
- [x] Unit tests pass

### User testing

Add some snippet to tweak the content of the page, such as:

```
add_filter( 'woocommerce_product_reviews_list_table', static function ( $content ) {
	return $content . 'test';
}, 10, 2);
```

and check if it produces the expected result