### PR TITLE
Fix search button label

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -582,7 +582,7 @@ class Reviews {
 				<input type="hidden" name="page" value="<?php echo esc_attr( $page ); ?>" />
 				<input type="hidden" name="post_type" value="product" />
 
-				<?php $this->reviews_list_table->search_box( __( 'Search reviews', 'woocommerce' ), 'reviews' ); ?>
+				<?php $this->reviews_list_table->search_box( __( 'Search Reviews', 'woocommerce' ), 'reviews' ); ?>
 
 				<?php $this->reviews_list_table->display(); ?>
 			</form>


### PR DESCRIPTION
## Summary

This PR fixes the search button label.

## Story: [MWC-5499](https://jira.godaddy.com/browse/MWC-5499)

## QA

1. Go to Products > Reviews
    - [ ] The search button label is "Search Reviews" (with an upper R)