### PR TITLE
Add search term to query args

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -89,6 +89,8 @@ class ReviewsListTable extends WP_List_Table {
 		$args = wp_parse_args( $this->get_filter_product_arguments(), $args );
 		// Include the review status arguments.
 		$args = wp_parse_args( $this->get_status_arguments(), $args );
+		// Include the search argument.
+		$args = wp_parse_args( $this->get_search_arguments(), $args );
 
 		$comments = get_comments( $args );
 
@@ -252,6 +254,21 @@ class ReviewsListTable extends WP_List_Table {
 
 		if ( ! empty( $comment_status ) && 'all' !== $comment_status && array_key_exists( $comment_status, $this->get_status_filters() ) ) {
 			$args['status'] = $this->convert_status_to_query_value( $comment_status );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Gets the `search` argument based on the current request.
+	 *
+	 * @return array
+	 */
+	protected function get_search_arguments() : array {
+		$args = [];
+
+		if ( ! empty( $_REQUEST['s'] ) ) {
+			$args['search'] = sanitize_text_field( wp_unslash( $_REQUEST['s'] ) );
 		}
 
 		return $args;

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1086,6 +1086,31 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @covers       \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_search_arguments()
+	 * @dataProvider provider_get_search_arguments
+	 *
+	 * @param mixed $search_value  Current search value in the request.
+	 * @param array $expected_args Expected result of the method.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_search_arguments( $search_value, array $expected_args ) {
+		$_REQUEST['s'] = $search_value;
+
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_search_arguments' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected_args, $method->invoke( $list_table ) );
+	}
+
+	/** @see test_get_search_arguments */
+	public function provider_get_search_arguments() : Generator {
+		yield 'no search' => [ null, [] ];
+		yield 'search value' => [ 'test', [ 'search' => 'test' ] ];
+	}
+
+	/**
 	 * Tests that can output the text for when no reviews are found.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::no_items()


### PR DESCRIPTION
## Summary

Ensures that the results reflect the search term you enter.

## Story: [MWC-5481](https://jira.godaddy.com/browse/MWC-5481)

## QA

1. Go to Products > Reviews.
2. Enter a search term that is definitely contained in at least one (but not all) of your reviews.
    - [x] Results are updated to only show records matching that term.
3. Now enter a search term that's definitely NOT contained in any of your reviews. Example: `sdfsdf`
    - [x] You see: `No reviews found.`