### PR TITLE
Make notice dismissible

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -64,9 +64,7 @@ class ReviewsCommentsOverrides {
 			<p><?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?></p>
 			<p class="submit">
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a>
-				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button">
-					<?php esc_html_e( 'Dismiss', 'woocommerce' ); ?>
-				</a>
+				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
 			</p>
 		</div>
 

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -9,6 +9,8 @@ use WP_Comment_Query;
  */
 class ReviewsCommentsOverrides {
 
+	const REVIEWS_MOVED_NOTICE_ID = 'product_reviews_moved';
+
 	/**
 	 * Class instance.
 	 *
@@ -36,6 +38,11 @@ class ReviewsCommentsOverrides {
 			return;
 		}
 
+		// Do not display if the current user has dismissed this notice.
+		if ( get_user_meta( get_current_user_id(), 'dismissed_' . static::REVIEWS_MOVED_NOTICE_ID . '_notice', true ) ) {
+			return;
+		}
+
 		$this->display_reviews_moved_notice();
 	}
 
@@ -43,15 +50,10 @@ class ReviewsCommentsOverrides {
 	 * Renders an admin notice informing the user that reviews were moved to a new page.
 	 */
 	protected function display_reviews_moved_notice() {
-		$notice_name = 'product_reviews_moved';
-		if ( get_user_meta( get_current_user_id(), 'dismissed_' . $notice_name . '_notice', true ) ) {
-			return;
-		}
-
 		$dismiss_url = wp_nonce_url(
 			add_query_arg(
 				[
-					'wc-hide-notice' => urlencode( $notice_name ),
+					'wc-hide-notice' => urlencode( static::REVIEWS_MOVED_NOTICE_ID ),
 				]
 			),
 			'woocommerce_hide_notices_nonce',

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsCommentsOverrides.php
@@ -43,12 +43,31 @@ class ReviewsCommentsOverrides {
 	 * Renders an admin notice informing the user that reviews were moved to a new page.
 	 */
 	protected function display_reviews_moved_notice() {
+		$notice_name = 'product_reviews_moved';
+		if ( get_user_meta( get_current_user_id(), 'dismissed_' . $notice_name . '_notice', true ) ) {
+			return;
+		}
+
+		$dismiss_url = wp_nonce_url(
+			add_query_arg(
+				[
+					'wc-hide-notice' => urlencode( $notice_name ),
+				]
+			),
+			'woocommerce_hide_notices_nonce',
+			'_wc_notice_nonce'
+		);
 		?>
 
 		<div class="notice notice-info">
 			<p><strong><?php esc_html_e( 'Product reviews have moved!', 'woocommerce' ); ?></strong></p>
 			<p><?php esc_html_e( 'Product reviews can now be managed from Products > Reviews.', 'woocommerce' ); ?></p>
-			<p class="submit"><a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a></p>
+			<p class="submit">
+				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=product&page=product-reviews' ) ); ?>" class="button-primary"><?php esc_html_e( 'Visit new location', 'woocommerce' ); ?></a>
+				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button">
+					<?php esc_html_e( 'Dismiss', 'woocommerce' ); ?>
+				</a>
+			</p>
 		</div>
 
 		<?php

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsCommentsOverridesTest.php
@@ -66,11 +66,16 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 
 		$output = trim( ob_get_clean() );
 
+		$nonce = wp_create_nonce( 'woocommerce_hide_notices_nonce' );
+
 		$this->assertSame(
 			'<div class="notice notice-info">
 			<p><strong>Product reviews have moved!</strong></p>
 			<p>Product reviews can now be managed from Products &gt; Reviews.</p>
-			<p class="submit"><a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">Visit new location</a></p>
+			<p class="submit">
+				<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">Visit new location</a>
+				<a href="?wc-hide-notice=product_reviews_moved&#038;_wc_notice_nonce=' . $nonce . '" class="button">Dismiss</a>
+			</p>
 		</div>',
 			$output
 		);


### PR DESCRIPTION
## Summary
Proof of concept to make the notice dismissable, utilizing WooCommerce's existing logic in `includes/admin/class-wc-admin-notices.php`

## Story: [MWC-5356](https://jira.godaddy.com/browse/MWC-5356)

## Details

Base PR: https://github.com/godaddy-wordpress/woocommerce/pull/21

Slack discussion: https://godaddy.slack.com/archives/C02PYQALB2Q/p1649961231898799?thread_ts=1649870560.853349&cid=C02PYQALB2Q

One quirk with using all of WooCommerce's existing logic is that dismissing a notice requires the `manage_woocommerce` capability. But someone could be viewing the comments page who doesn't have that..

This is a draft for now until we decide this is the route we want to go. Then tests can also be added.

## QA

- Visit Comments page.
    - [x] You see notice.
- Click the "Dismiss" button.
    - [x] Page refreshes and notice is now gone.
- Refresh the page again.
    - [x] Notice still doesn't appear.