### PR TITLE
"Product" column - comments icon leads to old Comments page

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -110,6 +110,21 @@ class Reviews {
 	}
 
 	/**
+	 * Retrieves the URL to the product reviews page.
+	 *
+	 * @return string
+	 */
+	public static function get_reviews_page_url(): string {
+		return add_query_arg(
+			[
+				'post_type' => 'product',
+				'page'      => static::MENU_SLUG,
+			],
+			admin_url( 'edit.php' )
+		);
+	}
+
+	/**
 	 * Determines whether the current page is the reviews page.
 	 *
 	 * @global WP_Screen $current_screen

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -1385,8 +1385,9 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Displays a review count bubble. Based on {@see WP_List_Table::comments_bubble()}, but overridden so we can
-	 * customize the URL and some of the language.
+	 * Displays a review count bubble.
+	 *
+	 * Based on {@see WP_List_Table::comments_bubble()}, but overridden, so we can customize the URL and text output.
 	 *
 	 * @param int $post_id          The product ID.
 	 * @param int $pending_comments Number of pending reviews.
@@ -1398,19 +1399,19 @@ class ReviewsListTable extends WP_List_Table {
 		$pending_reviews_number  = number_format_i18n( $pending_comments );
 
 		$approved_only_phrase = sprintf(
-		/* translators: %s: Number of reviews. */
+			/* translators: %s: Number of reviews. */
 			_n( '%s review', '%s reviews', $approved_review_count, 'woocommerce' ),
 			$approved_reviews_number
 		);
 
 		$approved_phrase = sprintf(
-		/* translators: %s: Number of reviews. */
+			/* translators: %s: Number of reviews. */
 			_n( '%s approved review', '%s approved reviews', $approved_review_count, 'woocommerce' ),
 			$approved_reviews_number
 		);
 
 		$pending_phrase = sprintf(
-		/* translators: %s: Number of reviews. */
+			/* translators: %s: Number of reviews. */
 			_n( '%s pending review', '%s pending reviews', $pending_comments, 'woocommerce' ),
 			$pending_reviews_number
 		);

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -813,13 +813,7 @@ class ReviewsListTable extends WP_List_Table {
 	 * @return string
 	 */
 	protected function get_view_url( string $comment_type, int $post_id ) : string {
-		$link = add_query_arg(
-			[
-				'post_type' => 'product',
-				'page'      => Reviews::MENU_SLUG,
-			],
-			admin_url( 'edit.php' )
-		);
+		$link = Reviews::get_reviews_page_url();
 
 		if ( ! empty( $comment_type ) && 'all' !== $comment_type ) {
 			$link = add_query_arg( 'comment_type', urlencode( $comment_type ), $link );
@@ -1388,6 +1382,99 @@ class ReviewsListTable extends WP_List_Table {
 			<?php endif; ?>
 		</select>
 		<?php
+	}
+
+	/**
+	 * Displays a review count bubble. Based on {@see WP_List_Table::comments_bubble()}, but overridden so we can
+	 * customize the URL and some of the language.
+	 *
+	 * @param int $post_id          The product ID.
+	 * @param int $pending_comments Number of pending reviews.
+	 */
+	protected function comments_bubble( $post_id, $pending_comments ) {
+		$approved_review_count = get_comments_number();
+
+		$approved_reviews_number = number_format_i18n( $approved_review_count );
+		$pending_reviews_number  = number_format_i18n( $pending_comments );
+
+		$approved_only_phrase = sprintf(
+		/* translators: %s: Number of reviews. */
+			_n( '%s review', '%s reviews', $approved_review_count, 'woocommerce' ),
+			$approved_reviews_number
+		);
+
+		$approved_phrase = sprintf(
+		/* translators: %s: Number of reviews. */
+			_n( '%s approved review', '%s approved reviews', $approved_review_count, 'woocommerce' ),
+			$approved_reviews_number
+		);
+
+		$pending_phrase = sprintf(
+		/* translators: %s: Number of reviews. */
+			_n( '%s pending review', '%s pending reviews', $pending_comments, 'woocommerce' ),
+			$pending_reviews_number
+		);
+
+		if ( ! $approved_review_count && ! $pending_comments ) {
+			// No reviews at all.
+			printf(
+				'<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">%s</span>',
+				esc_html__( 'No reviews', 'woocommerce' )
+			);
+		} elseif ( $approved_review_count && 'trash' === get_post_status( $post_id ) ) {
+			// Don't link the comment bubble for a trashed product.
+			printf(
+				'<span class="post-com-count post-com-count-approved"><span class="comment-count-approved" aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></span>',
+				esc_html( $approved_reviews_number ),
+				$pending_comments ? esc_html( $approved_phrase ) : esc_html( $approved_only_phrase )
+			);
+		} elseif ( $approved_review_count ) {
+			// Link the comment bubble to approved reviews.
+			printf(
+				'<a href="%s" class="post-com-count post-com-count-approved"><span class="comment-count-approved" aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></a>',
+				esc_url(
+					add_query_arg(
+						[
+							'product_id'     => urlencode( $post_id ),
+							'comment_status' => 'approved',
+						],
+						Reviews::get_reviews_page_url()
+					)
+				),
+				esc_html( $approved_reviews_number ),
+				$pending_comments ? esc_html( $approved_phrase ) : esc_html( $approved_only_phrase )
+			);
+		} else {
+			// Don't link the comment bubble when there are no approved reviews.
+			printf(
+				'<span class="post-com-count post-com-count-no-comments"><span class="comment-count comment-count-no-comments" aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></span>',
+				esc_html( $approved_reviews_number ),
+				$pending_comments ? esc_html__( 'No approved reviews', 'woocommerce' ) : esc_html__( 'No reviews', 'woocommerce' )
+			);
+		}
+
+		if ( $pending_comments ) {
+			printf(
+				'<a href="%s" class="post-com-count post-com-count-pending"><span class="comment-count-pending" aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></a>',
+				esc_url(
+					add_query_arg(
+						[
+							'product_id'     => urlencode( $post_id ),
+							'comment_status' => 'moderated',
+						],
+						Reviews::get_reviews_page_url()
+					)
+				),
+				esc_html( $pending_reviews_number ),
+				esc_html( $pending_phrase )
+			);
+		} else {
+			printf(
+				'<span class="post-com-count post-com-count-pending post-com-count-no-pending"><span class="comment-count comment-count-no-pending" aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></span>',
+				esc_html( $pending_reviews_number ),
+				$approved_review_count ? esc_html__( 'No pending reviews', 'woocommerce' ) : esc_html__( 'No reviews', 'woocommerce' )
+			);
+		}
 	}
 
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ReviewsTest.php
@@ -611,4 +611,11 @@ test2</p></div>',
 		$this->assertTrue( $method->invoke( $reviews, $review_reply ) );
 	}
 
+	/**
+	 * @covers Reviews::get_reviews_page_url()
+	 */
+	public function test_get_reviews_page_url() : void {
+		$this->assertSame( 'http://example.org/wp-admin/edit.php?post_type=product&page=product-reviews', Reviews::get_reviews_page_url() );
+	}
+
 }


### PR DESCRIPTION
## Summary

Overrides the `comments_bubble()` method so we can:

1. Customize the URL to show reviews for a given product.
2. Change some of the `comment` language to `review`.

## Story: [MWC-5520](https://jira.godaddy.com/browse/MWC-5520)

## Details

I also create a new `Reviews::get_reviews_page_url()` method to return the base URL to the page. I did this because I wanted to use that exact same code a second time.

## QA

### Setup

- Have at least two different products.
- One of the products should have at least one pending review.
- One of the products should not have any pending reviews.

### Steps

1. Navigate to Products > Reviews and look at the "Product" column.
    - [x] For a product with pending reviews, you see a grey comment bubble with the correct number of comments. You also see a smaller, overlapping bubble with the number of pending comments.
    - [x] For a product with no pending reviews, you only see a grey comment bubble.
2. Click on the larger, grey comment bubble. The page should redirect with the following changes:
    - [x] You are on the `Approved` status.
    - [x] The product filter is applied for the product you selected.
    - [x] The list table shows only reviews for that product.
3. Click on the smaller, overlapping bubble. The page should redirect with the following changes:
    - [x] You are on the `Pending` status.
    - [x] The product filter is applied for the product you selected.
    - [x] The list table shows only pending reviews for that product.