### PR TITLE
Implement pagination

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -110,7 +110,7 @@ class ReviewsListTable extends WP_List_Table {
 	/**
 	 * Returns the number of items to show per page.
 	 *
-	 * @return int
+	 * @return int Customized per-page value if available, or 20 as the default.
 	 */
 	protected function get_per_page() : int {
 		return $this->get_items_per_page( 'edit_comments_per_page' );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1773,4 +1773,36 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		yield 'page 2' => [ null, 2, [ 'offset' => 20 ] ];
 	}
 
+	/**
+	 * Tests that `offset` and `number` values are always set to `0`, and that `count` is added to the array.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_total_comments_arguments()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_total_comments_arguments() {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_total_comments_arguments' );
+		$method->setAccessible( true );
+
+		$default_query_args = [
+			'offset'  => 20,
+			'number'  => 20,
+			'status'  => '1',
+			'post_id' => 5,
+		];
+
+		$this->assertSame(
+			[
+				'offset'  => 0,
+				'number'  => 0,
+				'status'  => '1',
+				'post_id' => 5,
+				'count'   => true,
+			],
+			$method->invoke( $list_table, $default_query_args )
+		);
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1805,4 +1805,20 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * This is only testing the default value as we don't have a "current user".
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_per_page()
+	 *
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_per_page() {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_per_page' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 20, $method->invoke( $list_table ) );
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsListTableTest.php
@@ -1739,4 +1739,38 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * @covers       \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_offset_arguments()
+	 * @dataProvider provider_get_offset_arguments
+	 *
+	 * @param mixed    $request_start_value `$_REQUEST['start']` value.
+	 * @param int|null $current_page_number Current page number (used if `$_REQUEST['start']` isn't set).
+	 * @param array    $expected_args       Expected result of the method.
+	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
+	 */
+	public function test_get_offset_arguments( $request_start_value, ?int $current_page_number, array $expected_args ) {
+		$list_table = $this->get_reviews_list_table();
+		$method = ( new ReflectionClass( $list_table ) )->getMethod( 'get_offset_arguments' );
+		$method->setAccessible( true );
+
+		if ( ! is_null( $request_start_value ) ) {
+			$_REQUEST['start'] = $request_start_value;
+		} else {
+			unset( $_REQUEST['start'] );
+		}
+
+		$_REQUEST['paged'] = $current_page_number;
+
+		$this->assertSame( $expected_args, $method->invoke( $list_table ) );
+	}
+
+	/** @see test_get_offset_arguments */
+	public function provider_get_offset_arguments() : Generator {
+		yield 'start value has offset' => [ 5, null, [ 'offset' => 5 ] ];
+		yield 'start value set, but empty string' => [ '', null, [ 'offset' => 0 ] ];
+		yield 'page 1' => [ null, 1, [ 'offset' => 0 ] ];
+		yield 'page 2' => [ null, 2, [ 'offset' => 20 ] ];
+	}
+
 }


### PR DESCRIPTION
## Summary

This adds pagination support, so you can move from one page to another.

## Story: [MWC-5482](https://jira.godaddy.com/browse/MWC-5482)

## Details

For the number to show per-page, I used `$this->get_items_per_page( 'edit_comments_per_page' )` . That will actually get the value from the Comments page "Screen Options". If not customized, then it defaults to `20`.

There was nothing in the pitch about requiring a custom Screen Options value on this page (we don't have one), so I think the options were:

1. Choose a hard-coded value.
2. Use the Comments page screen options.
3. Code a custom screen option for this new page.

I went with 2, but could adjust accordingly. IMO, a custom screen option for this page would be nice, but doesn't need to be done for this epic. Perhaps something to follow up with at a later date.

## QA

1. Go to the Comments page and click on "Screen Options" in the top right.
2. Set a **small** value for easier testing (smaller than the number of comments you have). I have mine set to `2`.
4. Go to Products > Reviews.
    - [x] Right above the table, on the right-hand side, you see `{number} items`, and `{number}` accurately reflects the total number of comments you have.
    - [x] You have buttons to move between pages.
5. Click to navigate to the next page.
    - [x] Results update correctly.
6. Go to the last page.
    - [x] You are no longer able to click to another next page, as you're at the end.
7. Start over, and this time apply some filters. (Status, type, rating, something like that, or a combo)
    - [x] Results update.
8. Navigate to the next page.
    - [x] Results still update correctly.
    - [x] All filters remain correctly.