### PR TITLE
Trash and spam action links not working

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -266,8 +266,6 @@ class ReviewsListTable extends WP_List_Table {
 	 * @return void
 	 */
 	public function display() {
-		$singular = $this->_args['singular'] ?? false;
-
 		$this->display_tablenav( 'top' );
 
 		$this->screen->render_screen_reader_content( 'heading_list' );
@@ -279,7 +277,7 @@ class ReviewsListTable extends WP_List_Table {
 				<?php $this->print_column_headers(); ?>
 			</tr>
 			</thead>
-			<tbody id="the-comment-list" <?php echo esc_attr( $singular ? "data-wp-lists='list:$singular'" : '' ); ?>>
+			<tbody id="the-comment-list" data-wp-lists="list:comment">
 			<?php $this->display_rows_or_placeholder(); ?>
 			</tbody>
 			<tfoot>

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -42,7 +42,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( '<table class="wp-list-table', $output );
-		$this->assertStringContainsString( '<tbody id="the-comment-list', $output );
+		$this->assertStringContainsString( '<tbody id="the-comment-list" data-wp-lists="list:comment">', $output );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This makes it so the JavaScript versions of the `Trash` and `Spam` links actually update the comment status.

## Story: [MWC-5477](https://jira.godaddy.com/browse/MWC-5477)

## Details

Based off https://github.com/godaddy-wordpress/woocommerce/pull/38, as that's required to make the JavaScript even work at all.

The ajax action is determined based on the `list:{object}` value. So previously it was doing an ajax request with the action `delete-product_review`, which we would have had to register a custom callback for. This makes it use the WordPress core `delete-comment` action instead, which already exists.

This also fixes the UI restore issue mentioned in the story.

## QA

1. Hover over a review and click "Trash".
    - [x] The `Trash` status count has been incremented.
2. Click `Restore`
    - [x] The review/reply reappears in the DOM, as normal.
3. Hover over a review and click "Spam".
    - [x] The `Spam` status count has been incremented.
4. Click through to the "Spam" status.
    - [x] The review appears here (confirm the status has indeed changed).
5. Click "Not Spam".
    - [x] The review disappears from the DOM.
6. Refresh the page.
    - [x] The review is still gone.

## Before Merge

- [x] https://github.com/godaddy-wordpress/woocommerce/pull/38 has been approved and merged.