### PR TITLE
Load JavaScript & add quickedit/reply markup.

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -213,8 +213,8 @@ class Reviews {
 	public function handle_reply_to_review(): void {
 		check_ajax_referer( 'replyto-comment', '_ajax_nonce-replyto-comment' );
 
-		$reply_post_id = isset( $_POST['comment_post_ID'] ) ? (int) sanitize_text_field( wp_unslash( $_POST['comment_post_ID'] ) ) : 0;
-		$post          = get_post( $reply_post_id );
+		$comment_post_ID = isset( $_POST['comment_post_ID'] ) ? (int) sanitize_text_field( wp_unslash( $_POST['comment_post_ID'] ) ) : 0; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$post            = get_post( $comment_post_ID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 		if ( ! $post ) {
 			wp_die( -1 );
@@ -230,7 +230,7 @@ class Reviews {
 			return;
 		}
 
-		if ( ! current_user_can( 'edit_post', $reply_post_id ) ) {
+		if ( ! current_user_can( 'edit_post', $comment_post_ID ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 			wp_die( -1 );
 		}
 
@@ -277,13 +277,13 @@ class Reviews {
 		}
 
 		$comment_auto_approved = false;
-		$commentdata           = compact( 'reply_post_id', 'comment_author', 'comment_author_email', 'comment_author_url', 'comment_content', 'comment_type', 'comment_parent', 'user_ID' );
+		$commentdata           = compact( 'comment_post_ID', 'comment_author', 'comment_author_email', 'comment_author_url', 'comment_content', 'comment_type', 'comment_parent', 'user_ID' );
 
 		// Automatically approve parent comment.
 		if ( ! empty( $_POST['approve_parent'] ) ) {
 			$parent = get_comment( $comment_parent );
 
-			if ( $parent && '0' === $parent->comment_approved && $parent->comment_post_ID == $reply_post_id ) {
+			if ( $parent && '0' === $parent->comment_approved && $parent->comment_post_ID == $comment_post_ID ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 				if ( ! current_user_can( 'edit_comment', $parent->comment_ID ) ) {
 					wp_die( -1 );
 				}

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -145,8 +145,15 @@ class Reviews {
 	}
 
 	/**
-	 * Ajax callback for editing a review. This is based on {@see wp_ajax_edit_comment()}, and is designed to run
-	 * before that callback so we can override the rendering for a review.
+	 * Ajax callback for editing a review.
+	 *
+	 * This functionality is taken from {@see wp_ajax_edit_comment()} and is largely copy and pasted. The only thing
+	 * we want to change is the review row HTML in the response. WordPress core uses a comment list table and we need
+	 * to use our own {@see ReviewsListTable} class to support our custom columns.
+	 *
+	 * This ajax callback is registered with a lower priority than WordPress core's so that our code can run
+	 * first. If the supplied comment ID is not a review or a reply to a review, then we `return` early from this method
+	 * to allow the WordPress core callback to take over.
 	 *
 	 * @return void
 	 */
@@ -205,8 +212,15 @@ class Reviews {
 	}
 
 	/**
-	 * Ajax callback for replying to a review inline. This is based on {@see wp_ajax_replyto_comment()}, and is designed
-	 * to run before that callback so we can override the rendering for a review reply.
+	 * Ajax callback for replying to a review inline.
+	 *
+	 * This functionality is taken from {@see wp_ajax_replyto_comment()} and is largely copy and pasted. The only thing
+	 * we want to change is the review row HTML in the response. WordPress core uses a comment list table and we need
+	 * to use our own {@see ReviewsListTable} class to support our custom columns.
+	 *
+	 * This ajax callback is registered with a lower priority than WordPress core's so that our code can run
+	 * first. If the supplied comment ID is not a review or a reply to a review, then we `return` early from this method
+	 * to allow the WordPress core callback to take over.
 	 *
 	 * @return void
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -247,6 +247,7 @@ class Reviews {
 			$comment_author       = wp_slash( $user->display_name );
 			$comment_author_email = wp_slash( $user->user_email );
 			$comment_author_url   = wp_slash( $user->user_url );
+			// WordPress core already sanitizes `content` during the `pre_comment_content` hook, which is why it's not needed here.
 			$comment_content      = isset( $_POST['content'] ) ? wp_unslash( $_POST['content'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$comment_type         = isset( $_POST['comment_type'] ) ? sanitize_text_field( wp_unslash( $_POST['comment_type'] ) ) : 'comment';
 

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -43,6 +43,7 @@ class Reviews {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_reviews_page' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'load_javascript' ] );
 
 		add_action( 'admin_notices', [ $this, 'display_notices' ] );
 	}
@@ -108,6 +109,18 @@ class Reviews {
 		global $current_screen;
 
 		return isset( $current_screen->base ) && 'product_page_product-reviews' === $current_screen->base;
+	}
+
+	/**
+	 * Loads the JavaScript required for inline replies and quick edit.
+	 *
+	 * @return void
+	 */
+	public function load_javascript() : void {
+		if ( $this->is_reviews_page() ) {
+			wp_enqueue_script( 'admin-comments' );
+			enqueue_comment_hotkeys_js();
+		}
 	}
 
 	/**
@@ -252,6 +265,8 @@ class Reviews {
 			</form>
 		</div>
 		<?php
+		wp_comment_reply( '-1', true, 'detail' );
+		wp_comment_trashnotice();
 
 		/**
 		 * Filters the contents of the product reviews list table output.

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -873,6 +873,18 @@ class ReviewsListTable extends WP_List_Table {
 			'</div>'
 		);
 
+		if ( $this->current_user_can_edit_review ) {
+			?>
+			<div id="inline-<?php echo esc_attr( $item->comment_ID ); ?>" class="hidden">
+				<textarea class="comment" rows="1" cols="1"><?php echo esc_textarea( $item->comment_content ); ?></textarea>
+				<div class="author-email"><?php echo esc_attr( $item->comment_author_email ); ?></div>
+				<div class="author"><?php echo esc_attr( $item->comment_author ); ?></div>
+				<div class="author-url"><?php echo esc_attr( $item->comment_author_url ); ?></div>
+				<div class="comment_status"><?php echo esc_html( $item->comment_approved ); ?></div>
+			</div>
+			<?php
+		}
+
 		echo $this->filter_column_output( 'comment', ob_get_clean(), $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 


### PR DESCRIPTION
## Summary

Makes the following feature work:

- Quick edit
- Inline replies to reviews

## Story: [MWC-5353](https://jira.godaddy.com/browse/MWC-5353)

## Details

I didn't add many tests because the bulk of this was copy and pasted from WordPress core functions and honestly I didn't know how to test it.

## QA

- [x] Code review
- [x] Tests pass

### Reviews: Quick edit

- Hover over a review and click "Quick Edit".
- Make edits to the review and save.
    - [x] Review is re-rendered with correct columns.
    - [x] Review contains edited data.
- Refresh the page.
    - [x] Changes to the review you edited have still persisted.

### Reviews: Inline replies

- Hover over a review and click "Reply".
- Leave the reply box empty and submit.
    - [x] You get an error message.
- Type your reply and submit.
    - [x] Reply is inserted into the DOM correctly, with correct columns.
- Refresh the page.
    - [x] Reply is still listed correctly (note it's normal for the position within the table to be different, but your reply should have the same text/data).

### Comments: Quick edit

The point of this test is to ensure that we haven't disrupted the comments quick edit.

- Go to "Comments", hover over a comment, and click "Quick Edit".
- Make edits to the comment and save.
    - [x] Comment is re-rendered with correct columns (no "review" columns are present).

### Comments: Inline replies

The point of this test is to ensure that we haven't disrupted the comments inline reply.

- Hover over a comment, and click "Reply".
- Type your reply and submit.
    - [x] Reply is inserted into the DOM correctly, with correct columns (no "review" columns are present).