### PR TITLE
Fix the column type size

### DIFF
--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -7859,3 +7859,7 @@ table.bar_chart {
 		}
 	}
 }
+
+.product-reviews th.column-type {
+	width: 10%;
+}

--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -7860,6 +7860,12 @@ table.bar_chart {
 	}
 }
 
-.product-reviews th.column-type {
-	width: 10%;
+/**
+  * Product Reviews
+  */
+.wp-list-table.product-reviews {
+
+	th.column-type {
+		width: 10%;
+	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -602,7 +602,7 @@ class ReviewsListTable extends WP_List_Table {
 	public function get_columns() {
 		$columns = [
 			'cb'       => '<input type="checkbox" />',
-			'type'     => _x( 'Type', 'review type', 'woocommerce' ),
+			'type'     => _x( 'Type', 'review type', 'woocommerce' ) . '<style>.column-type { width: 10%; }</style>',
 			'author'   => __( 'Author', 'woocommerce' ),
 			'rating'   => __( 'Rating', 'woocommerce' ),
 			'comment'  => _x( 'Review', 'column name', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -602,7 +602,7 @@ class ReviewsListTable extends WP_List_Table {
 	public function get_columns() {
 		$columns = [
 			'cb'       => '<input type="checkbox" />',
-			'type'     => _x( 'Type', 'review type', 'woocommerce' ) . '<style>.column-type { width: 10%; }</style>',
+			'type'     => _x( 'Type', 'review type', 'woocommerce' ),
 			'author'   => __( 'Author', 'woocommerce' ),
 			'rating'   => __( 'Rating', 'woocommerce' ),
 			'comment'  => _x( 'Review', 'column name', 'woocommerce' ),


### PR DESCRIPTION
## Summary

This PR fixes the column type size to leave more room for the comment column.

## Story: [MWC-5491](https://jira.godaddy.com/browse/MWC-5491)

## QA

1. Go to `godaddy-wordpress/woocommerce/plugins/woocommerce`
1. Run `pnpm nx build woocommerce-legacy-assets`
1. Write a big review for a product
1. Go to Products > Reviews
    - [x] The type column size is enough to fit the _Review_ word
    - [x] The comment column is the bigger column