### PR TITLE
Exclude reviews from regular comments count

### DIFF
--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -36,7 +36,7 @@ class WC_Comments {
 		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_webhook_comments' ), 10, 1 );
 		add_filter( 'comment_feed_where', array( __CLASS__, 'exclude_webhook_comments_from_feed_where' ) );
 
-		// Secure product reviews.
+		// Exclude product reviews.
 		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_product_reviews' ), 10, 1 );
 
 		// Count comments.

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -244,7 +244,8 @@ class WC_Comments {
 					"
 					SELECT comment_approved, COUNT(*) AS num_comments
 					FROM {$wpdb->comments}
-					WHERE comment_type NOT IN ('action_log', 'order_note', 'webhook_delivery')
+					LEFT JOIN {$wpdb->posts} ON comment_post_ID = {$wpdb->posts}.ID
+					WHERE comment_type NOT IN ('action_log', 'order_note', 'webhook_delivery') AND {$wpdb->posts}.post_type NOT IN ('product')
 					GROUP BY comment_approved
 					",
 					ARRAY_A

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -241,7 +241,7 @@ class WC_Comments {
 	}
 
 	/**
-	 * Remove order notes and webhook delivery logs from wp_count_comments().
+	 * Remove order notes, webhook delivery logs, and product reviews from wp_count_comments().
 	 *
 	 * @since  2.2
 	 * @param  object $stats   Comment stats.

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -36,6 +36,9 @@ class WC_Comments {
 		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_webhook_comments' ), 10, 1 );
 		add_filter( 'comment_feed_where', array( __CLASS__, 'exclude_webhook_comments_from_feed_where' ) );
 
+		// Secure product reviews.
+		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_product_reviews' ), 10, 1 );
+
 		// Count comments.
 		add_filter( 'wp_count_comments', array( __CLASS__, 'wp_count_comments' ), 10, 2 );
 
@@ -72,6 +75,23 @@ class WC_Comments {
 			$open = false;
 		}
 		return $open;
+	}
+
+	/**
+	 * Removes product reviews from the edit-comments page to fix the "Mine" tab counter.
+	 *
+	 * @param  array $clauses A compacted array of comment query clauses.
+	 * @return array
+	 */
+	public static function exclude_product_reviews( $clauses ) {
+		global $wpdb, $current_screen;
+
+		if ( isset( $current_screen->base ) && 'edit-comments' === $current_screen->base ) {
+			$clauses['join']  .= " LEFT JOIN {$wpdb->posts} AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID ";
+			$clauses['where'] .= ( $clauses['where'] ? ' AND ' : '' ) . " wp_posts_to_exclude_reviews.post_type NOT IN ('product') ";
+		}
+
+		return $clauses;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -41,6 +41,8 @@ class Reviews {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_reviews_page' ] );
+
+		add_action( 'init', [ $this, 'override_wp_count_comments' ] );
 	}
 
 	/**
@@ -89,6 +91,16 @@ class Reviews {
 		);
 
 		add_action( "load-{$this->reviews_page_hook}", [ $this, 'load_reviews_screen' ] );
+	}
+
+	/**
+	 * Overrides the WordPress comments count functions.
+	 *
+	 * This is necessary to prevent product reviews to be counted as regular post comments.
+	 */
+	public function override_wp_count_comments() {
+
+		add_filter( 'wp_count_comments', [ $this, 'count_comments' ], 10, 2 );
 	}
 
 	/**
@@ -160,6 +172,134 @@ class Reviews {
 		 * @param ReviewsListTable $reviews_list_table The reviews list table instance.
 		 */
 		echo apply_filters( 'woocommerce_product_reviews_list_table', ob_get_clean(), $this->reviews_list_table ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	/**
+	 * Retrieves the total comment counts for the whole site or a single post.
+	 *
+	 * This method overrides the default count_comments from WordPress to not consider product reviews as comments.
+	 *
+	 * @param array $count   This param is not used, but added given that count_comments is a callback to a filter.
+	 * @param int   $post_id Optional. Restrict the comment counts to the given post. Default 0, which indicates that
+	 *                       comment counts for the whole site will be retrieved.
+	 * @return stdClass {
+	 *     The number of comments keyed by their status.
+	 *
+	 *     @type int $approved       The number of approved comments.
+	 *     @type int $moderated      The number of comments awaiting moderation (a.k.a. pending).
+	 *     @type int $spam           The number of spam comments.
+	 *     @type int $trash          The number of trashed comments.
+	 *     @type int $post-trashed   The number of comments for posts that are in the trash.
+	 *     @type int $total_comments The total number of non-trashed comments, including spam.
+	 *     @type int $all            The total number of pending or approved comments.
+	 * }
+	 */
+	public function count_comments( $count, $post_id = 0 ) {
+
+		$post_id = (int) $post_id;
+
+		/**
+		 * Filters the comments count for a given post or the whole site.
+		 *
+		 * @param array|stdClass $count   An empty array or an object containing comment counts.
+		 * @param int            $post_id The post ID. Can be 0 to represent the whole site.
+		 */
+		$filtered = apply_filters( 'woocommerce_product_reviews_count_comments', array(), $post_id );
+		if ( ! empty( $filtered ) ) {
+			return $filtered;
+		}
+
+		$count = wp_cache_get( "comments-{$post_id}", 'counts' );
+		if ( false !== $count ) {
+			return $count;
+		}
+
+		$stats              = $this->get_comment_count( $post_id );
+		$stats['moderated'] = $stats['awaiting_moderation'];
+		unset( $stats['awaiting_moderation'] );
+
+		$stats_object = (object) $stats;
+		wp_cache_set( "comments-{$post_id}", $stats_object, 'counts' );
+
+		return $stats_object;
+	}
+
+	/**
+	 * Retrieves the total comment counts for the whole site or a single post.
+	 *
+	 * This method overrides the default get_comment_count from WordPress to not consider product reviews as comments.
+	 *
+	 * @param int $post_id Optional. Restrict the comment counts to the given post. Default 0, which indicates that
+	 *                     comment counts for the whole site will be retrieved.
+	 * @return int[] {
+	 *     The number of comments keyed by their status.
+	 *
+	 *     @type int $approved            The number of approved comments.
+	 *     @type int $awaiting_moderation The number of comments awaiting moderation (a.k.a. pending).
+	 *     @type int $spam                The number of spam comments.
+	 *     @type int $trash               The number of trashed comments.
+	 *     @type int $post-trashed        The number of comments for posts that are in the trash.
+	 *     @type int $total_comments      The total number of non-trashed comments, including spam.
+	 *     @type int $all                 The total number of pending or approved comments.
+	 * }
+	 */
+	protected function get_comment_count( $post_id = 0 ) {
+		global $wpdb;
+
+		$post_id = (int) $post_id;
+
+		$where = '';
+		if ( $post_id > 0 ) {
+			$where = $wpdb->prepare( $where . ' AND comment_post_ID = %d', $post_id ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		}
+
+		$sql = "
+			SELECT comment_approved, COUNT( * ) AS total
+			FROM {$wpdb->comments}
+			WHERE comment_type <> 'review' {$where}
+			GROUP BY comment_approved
+		";
+
+		$totals = (array) $wpdb->get_results( $wpdb->prepare( $sql ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		$comment_count = array(
+			'approved'            => 0,
+			'awaiting_moderation' => 0,
+			'spam'                => 0,
+			'trash'               => 0,
+			'post-trashed'        => 0,
+			'total_comments'      => 0,
+			'all'                 => 0,
+		);
+
+		foreach ( $totals as $row ) {
+			switch ( $row['comment_approved'] ) {
+				case 'trash':
+					$comment_count['trash'] = $row['total'];
+					break;
+				case 'post-trashed':
+					$comment_count['post-trashed'] = $row['total'];
+					break;
+				case 'spam':
+					$comment_count['spam']            = $row['total'];
+					$comment_count['total_comments'] += $row['total'];
+					break;
+				case '1':
+					$comment_count['approved']        = $row['total'];
+					$comment_count['total_comments'] += $row['total'];
+					$comment_count['all']            += $row['total'];
+					break;
+				case '0':
+					$comment_count['awaiting_moderation'] = $row['total'];
+					$comment_count['total_comments']     += $row['total'];
+					$comment_count['all']                += $row['total'];
+					break;
+				default:
+					break;
+			}
+		}
+
+		return array_map( 'intval', $comment_count );
 	}
 
 }

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -194,7 +194,7 @@ class Reviews {
 	 *     @type int $all            The total number of pending or approved comments.
 	 * }
 	 */
-	public function count_comments( $count, $post_id = 0 ) {
+	public function count_comments( $count = [], $post_id = 0 ) {
 
 		$post_id = (int) $post_id;
 


### PR DESCRIPTION
# Summary

This PR updates how WordPress calculates comments counts to exclude product reviews from the totals.

### Story: [MWC 5398](https://jira.godaddy.com/browse/MWC-5398)

## Notes

* ⚠️ **The notes below are referring to this PR's first commit (https://github.com/godaddy-wordpress/woocommerce/pull/36/commits/6d0d513496fe33b23a216788410c6b7f189b6aba).**
  * I don't like the strategy used here, but unfortunately I couldn't come up with another solution... here's the thing:
    *  [`wp_count_comments`](https://developer.wordpress.org/reference/functions/wp_count_comments/) offers a single filter called `wp_count_comments` which is executed before the count is done. The best scenario here would be having a filter before the returned array, otherwise, we could only subtract them from the reviews totals;
    * That said, to achieve whats requested on MWC-5398, I had to make use of that filter, but replacing the two WordPress count functions with our implementation + tweaking the SQL to filter out product reviews;
    * That works for the counter bubble, for the comments page tabs, and also for any subsequent calls to WP's `count_comments`;
    * The reason I don't like that strategy is the fact that other plugins overriding the same functions may conflict with our implementation in case their filter has a lower priority. Still, if WordPress updates those functions in the future, we'd have to replicate the changes in the `Reviews` class.
    * Apparently, the current `woocommerce-product-reviews-pro` plugin doesn't handle those totals -- at least in my tests, post comments and product reviews are counting for those totals, so I guess we don't have a prior art on that.
  * Please, feel free to suggest any other strategy that comes to your mind.
  * **⚠️ Unit tests:** Given that this approach may lead to discussions, I've opted to not add tests now.

## QA

- [x] Code review
- [x] Unit tests pass

### User testing

1. Have at least a product and a blog post on your store
1. Post a few product reviews and a few post comments
    * Use an anonymous user so they will be pending approval
1. Go to `wp-admin`
    - [x] The comments bubble shows the number of pending **post comments**
1. Go to the Comments page
    - [x] The tabs over the comments table reflect the proper amounts (comments count only, not considering review amounts)
1. Go to a product page with reviews
    - [x] The reviews are shown