### PR TITLE
Update Product Reviews page hooks since tags

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -174,6 +174,8 @@ class WC_Admin_Notices {
 			/**
 			 * Filter the capability required to dismiss a given notice.
 			 *
+			 * @since 6.6.0
+			 *
 			 * @param string $default_capability The default required capability.
 			 * @param string $notice_name The notice name.
 			 */

--- a/plugins/woocommerce/src/Internal/Admin/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/Reviews.php
@@ -84,6 +84,8 @@ class Reviews {
 		/**
 		 * Filters whether the current user can manage product reviews.
 		 *
+		 * @since 6.6.0
+		 *
 		 * @param string $capability The capability (defaults to `moderate_comments`).
 		 * @param string $context    The context for which the capability is needed.
 		 */
@@ -608,6 +610,8 @@ class Reviews {
 
 		/**
 		 * Filters the contents of the product reviews list table output.
+		 *
+		 * @since 6.6.0
 		 *
 		 * @param string           $output             The HTML output of the list table.
 		 * @param ReviewsListTable $reviews_list_table The reviews list table instance.

--- a/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ReviewsListTable.php
@@ -613,6 +613,8 @@ class ReviewsListTable extends WP_List_Table {
 		/**
 		 * Filters the table columns.
 		 *
+		 * @since 6.6.0
+		 *
 		 * @param array $columns
 		 */
 		return apply_filters( 'woocommerce_product_reviews_table_columns', $columns );
@@ -1224,6 +1226,8 @@ class ReviewsListTable extends WP_List_Table {
 		 *
 		 * This action can be used to render custom columns that have been added.
 		 *
+		 * @since 6.6.0
+		 *
 		 * @param WP_Comment $item The review or reply being rendered.
 		 */
 		do_action( 'woocommerce_product_reviews_table_column_' . $column_name, $item );
@@ -1243,6 +1247,8 @@ class ReviewsListTable extends WP_List_Table {
 
 		/**
 		 * Filters the output of a column.
+		 *
+		 * @since 6.6.0
 		 *
 		 * @param string     $output The column output.
 		 * @param WP_Comment $item   The product review being rendered.


### PR DESCRIPTION
## Summary

This PR updates all phpdoc blocks of action and filter hooks introduced to support the Product Reviews page feature to have a since tag pointing to `6.6.0`. 

### Story: [MWC-5815](https://jira.godaddy.com/browse/MWC-5815)

Ref: https://github.com/woocommerce/woocommerce/pull/32763#pullrequestreview-968898718

## QA

- [x] Code review

Ignore for now results of GH actions, should be fixed with #48 