### PR TITLE
Ensure pending reviews have styles consistent with pending comments

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -322,6 +322,211 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Generate and display row actions links.
+	 *
+	 * @see WP_Comments_List_Table::handle_row_actions() for consistency.
+	 *
+	 * @global string $comment_status Status for the current listed comments.
+	 *
+	 * @param WP_Comment $item        The product review or reply in context.
+	 * @param string     $column_name Current column name.
+	 * @param string     $primary     Primary column name.
+	 * @return string
+	 */
+	protected function handle_row_actions( $item, $column_name, $primary ) {
+		global $comment_status;
+
+		if ( $primary !== $column_name || ! $this->current_user_can_edit_review ) {
+			return '';
+		}
+
+		$review_status = wp_get_comment_status( $item );
+
+		$url = add_query_arg(
+			[
+				'c' => urlencode( $item->comment_ID ),
+			],
+			admin_url( 'comment.php' )
+		);
+
+		$approve_url   = wp_nonce_url( add_query_arg( 'action', 'approvecomment', $url ), "approve-comment_$item->comment_ID" );
+		$unapprove_url = wp_nonce_url( add_query_arg( 'action', 'unapprovecomment', $url ), "approve-comment_$item->comment_ID" );
+		$spam_url      = wp_nonce_url( add_query_arg( 'action', 'spamcomment', $url ), "delete-comment_$item->comment_ID" );
+		$unspam_url    = wp_nonce_url( add_query_arg( 'action', 'unspamcomment', $url ), "delete-comment_$item->comment_ID" );
+		$trash_url     = wp_nonce_url( add_query_arg( 'action', 'trashcomment', $url ), "delete-comment_$item->comment_ID" );
+		$untrash_url   = wp_nonce_url( add_query_arg( 'action', 'untrashcomment', $url ), "delete-comment_$item->comment_ID" );
+		$delete_url    = wp_nonce_url( add_query_arg( 'action', 'deletecomment', $url ), "delete-comment_$item->comment_ID" );
+
+		$actions = [
+			'approve'   => '',
+			'unapprove' => '',
+			'reply'     => '',
+			'quickedit' => '',
+			'edit'      => '',
+			'spam'      => '',
+			'unspam'    => '',
+			'trash'     => '',
+			'untrash'   => '',
+			'delete'    => '',
+		];
+
+		if ( $comment_status && 'all' !== $comment_status ) {
+			if ( 'approved' === $review_status ) {
+				$actions['unapprove'] = sprintf(
+					'<a href="%s" data-wp-lists="%s" class="vim-u vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+					esc_url( $unapprove_url ),
+					esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:e7e7d3:action=dim-comment&amp;new=unapproved" ),
+					esc_attr__( 'Unapprove this review', 'woocommerce' ),
+					esc_html__( 'Unapprove', 'woocommerce' )
+				);
+			} elseif ( 'unapproved' === $review_status ) {
+				$actions['approve'] = sprintf(
+					'<a href="%s" data-wp-lists="%s" class="vim-a vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+					esc_url( $approve_url ),
+					esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:e7e7d3:action=dim-comment&amp;new=approved" ),
+					esc_attr__( 'Approve this review', 'woocommerce' ),
+					esc_html__( 'Approve', 'woocommerce' )
+				);
+			}
+		} else {
+			$actions['approve'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-a aria-button-if-js" aria-label="%s">%s</a>',
+				esc_url( $approve_url ),
+				esc_attr( "dim:the-comment-list:comment-{$item->comment_ID}:unapproved:e7e7d3:e7e7d3:new=approved" ),
+				esc_attr__( 'Approve this review', 'woocommerce' ),
+				esc_html__( 'Approve', 'woocommerce' )
+			);
+
+			$actions['unapprove'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-u aria-button-if-js" aria-label="%s">%s</a>',
+				esc_url( $unapprove_url ),
+				esc_attr( "dim:the-comment-list:comment-{$item->comment_ID}:unapproved:e7e7d3:e7e7d3:new=unapproved" ),
+				esc_attr__( 'Unapprove this review', 'woocommerce' ),
+				esc_html__( 'Unapprove', 'woocommerce' )
+			);
+		}
+
+		if ( 'spam' !== $review_status ) {
+			$actions['spam'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-s vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				esc_url( $spam_url ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}::spam=1" ),
+				esc_attr__( 'Mark this review as spam', 'woocommerce' ),
+				/* translators: "Mark as spam" link. */
+				esc_html_x( 'Spam', 'verb', 'woocommerce' )
+			);
+		} else {
+			$actions['unspam'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				esc_url( $unspam_url ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:66cc66:unspam=1" ),
+				esc_attr__( 'Restore this review from the spam', 'woocommerce' ),
+				esc_html_x( 'Not Spam', 'review', 'woocommerce' )
+			);
+		}
+
+		if ( 'trash' === $review_status ) {
+			$actions['untrash'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="vim-z vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				esc_url( $untrash_url ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}:66cc66:untrash=1" ),
+				esc_attr__( 'Restore this review from the Trash', 'woocommerce' ),
+				esc_html__( 'Restore', 'woocommerce' )
+			);
+		}
+
+		if ( 'spam' === $review_status || 'trash' === $review_status || ! EMPTY_TRASH_DAYS ) {
+			$actions['delete'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				esc_url( $delete_url ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}::delete=1" ),
+				esc_attr__( 'Delete this review permanently', 'woocommerce' ),
+				esc_html__( 'Delete Permanently', 'woocommerce' )
+			);
+		} else {
+			$actions['trash'] = sprintf(
+				'<a href="%s" data-wp-lists="%s" class="delete vim-d vim-destructive aria-button-if-js" aria-label="%s">%s</a>',
+				esc_url( $trash_url ),
+				esc_attr( "delete:the-comment-list:comment-{$item->comment_ID}::trash=1" ),
+				esc_attr__( 'Move this review to the Trash', 'woocommerce' ),
+				esc_html_x( 'Trash', 'verb', 'woocommerce' )
+			);
+		}
+
+		if ( 'spam' !== $review_status && 'trash' !== $review_status ) {
+			$actions['edit'] = sprintf(
+				'<a href="%s" aria-label="%s">%s</a>',
+				esc_url(
+					add_query_arg(
+						[
+							'action' => 'editcomment',
+							'c'      => urlencode( $item->comment_ID ),
+						],
+						admin_url( 'comment.php' )
+					)
+				),
+				esc_attr__( 'Edit this review', 'woocommerce' ),
+				esc_html__( 'Edit', 'woocommerce' )
+			);
+
+			$format = '<button type="button" data-comment-id="%d" data-post-id="%d" data-action="%s" class="%s button-link" aria-expanded="false" aria-label="%s">%s</button>';
+
+			$actions['quickedit'] = sprintf(
+				$format,
+				esc_attr( $item->comment_ID ),
+				esc_attr( $item->comment_post_ID ),
+				'edit',
+				'vim-q comment-inline',
+				esc_attr__( 'Quick edit this review inline', 'woocommerce' ),
+				esc_html__( 'Quick Edit', 'woocommerce' )
+			);
+
+			$actions['reply'] = sprintf(
+				$format,
+				esc_attr( $item->comment_ID ),
+				esc_attr( $item->comment_post_ID ),
+				'replyto',
+				'vim-r comment-inline',
+				esc_attr__( 'Reply to this review', 'woocommerce' ),
+				esc_html__( 'Reply', 'woocommerce' )
+			);
+		}
+
+		$always_visible = 'excerpt' === get_user_setting( 'posts_list_mode', 'list' );
+
+		$output = '<div class="' . ( $always_visible ? 'row-actions visible' : 'row-actions' ) . '">';
+
+		$i = 0;
+
+		foreach ( $actions as $action => $link ) {
+			++$i;
+
+			if ( ( ( 'approve' === $action || 'unapprove' === $action ) && 2 === $i ) || 1 === $i ) {
+				$sep = '';
+			} else {
+				$sep = ' | ';
+			}
+
+			if ( ( 'reply' === $action || 'quickedit' === $action ) && ! wp_doing_ajax() ) {
+				$action .= ' hide-if-no-js';
+			} elseif ( ( 'untrash' === $action && 'trash' === $review_status ) || ( 'unspam' === $action && 'spam' === $review_status ) ) {
+				if ( '1' === get_comment_meta( $item->comment_ID, '_wp_trash_meta_status', true ) ) {
+					$action .= ' approve';
+				} else {
+					$action .= ' unapprove';
+				}
+			}
+
+			$output .= "<span class='$action'>$sep$link</span>";
+		}
+
+		$output .= '</div>';
+		$output .= '<button type="button" class="toggle-row"><span class="screen-reader-text">' . esc_html__( 'Show more details', 'woocommerce' ) . '</span></button>';
+
+		return $output;
+	}
+
+	/**
 	 * Gets the columns for the table.
 	 *
 	 * @return array Table columns and their headings.
@@ -732,13 +937,12 @@ class ReviewsListTable extends WP_List_Table {
 
 		if ( $this->current_user_can_edit_review ) :
 
-			if ( ! empty( $item->comment_author_email ) ) :
-				/** This filter is documented in wp-includes/comment-template.php */
-				$email = apply_filters( 'comment_email', $item->comment_author_email, $item );
+			if ( ! empty( $item->comment_author_email ) && is_email( $item->comment_author_email ) ) :
 
