### PR TITLE
Display notices after a bulk action is completed

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -11,7 +11,7 @@ namespace Automattic\WooCommerce\Internal\Admin;
 class Reviews {
 
 	/**
-	 * Admin page identifier.
+	 * Admin page identifier. (test with commit)
 	 */
 	const MENU_SLUG = 'product-reviews';
 

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -96,6 +96,18 @@ class Reviews {
 			$this->maybe_display_reviews_bulk_action_notice();
 		}
 	}
+
+	/**
+	 * May display the bulk action admin notice.
+	 *
+	 * @return void
+	 */
+	public function maybe_display_reviews_bulk_action_notice() {
+
+		$messages = $this->get_bulk_action_notice_messages();
+
+		echo ! empty( $messages ) ? '<div id="moderated" class="updated"><p>' . implode( "<br/>\n", $messages ) . '</p></div>' : '';  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
 	/**
 	 * Counts the number of pending product reviews/replies, and returns the notification bubble if there's more than zero.
 	 *

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -104,7 +104,7 @@ class Reviews {
 	 *
 	 * @return void
 	 */
-	public function maybe_display_reviews_bulk_action_notice() {
+	protected function maybe_display_reviews_bulk_action_notice() {
 
 		$messages = $this->get_bulk_action_notice_messages();
 

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -158,6 +158,11 @@ class Reviews {
 			$messages[] = sprintf( _n( '%s comment restored from the Trash', '%s comments restored from the Trash', $untrashed, 'woocommerce' ), $untrashed );
 		}
 
+		if ( $deleted > 0 ) {
+			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
+			$messages[] = sprintf( _n( '%s comment permanently deleted', '%s comments permanently deleted', $deleted, 'woocommerce' ), $deleted );
+		}
+
 		return $messages;
 	}
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -147,6 +147,12 @@ class Reviews {
 			$messages[] = sprintf( _n( '%s comment restored from the spam', '%s comments restored from the spam', $unspammed, 'woocommerce' ), $unspammed );
 		}
 
+		if ( $trashed > 0 ) {
+			$ids = isset( $_REQUEST['ids'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ids'] ) ) : 0;
+			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
+			$messages[] = sprintf( _n( '%s comment moved to the Trash.', '%s comments moved to the Trash.', $trashed, 'woocommerce' ), $trashed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=untrash&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
+		}
+
 		return $messages;
 	}
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -153,6 +153,11 @@ class Reviews {
 			$messages[] = sprintf( _n( '%s comment moved to the Trash.', '%s comments moved to the Trash.', $trashed, 'woocommerce' ), $trashed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=untrash&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
 		}
 
+		if ( $untrashed > 0 ) {
+			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
+			$messages[] = sprintf( _n( '%s comment restored from the Trash', '%s comments restored from the Trash', $untrashed, 'woocommerce' ), $untrashed );
+		}
+
 		return $messages;
 	}
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -116,7 +116,7 @@ class Reviews {
 	 *
 	 * @return array
 	 */
-	public function get_bulk_action_notice_messages() : array {
+	protected function get_bulk_action_notice_messages() : array {
 
 		$approved   = isset( $_REQUEST['approved'] ) ? (int) $_REQUEST['approved'] : 0;
 		$unapproved = isset( $_REQUEST['unapproved'] ) ? (int) $_REQUEST['unapproved'] : 0;
@@ -167,6 +167,7 @@ class Reviews {
 
 		return $messages;
 	}
+
 	/**
 	 * Counts the number of pending product reviews/replies, and returns the notification bubble if there's more than zero.
 	 *

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -116,6 +116,14 @@ class Reviews {
 	 */
 	public function get_bulk_action_notice_messages() : array {
 
+		$approved   = isset( $_REQUEST['approved'] ) ? (int) $_REQUEST['approved'] : 0;
+		$unapproved = isset( $_REQUEST['unapproved'] ) ? (int) $_REQUEST['unapproved'] : 0;
+		$deleted    = isset( $_REQUEST['deleted'] ) ? (int) $_REQUEST['deleted'] : 0;
+		$trashed    = isset( $_REQUEST['trashed'] ) ? (int) $_REQUEST['trashed'] : 0;
+		$untrashed  = isset( $_REQUEST['untrashed'] ) ? (int) $_REQUEST['untrashed'] : 0;
+		$spammed    = isset( $_REQUEST['spammed'] ) ? (int) $_REQUEST['spammed'] : 0;
+		$unspammed  = isset( $_REQUEST['unspammed'] ) ? (int) $_REQUEST['unspammed'] : 0;
+
 		$messages = [];
 
 		return $messages;

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -131,6 +131,11 @@ class Reviews {
 			$messages[] = sprintf( _n( '%s comment approved', '%s comments approved', $approved, 'woocommerce' ), $approved );
 		}
 
+		if ( $unapproved > 0 ) {
+			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
+			$messages[] = sprintf( _n( '%s comment unapproved', '%s comments unapproved', $unapproved, 'woocommerce' ), $unapproved );
+		}
+
 		return $messages;
 	}
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -41,6 +41,8 @@ class Reviews {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_reviews_page' ] );
+
+		add_action( 'admin_notices', [ $this, 'display_notices' ] );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -126,6 +126,11 @@ class Reviews {
 
 		$messages = [];
 
+		if ( $approved > 0 ) {
+			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
+			$messages[] = sprintf( _n( '%s comment approved', '%s comments approved', $approved, 'woocommerce' ), $approved );
+		}
+
 		return $messages;
 	}
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -11,7 +11,7 @@ namespace Automattic\WooCommerce\Internal\Admin;
 class Reviews {
 
 	/**
-	 * Admin page identifier. (test with commit)
+	 * Admin page identifier.
 	 */
 	const MENU_SLUG = 'product-reviews';
 

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -108,6 +108,18 @@ class Reviews {
 
 		echo ! empty( $messages ) ? '<div id="moderated" class="updated"><p>' . implode( "<br/>\n", $messages ) . '</p></div>' : '';  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
+
+	/**
+	 * Gets the applicable bulk action admin notice messages.
+	 *
+	 * @return array
+	 */
+	public function get_bulk_action_notice_messages() : array {
+
+		$messages = [];
+
+		return $messages;
+	}
 	/**
 	 * Counts the number of pending product reviews/replies, and returns the notification bubble if there's more than zero.
 	 *

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -130,39 +130,39 @@ class Reviews {
 
 		if ( $approved > 0 ) {
 			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
-			$messages[] = sprintf( _n( '%s comment approved', '%s comments approved', $approved, 'woocommerce' ), $approved );
+			$messages[] = sprintf( _n( '%s review approved', '%s reviews approved', $approved, 'woocommerce' ), $approved );
 		}
 
 		if ( $unapproved > 0 ) {
 			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
-			$messages[] = sprintf( _n( '%s comment unapproved', '%s comments unapproved', $unapproved, 'woocommerce' ), $unapproved );
+			$messages[] = sprintf( _n( '%s review unapproved', '%s reviews unapproved', $unapproved, 'woocommerce' ), $unapproved );
 		}
 
 		if ( $spammed > 0 ) {
 			$ids = isset( $_REQUEST['ids'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ids'] ) ) : 0;
 			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
-			$messages[] = sprintf( _n( '%s comment marked as spam.', '%s comments marked as spam.', $spammed, 'woocommerce' ), $spammed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=unspam&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
+			$messages[] = sprintf( _n( '%s review marked as spam.', '%s reviews marked as spam.', $spammed, 'woocommerce' ), $spammed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=unspam&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
 		}
 
 		if ( $unspammed > 0 ) {
 			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
-			$messages[] = sprintf( _n( '%s comment restored from the spam', '%s comments restored from the spam', $unspammed, 'woocommerce' ), $unspammed );
+			$messages[] = sprintf( _n( '%s review restored from the spam', '%s reviews restored from the spam', $unspammed, 'woocommerce' ), $unspammed );
 		}
 
 		if ( $trashed > 0 ) {
 			$ids = isset( $_REQUEST['ids'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ids'] ) ) : 0;
 			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
-			$messages[] = sprintf( _n( '%s comment moved to the Trash.', '%s comments moved to the Trash.', $trashed, 'woocommerce' ), $trashed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=untrash&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
+			$messages[] = sprintf( _n( '%s review moved to the Trash.', '%s reviews moved to the Trash.', $trashed, 'woocommerce' ), $trashed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=untrash&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
 		}
 
 		if ( $untrashed > 0 ) {
 			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
-			$messages[] = sprintf( _n( '%s comment restored from the Trash', '%s comments restored from the Trash', $untrashed, 'woocommerce' ), $untrashed );
+			$messages[] = sprintf( _n( '%s review restored from the Trash', '%s reviews restored from the Trash', $untrashed, 'woocommerce' ), $untrashed );
 		}
 
 		if ( $deleted > 0 ) {
 			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
-			$messages[] = sprintf( _n( '%s comment permanently deleted', '%s comments permanently deleted', $deleted, 'woocommerce' ), $deleted );
+			$messages[] = sprintf( _n( '%s review permanently deleted', '%s reviews permanently deleted', $deleted, 'woocommerce' ), $deleted );
 		}
 
 		return $messages;

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -84,6 +84,18 @@ class Reviews {
 
 		return 'edit.php' === $pagenow && isset( $_GET['page'] ) && 'product-reviews' === $_GET['page'];
 	}
+
+	/**
+	 * Displays notices on the Reviews page.
+	 *
+	 * @return void
+	 */
+	public function display_notices() {
+
+		if ( $this->is_reviews_page() ) {
+			$this->maybe_display_reviews_bulk_action_notice();
+		}
+	}
 	/**
 	 * Counts the number of pending product reviews/replies, and returns the notification bubble if there's more than zero.
 	 *

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -82,9 +82,9 @@ class Reviews {
 	 * @return bool
 	 */
 	public function is_reviews_page() : bool {
-		global $pagenow;
+		global $current_screen;
 
-		return 'edit.php' === $pagenow && isset( $_GET['page'] ) && 'product-reviews' === $_GET['page'];
+		return isset( $current_screen->base ) && 'product_page_product-reviews' === $current_screen->base;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -142,6 +142,11 @@ class Reviews {
 			$messages[] = sprintf( _n( '%s comment marked as spam.', '%s comments marked as spam.', $spammed, 'woocommerce' ), $spammed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=unspam&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
 		}
 
+		if ( $unspammed > 0 ) {
+			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
+			$messages[] = sprintf( _n( '%s comment restored from the spam', '%s comments restored from the spam', $unspammed, 'woocommerce' ), $unspammed );
+		}
+
 		return $messages;
 	}
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -75,6 +75,16 @@ class Reviews {
 	}
 
 	/**
+	 * Determines whether the current page is the reviews page.
+	 *
+	 * @return bool
+	 */
+	public function is_reviews_page() : bool {
+		global $pagenow;
+
+		return 'edit.php' === $pagenow && isset( $_GET['page'] ) && 'product-reviews' === $_GET['page'];
+	}
+	/**
 	 * Counts the number of pending product reviews/replies, and returns the notification bubble if there's more than zero.
 	 *
 	 * @return string Empty string if there are no pending reviews, or bubble HTML if there are.

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -136,6 +136,12 @@ class Reviews {
 			$messages[] = sprintf( _n( '%s comment unapproved', '%s comments unapproved', $unapproved, 'woocommerce' ), $unapproved );
 		}
 
+		if ( $spammed > 0 ) {
+			$ids = isset( $_REQUEST['ids'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ids'] ) ) : 0;
+			/* translators: %s is an integer higher than 0 (1, 2, 3...) */
+			$messages[] = sprintf( _n( '%s comment marked as spam.', '%s comments marked as spam.', $spammed, 'woocommerce' ), $spammed ) . ' <a href="' . esc_url( wp_nonce_url( "edit-comments.php?doaction=undo&action=unspam&ids=$ids", 'bulk-comments' ) ) . '">' . __( 'Undo', 'woocommerce' ) . '</a><br />';
+		}
+
 		return $messages;
 	}
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -182,7 +182,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * @dataProvider provider_is_reviews_page
 	 *
 	 * @param string|null $new_pagenow     the value of the global $pageview var.
-	 * @param string|null $page            the value of $_GET['page'].
+	 * @param string|null $page            the value of $_GET[ 'page' ].
 	 * @param bool        $expected_result the expected bool result.
 	 * @return void
 	 */
@@ -229,6 +229,131 @@ class ReviewsTest extends WC_Unit_Test_Case {
 			'new_pagenow'     => 'edit.php',
 			'page'            => 'product-reviews',
 			'expected_result' => true,
+		];
+	}
+
+	/**
+	 * Tests that the admin notice messages are properly returned.
+	 *
+	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::get_bulk_action_notice_messages()
+	 * @dataProvider provider_get_bulk_action_notice_messages
+	 *
+	 * @param string[] $statuses        the wp comment statuses after a bulk operation.
+	 * @param int      $count           the number of affected comments.
+	 * @param array    $expected_result the action notice messages.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_bulk_action_notice_messages( $statuses, $count, $expected_result ) {
+
+		$reviews = new Reviews();
+
+		$method = ( new ReflectionClass( $reviews ) )->getMethod( 'get_bulk_action_notice_messages' );
+		$method->setAccessible( true );
+
+		foreach ( $statuses as $status ) {
+			$_REQUEST[ $status ] = $count;
+		}
+		$_REQUEST['ids'] = '1,2,3';
+
+		$result = $method->invoke( $reviews );
+
+		foreach ( $expected_result as $i => $expected_message ) {
+			$this->assertContains( $expected_message, $result[ $i ] );
+		}
+	}
+
+	/** @see test_get_bulk_action_notice_messages */
+	public function provider_get_bulk_action_notice_messages() : Generator {
+
+		yield 'An approved comment status' => [
+			'status'         => [ 'approved' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment approved' ],
+		];
+
+		yield 'Two approved comment statuses' => [
+			'status'         => [ 'approved' ],
+			'count'          => 2,
+			'expected_array' => [ '2 comments approved' ],
+		];
+
+		yield 'An unapproved comment status' => [
+			'status'         => [ 'unapproved' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment unapproved' ],
+		];
+
+		yield 'Two unapproved comment statuses' => [
+			'status'         => [ 'unapproved' ],
+			'count'          => 2,
+			'expected_array' => [ '2 comments unapproved' ],
+		];
+
+		yield 'A deleted comment status' => [
+			'status'         => [ 'deleted' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment permanently deleted' ],
+		];
+
+		yield 'Two deleted comment statuses' => [
+			'status'         => [ 'deleted' ],
+			'count'          => 2,
+			'expected_array' => [ '2 comments permanently deleted' ],
+		];
+
+		yield 'A trashed comment status' => [
+			'status'         => [ 'trashed' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment moved to the Trash.' ],
+		];
+
+		yield 'Two trashed comment statuses' => [
+			'status'         => [ 'trashed' ],
+			'count'          => 2,
+			'expected_array' => [ '2 comments moved to the Trash.' ],
+		];
+
+		yield 'An untrashed comment status' => [
+			'status'         => [ 'untrashed' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment restored from the Trash' ],
+		];
+
+		yield 'Two untrashed comment statuses' => [
+			'status'         => [ 'untrashed' ],
+			'count'          => 2,
+			'expected_array' => [ '2 comments restored from the Trash' ],
+		];
+
+		yield 'A spammed comment status' => [
+			'status'         => [ 'spammed' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment marked as spam.' ],
+		];
+
+		yield 'Two spammed comment statuses' => [
+			'status'         => [ 'spammed' ],
+			'count'          => 2,
+			'expected_array' => [ '2 comments marked as spam.' ],
+		];
+
+		yield 'An unspammed comment status' => [
+			'status'         => [ 'unspammed' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment restored from the spam' ],
+		];
+
+		yield 'Two unspammed comment statuses' => [
+			'status'         => [ 'unspammed' ],
+			'count'          => 2,
+			'expected_array' => [ '2 comments restored from the spam' ],
+		];
+
+		yield 'Two different statuses' => [
+			'status'         => [ 'approved', 'unapproved' ],
+			'count'          => 1,
+			'expected_array' => [ '1 comment approved', '1 comment unapproved' ],
 		];
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -190,17 +190,14 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::is_reviews_page()
 	 * @dataProvider provider_is_reviews_page
 	 *
-	 * @param string|null $new_pagenow     the value of the global $pageview var.
-	 * @param string|null $page            the value of $_GET[ 'page' ].
+	 * @param string|null $new_current_screen     the value of the global $pageview var.
 	 * @param bool        $expected_result the expected bool result.
 	 * @return void
 	 */
-	public function test_is_reviews_page( $new_pagenow, $page, $expected_result ) {
-		global $pagenow;
+	public function test_is_reviews_page( $new_current_screen, $expected_result ) {
+		global $current_screen;
 
-		$pagenow = $new_pagenow; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-
-		$_GET['page'] = $page;
+		$current_screen = $new_current_screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		$reviews = new Reviews();
 
@@ -210,34 +207,28 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	/** @see test_is_reviews_page */
 	public function provider_is_reviews_page() : Generator {
 
-		yield 'Global pagenow is null' => [
-			'new_pagenow'     => null,
-			'page'            => null,
-			'expected_result' => false,
+		yield 'Global current_screen is null' => [
+			'new_current_screen' => null,
+			'expected_result'    => false,
 		];
 
-		yield 'Global pagenow is anything other than the edit page' => [
-			'new_pagenow'     => 'test.php',
-			'page'            => null,
-			'expected_result' => false,
+		yield 'Global current_screen has no base' => [
+			'new_current_screen' => (object) [],
+			'expected_result'    => false,
 		];
 
-		yield 'Page is null' => [
-			'new_pagenow'     => 'edit.php',
-			'page'            => null,
-			'expected_result' => false,
+		$any_screen = (object) [ 'base' => 'any-page' ];
+
+		yield 'current_screen->base is anything other than the reviews page' => [
+			'new_current_screen' => $any_screen,
+			'expected_result'    => false,
 		];
 
-		yield 'Page is anything other than product-reviews' => [
-			'new_pagenow'     => 'edit.php',
-			'page'            => 'test',
-			'expected_result' => false,
-		];
+		$reviews_screen = (object) [ 'base' => 'product_page_product-reviews' ];
 
 		yield 'Page is product-reviews' => [
-			'new_pagenow'     => 'edit.php',
-			'page'            => 'product-reviews',
-			'expected_result' => true,
+			'new_current_screen' => $reviews_screen,
+			'expected_result'    => true,
 		];
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -20,9 +20,9 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * Sets the global vars before each test.
 	 */
 	public function setUp() : void {
-		global $pagenow;
+		global $current_screen;
 
-		$this->old_pagenow = $pagenow;
+		$this->old_current_screen = $current_screen;
 
 		parent::setUp();
 	}
@@ -31,9 +31,11 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * Restores the global vars after each test.
 	 */
 	public function tearDown() : void {
-		global $pagenow;
+		global $current_screen;
 
-		$pagenow = $this->old_pagenow; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$current_screen = $this->old_current_screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		parent::tearDown();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -268,94 +268,94 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	/** @see test_get_bulk_action_notice_messages */
 	public function provider_get_bulk_action_notice_messages() : Generator {
 
-		yield 'An approved comment status' => [
+		yield 'An approved review status' => [
 			'status'         => [ 'approved' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment approved' ],
+			'expected_array' => [ '1 review approved' ],
 		];
 
-		yield 'Two approved comment statuses' => [
+		yield 'Two approved review statuses' => [
 			'status'         => [ 'approved' ],
 			'count'          => 2,
-			'expected_array' => [ '2 comments approved' ],
+			'expected_array' => [ '2 reviews approved' ],
 		];
 
-		yield 'An unapproved comment status' => [
+		yield 'An unapproved review status' => [
 			'status'         => [ 'unapproved' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment unapproved' ],
+			'expected_array' => [ '1 review unapproved' ],
 		];
 
-		yield 'Two unapproved comment statuses' => [
+		yield 'Two unapproved review statuses' => [
 			'status'         => [ 'unapproved' ],
 			'count'          => 2,
-			'expected_array' => [ '2 comments unapproved' ],
+			'expected_array' => [ '2 reviews unapproved' ],
 		];
 
-		yield 'A deleted comment status' => [
+		yield 'A deleted review status' => [
 			'status'         => [ 'deleted' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment permanently deleted' ],
+			'expected_array' => [ '1 review permanently deleted' ],
 		];
 
-		yield 'Two deleted comment statuses' => [
+		yield 'Two deleted review statuses' => [
 			'status'         => [ 'deleted' ],
 			'count'          => 2,
-			'expected_array' => [ '2 comments permanently deleted' ],
+			'expected_array' => [ '2 reviews permanently deleted' ],
 		];
 
-		yield 'A trashed comment status' => [
+		yield 'A trashed review status' => [
 			'status'         => [ 'trashed' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment moved to the Trash.' ],
+			'expected_array' => [ '1 review moved to the Trash.' ],
 		];
 
-		yield 'Two trashed comment statuses' => [
+		yield 'Two trashed review statuses' => [
 			'status'         => [ 'trashed' ],
 			'count'          => 2,
-			'expected_array' => [ '2 comments moved to the Trash.' ],
+			'expected_array' => [ '2 reviews moved to the Trash.' ],
 		];
 
-		yield 'An untrashed comment status' => [
+		yield 'An untrashed review status' => [
 			'status'         => [ 'untrashed' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment restored from the Trash' ],
+			'expected_array' => [ '1 review restored from the Trash' ],
 		];
 
-		yield 'Two untrashed comment statuses' => [
+		yield 'Two untrashed review statuses' => [
 			'status'         => [ 'untrashed' ],
 			'count'          => 2,
-			'expected_array' => [ '2 comments restored from the Trash' ],
+			'expected_array' => [ '2 reviews restored from the Trash' ],
 		];
 
-		yield 'A spammed comment status' => [
+		yield 'A spammed review status' => [
 			'status'         => [ 'spammed' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment marked as spam.' ],
+			'expected_array' => [ '1 review marked as spam.' ],
 		];
 
-		yield 'Two spammed comment statuses' => [
+		yield 'Two spammed review statuses' => [
 			'status'         => [ 'spammed' ],
 			'count'          => 2,
-			'expected_array' => [ '2 comments marked as spam.' ],
+			'expected_array' => [ '2 reviews marked as spam.' ],
 		];
 
-		yield 'An unspammed comment status' => [
+		yield 'An unspammed review status' => [
 			'status'         => [ 'unspammed' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment restored from the spam' ],
+			'expected_array' => [ '1 review restored from the spam' ],
 		];
 
-		yield 'Two unspammed comment statuses' => [
+		yield 'Two unspammed review statuses' => [
 			'status'         => [ 'unspammed' ],
 			'count'          => 2,
-			'expected_array' => [ '2 comments restored from the spam' ],
+			'expected_array' => [ '2 reviews restored from the spam' ],
 		];
 
 		yield 'Two different statuses' => [
 			'status'         => [ 'approved', 'unapproved' ],
 			'count'          => 1,
-			'expected_array' => [ '1 comment approved', '1 comment unapproved' ],
+			'expected_array' => [ '1 review approved', '1 review unapproved' ],
 		];
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -357,4 +357,55 @@ class ReviewsTest extends WC_Unit_Test_Case {
 		];
 	}
 
+	/**
+	 * Tests that a notice message will result in a valid HTML return.
+	 *
+	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::maybe_display_reviews_bulk_action_notice()
+	 * @dataProvider provider_maybe_display_reviews_bulk_action_notice
+	 *
+	 * @param array  $messages        the action notice messages.
+	 * @param string $expected_result the expected result.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_maybe_display_reviews_bulk_action_notice( $messages, $expected_result ) {
+
+		$mock = $this->getMockBuilder( Reviews::class )
+			->setMethods( [ 'get_bulk_action_notice_messages' ] )
+			->getMock();
+
+		$mock->expects( $this->once() )
+			->method( 'get_bulk_action_notice_messages' )
+			->willReturn( $messages );
+
+		$method = ( new ReflectionClass( $mock ) )->getMethod( 'maybe_display_reviews_bulk_action_notice' );
+		$method->setAccessible( true );
+
+		ob_start();
+
+		$method->invoke( $mock );
+
+		$this->assertSame( $expected_result, ob_get_clean() );
+	}
+
+	/** @see test_maybe_display_reviews_bulk_action_notice */
+	public function provider_maybe_display_reviews_bulk_action_notice() : Generator {
+
+		yield 'No messages are returned' => [
+			'messages'        => [],
+			'expected_result' => '',
+		];
+
+		yield 'A message is returned' => [
+			'messages'        => [ 'test' ],
+			'expected_result' => '<div id="moderated" class="updated"><p>test</p></div>',
+		];
+
+		yield 'Two messages are returned' => [
+			'messages'        => [ 'test1', 'test2' ],
+			'expected_result' => '<div id="moderated" class="updated"><p>test1<br/>
+test2</p></div>',
+		];
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -251,6 +251,8 @@ class ReviewsTest extends WC_Unit_Test_Case {
 		$method = ( new ReflectionClass( $reviews ) )->getMethod( 'get_bulk_action_notice_messages' );
 		$method->setAccessible( true );
 
+		$_REQUEST = [];
+
 		foreach ( $statuses as $status ) {
 			$_REQUEST[ $status ] = $count;
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -408,4 +408,43 @@ test2</p></div>',
 		];
 	}
 
+	/**
+	 * Tests that the display method is called only for the reviews page.
+	 *
+	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::display_notices()
+	 * @dataProvider provider_display_notices
+	 *
+	 * @param bool $is_reviews_page                whether the current page is the reviews page or not.
+	 * @param bool $should_call_the_display_method indicates if the display method should be called.
+	 */
+	public function test_display_notices( $is_reviews_page, $should_call_the_display_method ) {
+
+		$mock = $this->getMockBuilder( Reviews::class )
+			->setMethods( [ 'is_reviews_page', 'maybe_display_reviews_bulk_action_notice' ] )
+			->getMock();
+
+		$mock->expects( $this->once() )
+			->method( 'is_reviews_page' )
+			->willReturn( $is_reviews_page );
+
+		$mock->expects( $this->exactly( (int) $should_call_the_display_method ) )
+			->method( 'maybe_display_reviews_bulk_action_notice' );
+
+		$mock->display_notices();
+	}
+
+	/** @see test_display_notices */
+	public function provider_display_notices() : Generator {
+
+		yield 'Is the reviews page' => [
+			'is_reviews_page'                          => true,
+			'maybe_display_reviews_bulk_action_notice' => true,
+		];
+
+		yield 'Is not the reviews page' => [
+			'is_reviews_page'                          => false,
+			'maybe_display_reviews_bulk_action_notice' => false,
+		];
+	}
+
 }


### PR DESCRIPTION
# Summary

Implements the row actions for the product reviews page.

### Story: [MWC 5349](https://jira.godaddy.com/browse/MWC-5349)

## QA

- [x] Code review
- [x] Unit tests pass

### User testing

1. Add two or more comments to any products in your store
1. Go to Products > Reviews
1. Make notes of the comments IDs by inspecting their checkboxes
1. Select more than one comment and then apply the _Unapprove_ bulk action
    - [x] I see the _X comments unapproved_ admin notice where `X` is the number of comments you have
1. Run `select comment_ID, comment_approved from wp_comments where comment_ID IN(2,3)` and replace the `IN` content with your IDs
    - [x] The `comment_approved` column is `0` for them
1. Repeat the steps above and select _Approve_ + running the SQL
    - [x] I see the _X comments approved_ admin notice where `X` is the number of comments you have
    - [x] The `comment_approved` column is `1` for them
1. Repeat the steps above and select _Mark as SPAM_ + running the SQL
    - [x] I see the _X comments marked as spam_ admin notice where `X` is the number of comments you have
    - [x] The `comment_approved` column is `spam` for them
    - [x] The notice has an _Undo_ link
1. Click on the _Undo_ link
    - [x] The comments are restored with ~the _approved_~ their previous status
1. Repeat the _spam_ tests above with _Move to Trash_
    - [x] I see the _X comments moved to the Trash_ admin notice where `X` is the number of comments you have
    - [x] The `comment_approved` column is `trash` for them
    - [x] The notice has an _Undo_ link
    - [x] The comments are restored with ~the _approved_~ their previous status when I click on _Undo_