### PR TITLE
The Product Reviews table looks broken on mobile devices

### DIFF
--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -7871,10 +7871,17 @@ table.bar_chart {
 
 	@media screen and (max-width: 782px) {
 
-		.column-type,
-		.column-author,
-		.column-rating {
+		th.column-type,
+		td.column-type,
+		th.column-author,
+		td.column-author,
+		th.column-rating,
+		td.column-rating {
 			display: none !important;
+		}
+
+		.toggle-row {
+			top: 10px;
 		}
 	}
 }

--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -7859,3 +7859,18 @@ table.bar_chart {
 		}
 	}
 }
+
+/**
+  * Product Reviews
+  */
+.wp-list-table.product-reviews {
+
+	@media screen and (max-width: 782px) {
+
+		.column-type,
+		.column-author,
+		.column-rating {
+			display: none !important;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes table layout for mobile devices.

## Story: [MWC-5488](https://jira.godaddy.com/browse/MWC-5488)

## QA

1. Go to `godaddy-wordpress/woocommerce/plugins/woocommerce`
1. Run `pnpm nx build woocommerce-legacy-assets`
1. Go to Products > Reviews
    - [x] All columns are displayed
1. Go to Products > Reviews on a mobile device (or use your browser's responsive feature)
    - [x] Only the checkbox and Review columns are displayed (consistent with WP Comments page)