### PR TITLE
Highlight Product Reviews when editing review or reply and update Edit Comment headline

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -225,11 +225,9 @@ class Reviews {
 	 * @return string
 	 */
 	public function edit_review_parent_file( $parent_file ) {
-		global $submenu_file;
+		global $submenu_file, $current_screen;
 
-		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-
-		if ( $screen && 'comment' === $screen->id && isset( $_GET['c'] ) ) {
+		if ( isset( $current_screen->id, $_GET['c'] ) && 'comment' === $current_screen->id ) {
 
 			$comment_id = absint( $_GET['c'] );
 			$comment = get_comment( $comment_id );

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -234,11 +234,11 @@ class Reviews {
 			$comment_id = absint( $_GET['c'] );
 			$comment = get_comment( $comment_id );
 
-			if ( $comment->comment_parent > 0 ) {
+			if ( isset( $comment->comment_parent ) && $comment->comment_parent > 0 ) {
 				$comment = get_comment( $comment->comment_parent );
 			}
 
-			if ( $comment && 'product' === get_post_type( $comment->comment_post_ID ) ) {
+			if ( isset( $comment->comment_post_ID ) && 'product' === get_post_type( $comment->comment_post_ID ) ) {
 				$parent_file  = 'edit.php?post_type=product';
 				$submenu_file = 'product-reviews'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			}

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -262,7 +262,7 @@ class Reviews {
 			return $translation;
 		}
 
-		// Try to get comment from query params.
+		// Try to get comment from query params when not in context already.
 		if ( ! $comment && isset( $_GET['action'], $_GET['c'] ) && 'editcomment' === $_GET['action'] ) {
 			$comment_id = absint( $_GET['c'] );
 			$comment    = get_comment( $comment_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -270,13 +270,13 @@ class Reviews {
 
 		$is_reply = false;
 
-		if ( $comment && $comment->comment_parent > 0 ) {
+		if ( isset( $comment->comment_parent ) && $comment->comment_parent > 0 ) {
 			$is_reply = true;
 			$comment = get_comment( $comment->comment_parent ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
 		// Only replace the translated text if we are editing a comment left on a product (ie. a review).
-		if ( $comment && 'product' === get_post_type( $comment->comment_post_ID ) ) {
+		if ( isset( $comment->comment_parent ) && 'product' === get_post_type( $comment->comment_post_ID ) ) {
 			if ( 'Edit Comment' === $text ) {
 				$translation = $is_reply
 					? __( 'Edit Review Reply', 'woocommerce' )

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -45,6 +45,8 @@ class Reviews {
 
 		add_action( 'admin_menu', [ $this, 'add_reviews_page' ] );
 
+		add_filter( 'parent_file', [ $this, 'edit_review_parent_file' ] );
+
 		add_action( 'admin_notices', [ $this, 'display_notices' ] );
 	}
 
@@ -212,6 +214,33 @@ class Reviews {
 		}
 
 		return ' <span class="awaiting-mod count-' . esc_attr( $count ) . '"><span class="pending-count">' . esc_html( $count ) . '</span></span>';
+	}
+
+	/**
+	 * Highlights Product -> Reviews admin menu item when editing a review or a reply to a review.
+	 *
+	 * @global string $submenu_file
+	 *
+	 * @param string $parent_file Parent menu item.
+	 * @return string
+	 */
+	public function edit_review_parent_file( $parent_file ) {
+		global $submenu_file;
+
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+		if ( $screen && 'comment' === $screen->id && isset( $_GET['c'] ) ) {
+
+			$comment_id = absint( $_GET['c'] );
+			$comment = get_comment( $comment_id );
+
+			if ( $comment && 'product' === get_post_type( $comment->comment_post_ID ) ) {
+				$parent_file  = 'edit.php?post_type=product';
+				$submenu_file = 'product-reviews'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			}
+		}
+
+		return $parent_file;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -47,7 +47,7 @@ class Reviews {
 
 		add_filter( 'parent_file', [ $this, 'edit_review_parent_file' ] );
 
-		add_filter( 'gettext', array( $this, 'filter_edit_comments_screen_translations' ), 10, 2 );
+		add_filter( 'gettext', [ $this, 'edit_comments_screen_text' ], 10, 2 );
 
 		add_action( 'admin_notices', [ $this, 'display_notices' ] );
 	}
@@ -250,7 +250,7 @@ class Reviews {
 	 * @param  string $text        Text to translate.
 	 * @return string              Translated text.
 	 */
-	public function filter_edit_comments_screen_translations( $translation, $text ) {
+	public function edit_comments_screen_text( $translation, $text ) {
 		global $comment;
 
 		// Bail out if not a text we should replace.
@@ -266,17 +266,14 @@ class Reviews {
 
 		// Only replace the translated text if we are editing a comment left on a product (ie. a review).
 		if ( $comment && 'product' === get_post_type( $comment->comment_post_ID ) ) {
-			switch ( $text ) {
-				case 'Edit Comment':
-					$translation = $comment->comment_parent > 0
-						? __( 'Edit Review Reply', 'woocommerce' )
-						: __( 'Edit Review', 'woocommerce' );
-					break;
-				case 'Moderate Comment':
-					$translation = $comment->comment_parent > 0
-						? __( 'Moderate Review Reply', 'woocommerce' )
-						: __( 'Moderate Review', 'woocommerce' );
-					break;
+			if ( 'Edit Comment' === $text ) {
+				$translation = $comment->comment_parent > 0
+					? __( 'Edit Review Reply', 'woocommerce' )
+					: __( 'Edit Review', 'woocommerce' );
+			} elseif ( 'Moderate Comment' === $text ) {
+				$translation = $comment->comment_parent > 0
+					? __( 'Moderate Review Reply', 'woocommerce' )
+					: __( 'Moderate Review', 'woocommerce' );
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -234,6 +234,10 @@ class Reviews {
 			$comment_id = absint( $_GET['c'] );
 			$comment = get_comment( $comment_id );
 
+			if ( $comment->comment_parent > 0 ) {
+				$comment = get_comment( $comment->comment_parent );
+			}
+
 			if ( $comment && 'product' === get_post_type( $comment->comment_post_ID ) ) {
 				$parent_file  = 'edit.php?post_type=product';
 				$submenu_file = 'product-reviews'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -264,14 +268,21 @@ class Reviews {
 			$comment    = get_comment( $comment_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
+		$is_reply = false;
+
+		if ( $comment && $comment->comment_parent > 0 ) {
+			$is_reply = true;
+			$comment = get_comment( $comment->comment_parent ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+
 		// Only replace the translated text if we are editing a comment left on a product (ie. a review).
 		if ( $comment && 'product' === get_post_type( $comment->comment_post_ID ) ) {
 			if ( 'Edit Comment' === $text ) {
-				$translation = $comment->comment_parent > 0
+				$translation = $is_reply
 					? __( 'Edit Review Reply', 'woocommerce' )
 					: __( 'Edit Review', 'woocommerce' );
 			} elseif ( 'Moderate Comment' === $text ) {
-				$translation = $comment->comment_parent > 0
+				$translation = $is_reply
 					? __( 'Moderate Review Reply', 'woocommerce' )
 					: __( 'Moderate Review', 'woocommerce' );
 			}

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -276,7 +276,7 @@ class Reviews {
 		}
 
 		// Only replace the translated text if we are editing a comment left on a product (ie. a review).
-		if ( isset( $comment->comment_parent ) && 'product' === get_post_type( $comment->comment_post_ID ) ) {
+		if ( isset( $comment->comment_post_ID ) && 'product' === get_post_type( $comment->comment_post_ID ) ) {
 			if ( 'Edit Comment' === $text ) {
 				$translation = $is_reply
 					? __( 'Edit Review Reply', 'woocommerce' )

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -208,17 +208,17 @@ class ReviewsTest extends WC_Unit_Test_Case {
 		global $comment;
 
 		$product = $this->factory()->post->create( [ 'post_type' => 'product' ] );
-		$review  = $this->factory()->comment->create( [ 'comment_post_ID' => $product ] );
-		$reply   = $this->factory()->comment->create(
+		$review  = $this->factory()->comment->create_and_get( [ 'comment_post_ID' => $product ] );
+		$reply   = $this->factory()->comment->create_and_get(
 			[
 				'comment_post_ID' => $product,
-				'comment_parent'  => $review,
+				'comment_parent'  => $review->comment_ID,
 			]
 		);
 
 		if ( ! $is_review ) {
 			$post    = $this->factory()->post->create();
-			$comment = $this->factory()->comment->create( [ 'comment_post_ID' => $post ] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$comment = $this->factory()->comment->create_and_get( [ 'comment_post_ID' => $post ] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		} else {
 			$comment = $is_reply ? $reply : $review; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -172,6 +172,26 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that it will override the parent file and the submenu file globals when editing a review.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::edit_review_parent_file()
+	 *
+	 * @return void
+	 */
+	public function test_edit_review_parent_file() {
+		global $submenu_file, $current_screen;
+
+		$product = $this->factory()->post->create( [ 'post_type' => 'product' ] );
+		$review = $this->factory()->comment->create( [ 'comment_post_ID' => $product ] );
+		$current_screen = (object) [ 'id' => 'comment' ]; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$_GET['c'] = $review;
+		$reviews = new Reviews();
+
+		$this->assertSame( 'edit.php?post_type=product', $reviews->edit_review_parent_file( 'test' ) );
+		$this->assertSame( 'product-reviews', $submenu_file );
+	}
+
+	/**
 	 * Tests that can output the reviews list table and filter it.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::render_reviews_list_table()

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -205,22 +205,22 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_edit_comments_screen_text( string $translated_text, string $original_text, bool $is_review, bool $is_reply, string $expected_text ) {
+		global $comment;
+
 		$product = $this->factory()->post->create( [ 'post_type' => 'product' ] );
-		$comment = $this->factory()->comment->create( [ 'comment_post_ID' => $this->factory->post->create() ] );
-		$review = $this->factory()->comment->create( [ 'comment_post_ID' => $product ] );
-		$reply = $this->factory()->comment->create(
+		$review  = $this->factory()->comment->create( [ 'comment_post_ID' => $product ] );
+		$reply   = $this->factory()->comment->create(
 			[
 				'comment_post_ID' => $product,
 				'comment_parent'  => $review,
 			]
 		);
 
-		$_GET['action'] = 'editcomment';
-
 		if ( ! $is_review ) {
-			$_GET['c'] = $comment;
+			$post    = $this->factory()->post->create();
+			$comment = $this->factory()->comment->create( [ 'comment_post_ID' => $post ] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		} else {
-			$_GET['c'] = $is_reply ? $reply : $review;
+			$comment = $is_reply ? $reply : $review; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
 		$this->assertSame( $expected_text, ( new Reviews() )->edit_comments_screen_text( $translated_text, $original_text ) );
@@ -228,12 +228,12 @@ class ReviewsTest extends WC_Unit_Test_Case {
 
 	/** @see test_edit_comments_screen_text */
 	public function data_provider_edit_comments_screen_text() : Generator {
-		yield 'Regular comment' => [ 'Foo', 'Bar', false, false, 'Foo' ];
+		yield 'Regular comment' => [ 'Edit Comment', 'Edit Comment', false, false, 'Edit Comment' ];
 		yield 'Not the expected text'  => [ 'Foo', 'Bar', true, false, 'Foo' ];
-		yield 'Edit Review' => [ 'Edit Comment', 'Edit Comment', true, false, 'Edit Review' ];
-		yield 'Edit Review Reply' => [ 'Edit Comment', 'Edit Comment', true, true, 'Edit Review Reply' ];
-		yield 'Moderate Review' => [ 'Moderate Comment', 'Moderate Comment', true, false, 'Moderate Review' ];
-		yield 'Moderate Review Reply' => [ 'Moderate Comment', 'Moderate Comment', true, true, 'Moderate Review Reply' ];
+		yield 'Edit Review' => [ 'Edit Comment Translated', 'Edit Comment', true, false, 'Edit Review' ];
+		yield 'Edit Review Reply' => [ 'Edit Comment Translated', 'Edit Comment', true, true, 'Edit Review Reply' ];
+		yield 'Moderate Review' => [ 'Moderate Comment Translated', 'Moderate Comment', true, false, 'Moderate Review' ];
+		yield 'Moderate Review Reply' => [ 'Moderate Comment Translated', 'Moderate Comment', true, true, 'Moderate Review Reply' ];
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Ensures that when editing a review or a reply, the Products > Review menu item is highlighted, in place of Comments, and that the headline of the Edit Comment page is changed into Edit Review or Edit Review Reply. 

Note that I don't think the proposal doc mentions about this, and I've opened a [comment here](https://docs.google.com/document/d/1oMku-8Fqzj6PCSmXh5j3ElE2hsxABp6TQ3ayuQ-Or8Q/edit?pli=1&disco=AAAAYbyMJ9U), but it could have been just an oversight and applying the same strategy as PRP isn't very costly.

At the time of writing this I have a test failing and I haven't figured out yet why, but user testing checks out for me.

### Story: [MWC 5476](https://jira.godaddy.com/browse/MWC-5476)

## QA

- [x] Code review
- [x] Unit tests pass

### User Testing

1. Have products, reviews and replies in your installation
2. Edit a review from Products > Reviews 
    - [x] The Products > Reviews menu item is highlighted in the WP sidebar
    - [x] The headline reads "Edit Review"
3. Edit a review reply from Products > Reviews (if at the time of writing this you can't see replies listed in the table, try a direct link such as `comment.php?action=editcomment&c=<COMMENT_ID>`
    - [x] The Products > Reviews menu item is highlighted in the WP sidebar
    - [x] The headline reads "Edit Review Reply"
