### PR TITLE
Update Manage all reviews link

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/reviews/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/reviews/index.js
@@ -294,7 +294,7 @@ class ReviewsPanel extends Component {
 				{ renderedReviews }
 				<Link
 					href={ getAdminLink(
-						'edit-comments.php?comment_type=review'
+						'edit.php?post_type=product&page=product-reviews'
 					) }
 					onClick={ () => this.recordReviewEvent( 'reviews_manage' ) }
 					className="woocommerce-layout__activity-panel-outbound-link woocommerce-layout__activity-panel-empty"


### PR DESCRIPTION
## Summary

This updates the "Manage all reviews" link on the WooCommerce "Home" screen.

## Story: [MWC-5357](https://jira.godaddy.com/browse/MWC-5357)

## Details

The story + discovery originally wrote about this being in a separate repo, but that `woocommerce-admin` repo has been merged into core, so we can do the PR now. No need to add the comment about waiting for it to be merged; it can just go in with all our other stuff.

## QA

1. Navigate to `/woocommerce-monorepo/plugins/woocommerce-admin`
2. Run `pnpm install`
3. Run `pnpm run dev`
4. In WordPress go to WooCommerce > Home.
5. Expand the "Reviews" panel and click "Manage all reviews"
    - [x] You are taken to our new reviews page.