### PR TITLE
Filter out empty row actions.

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -462,7 +462,7 @@ class ReviewsListTable extends WP_List_Table {
 
 		$i = 0;
 
-		foreach ( $actions as $action => $link ) {
+		foreach ( array_filter( $actions ) as $action => $link ) {
 			++$i;
 
 			if ( ( ( 'approve' === $action || 'unapprove' === $action ) && 2 === $i ) || 1 === $i ) {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -122,6 +122,9 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			} else {
 				$this->assertStringContainsString( 'Trash', $actions );
 			}
+
+			// Should not contain any tags with _only_ a pipe separator, but no label.
+			$this->assertStringNotContainsString( '> | </span>', $actions );
 		}
 	}
 


### PR DESCRIPTION
## Summary

This ensures that actions not available to the current review do not output the separator.

I found this bug immediately after merging https://github.com/godaddy-wordpress/woocommerce/pull/25 😞 

## Story: [MWC-5465](https://jira.godaddy.com/browse/MWC-5465)

## UI Changes

### Before:

![row-actions](https://user-images.githubusercontent.com/99189195/164212778-670afce4-55ea-498f-95ab-41030f21d23d.png)

### After:

![row-actions-after](https://user-images.githubusercontent.com/99189195/164212828-11d369bd-ebed-485a-882d-224e2612ffaa.png)

## QA

1. Mark at least one review as spam.
2. Click the "Spam" filter at the top to show the spam reviews.
3. Hover over it.
    - [x] There's only one separator in between each option.
4. Perform same test for all other statuses.
    - [x] There's only one separator in between each option.