-				if ( ! empty( $email ) && '@' !== $email ) {
-					printf( '<a href="%1$s">%2$s</a><br />', esc_url( 'mailto:' . $email ), esc_html( $email ) );
-				}
+				?>
+				<a href="mailto:<?php echo esc_attr( $item->comment_author_email ); ?>"><?php echo esc_html( $item->comment_author_email ); ?></a>
+				<?php
+
 			endif;
 
 			$link = add_query_arg(

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -239,6 +239,42 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Displays the product reviews HTML table.
+	 *
+	 * Reimplements {@see WP_Comment_::display()} but we change the ID to match the one output by {@see WP_Comments_List_Table::display()}.
+	 * This will automatically handle additional CSS for consistency with the comments page.
+	 *
+	 * @return void
+	 */
+	public function display() {
+		$singular = $this->_args['singular'];
+
+		$this->display_tablenav( 'top' );
+
+		$this->screen->render_screen_reader_content( 'heading_list' );
+
+		?>
+		<table class="wp-list-table <?php echo esc_attr( implode( ' ', $this->get_table_classes() ) ); ?>">
+			<thead>
+				<tr>
+					<?php $this->print_column_headers(); ?>
+				</tr>
+			</thead>
+			<tbody id="the-comment-list" <?php echo esc_attr( $singular ? "data-wp-lists='list:$singular'" : '' ); ?>>
+				<?php $this->display_rows_or_placeholder(); ?>
+			</tbody>
+			<tfoot>
+				<tr>
+					<?php $this->print_column_headers( false ); ?>
+				</tr>
+			</tfoot>
+		</table>
+		<?php
+
+		$this->display_tablenav( 'bottom' );
+	}
+
+	/**
 	 * Render a single row HTML.
 	 *
 	 * @global WP_Post $post
@@ -260,7 +296,7 @@ class ReviewsListTable extends WP_List_Table {
 		$this->current_user_can_edit_review = current_user_can( 'edit_comment', $comment->comment_ID );
 
 		?>
-		<tr id="comment-<?php echo esc_attr( $comment->comment_ID ); ?>" class="<?php echo esc_attr( $the_comment_class ); ?>">
+		<tr id="comment-<?php echo esc_attr( $comment->comment_ID ); ?>" class="comment <?php echo esc_attr( $the_comment_class ); ?>">
 			<?php $this->single_row_columns( $comment ); ?>
 		</tr>
 		<?php

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -247,7 +247,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @return void
 	 */
 	public function display() {
-		$singular = $this->_args['singular'];
+		$singular = $this->_args['singular'] ?? false;
 
 		$this->display_tablenav( 'top' );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -26,6 +26,26 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that will output the reviews list table with the expected HTML elements.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::display()
+	 *
+	 * @return void
+	 */
+	public function test_display() {
+		$this->factory()->comment->create_many( 2 );
+
+		ob_start();
+
+		$this->get_reviews_list_table()->display();
+
+		$output = ob_get_clean();
+
+		$this->assertContains( '<table class="wp-list-table"', $output );
+		$this->assertContains( '<tbody id="the-comment-list"', $output );
+	}
+
+	/**
 	 * Tests that can process the row output for a review or reply.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::single_row()

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -41,8 +41,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$output = ob_get_clean();
 
-		$this->assertContains( '<table class="wp-list-table"', $output );
-		$this->assertContains( '<tbody id="the-comment-list"', $output );
+		$this->assertStringContainsString( '<table class="wp-list-table"', $output );
+		$this->assertStringContainsString( '<tbody id="the-comment-list"', $output );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -41,8 +41,8 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( '<table class="wp-list-table"', $output );
-		$this->assertStringContainsString( '<tbody id="the-comment-list"', $output );
+		$this->assertStringContainsString( '<table class="wp-list-table', $output );
+		$this->assertStringContainsString( '<tbody id="the-comment-list', $output );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Ensures that the unapproved (moderated) reviews will apply the same styles as the corresponding comments in the comments page.

### Story: [MWC 5399](https://jira.godaddy.com/browse/MWC-5399)

#### Base PR: #25 

## Details

To accomplish this, I simply ensured that the CSS elements matched the comments page. Unfortunately to do so had to override a whole method because the ID of the table was hardcoded in the comments list method override. 

To make it easier for testing, I have based this PR on #25.

## QA

- [x] Code review
- [x] Unit tests pass

### User testing

1. Have product reviews in your installation
1. Moderate (unapprove) a review
    - [x] The same styles as unapproved comment will apply to the unapproved review
1. Approve the review back
    - [x] The normal styles will be applied to approved reviews

## Before merge

- [x] #25 is reviewed and merged first