### PR TITLE
Move Product Reviews page classes to more specific namespace

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Internal\Admin;
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Admin\PluginsHelper;
+use Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews;
+use Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides;
 use Automattic\WooCommerce\Internal\Admin\Settings;
 
 /**

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
@@ -3,7 +3,7 @@
  * Products > Reviews
  */
 
-namespace Automattic\WooCommerce\Internal\Admin;
+namespace Automattic\WooCommerce\Internal\Admin\ProductReviews;
 
 use WP_Ajax_Response;
 use WP_Comment;

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsCommentsOverrides.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Automattic\WooCommerce\Internal\Admin;
+namespace Automattic\WooCommerce\Internal\Admin\ProductReviews;
 
 use WP_Comment_Query;
 

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -3,7 +3,7 @@
  * Product > Reviews
  */
 
-namespace Automattic\WooCommerce\Internal\Admin;
+namespace Automattic\WooCommerce\Internal\Admin\ProductReviews;
 
 use WC_Product;
 use WP_Comment;

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Automattic\WooCommerce\Tests\Internal\Admin;
+namespace Automattic\WooCommerce\Tests\Internal\Admin\ProductReviews;
 
-use Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides;
+use Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides;
 use Generator;
 use ReflectionClass;
 use ReflectionException;
@@ -11,7 +11,7 @@ use WC_Unit_Test_Case;
 /**
  * Tests the product reviews overrides for the comments page.
  *
- * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides
+ * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides
  */
 class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 
@@ -38,7 +38,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::display_notices()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides::display_notices()
 	 * @dataProvider provider_test_display_notices()
 	 *
 	 * @param string $current_screen_base    The current WP_Screen base value.
@@ -77,7 +77,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::maybe_display_reviews_moved_notice()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides::maybe_display_reviews_moved_notice()
 	 * @dataProvider provider_test_maybe_display_reviews_moved_notice()
 	 *
 	 * @param bool $should_display_notice Whether the reviews moved notice should be displayed.
@@ -125,7 +125,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::should_display_reviews_moved_notice()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides::should_display_reviews_moved_notice()
 	 * @dataProvider provider_test_should_display_reviews_moved_notice()
 	 *
 	 * @param bool $user_has_capability       Whether the user has the capability to see the new page.
@@ -155,11 +155,11 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 			]
 		);
 
-		$reflection = new ReflectionClass( ReviewsCommentsOverrides::class );
+		$reflection = new ReflectionClass( \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides::class );
 		$method = $reflection->getMethod( 'should_display_reviews_moved_notice' );
 		$method->setAccessible( true );
 
-		$should_display_notice = $method->invoke( ReviewsCommentsOverrides::get_instance() );
+		$should_display_notice = $method->invoke( \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides::get_instance() );
 
 		$this->assertSame( $expected, $should_display_notice );
 	}
@@ -172,13 +172,13 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::display_reviews_moved_notice()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides::display_reviews_moved_notice()
 	 *
 	 * @return void
 	 * @throws ReflectionException Thrown when the method does not exist.
 	 */
 	public function test_display_reviews_moved_notice() : void {
-		$overrides = new ReviewsCommentsOverrides();
+		$overrides = new \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides();
 		$method = ( new ReflectionClass( $overrides ) )->getMethod( 'display_reviews_moved_notice' );
 		$method->setAccessible( true );
 
@@ -204,7 +204,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::get_dismiss_capability()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides::get_dismiss_capability()
 	 * @dataProvider provider_test_get_dismiss_capability()
 	 *
 	 * @param string $default_capability The default required capability.
@@ -214,7 +214,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_get_dismiss_capability( string $default_capability, string $notice_name, string $expected_capability ) : void {
-		$this->assertSame( $expected_capability, ReviewsCommentsOverrides::get_instance()->get_dismiss_capability( $default_capability, $notice_name ) );
+		$this->assertSame( $expected_capability, \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides::get_instance()->get_dismiss_capability( $default_capability, $notice_name ) );
 	}
 
 	/** @see test_get_dismiss_capability() */
@@ -226,7 +226,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can exclude reviews from comments in the comments page.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsCommentsOverrides::exclude_reviews_from_comments()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides::exclude_reviews_from_comments()
 	 *
 	 * @return void
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
@@ -155,11 +155,11 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 			]
 		);
 
-		$reflection = new ReflectionClass( \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides::class );
+		$reflection = new ReflectionClass( ReviewsCommentsOverrides::class );
 		$method = $reflection->getMethod( 'should_display_reviews_moved_notice' );
 		$method->setAccessible( true );
 
-		$should_display_notice = $method->invoke( \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides::get_instance() );
+		$should_display_notice = $method->invoke( ReviewsCommentsOverrides::get_instance() );
 
 		$this->assertSame( $expected, $should_display_notice );
 	}
@@ -178,7 +178,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	 * @throws ReflectionException Thrown when the method does not exist.
 	 */
 	public function test_display_reviews_moved_notice() : void {
-		$overrides = new \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides();
+		$overrides = new ReviewsCommentsOverrides();
 		$method = ( new ReflectionClass( $overrides ) )->getMethod( 'display_reviews_moved_notice' );
 		$method->setAccessible( true );
 
@@ -214,7 +214,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_get_dismiss_capability( string $default_capability, string $notice_name, string $expected_capability ) : void {
-		$this->assertSame( $expected_capability, \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides::get_instance()->get_dismiss_capability( $default_capability, $notice_name ) );
+		$this->assertSame( $expected_capability, ReviewsCommentsOverrides::get_instance()->get_dismiss_capability( $default_capability, $notice_name ) );
 	}
 
 	/** @see test_get_dismiss_capability() */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
@@ -21,7 +21,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 *
 	 * @return ReviewsListTable
 	 */
-	private function get_reviews_list_table() : \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable {
+	private function get_reviews_list_table() : ReviewsListTable {
 		return new ReviewsListTable( [ 'screen' => 'product_page_product-reviews' ] );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Automattic\WooCommerce\Tests\Internal\Admin;
+namespace Automattic\WooCommerce\Tests\Internal\Admin\ProductReviews;
 
-use Automattic\WooCommerce\Internal\Admin\ReviewsListTable;
+use Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable;
 use Generator;
 use ReflectionClass;
 use ReflectionException;
@@ -12,23 +12,23 @@ use WC_Unit_Test_Case;
 /**
  * Tests that product reviews page handler.
  *
- * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable
+ * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable
  */
 class ReviewsListTableTest extends WC_Unit_Test_Case {
 
 	/**
-	 * Returns a new instance of the {@see ReviewsListTable} class.
+	 * Returns a new instance of the {@see \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable} class.
 	 *
 	 * @return ReviewsListTable
 	 */
-	private function get_reviews_list_table() : ReviewsListTable {
+	private function get_reviews_list_table() : \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable {
 		return new ReviewsListTable( [ 'screen' => 'product_page_product-reviews' ] );
 	}
 
 	/**
 	 * Tests that will output the reviews list table with the expected HTML elements.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::display()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::display()
 	 *
 	 * @return void
 	 */
@@ -48,7 +48,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can process the row output for a review or reply.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::single_row()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::single_row()
 	 *
 	 * @return void
 	 */
@@ -84,7 +84,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can handle the row actions for a review in the Reviews page table.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::handle_row_actions()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::handle_row_actions()
 	 * @dataProvider data_provider_test_handle_row_actions
 	 *
 	 * @param string $review_status  The review status.
@@ -162,7 +162,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the product reviews' page columns.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_columns()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_columns()
 	 *
 	 * @return void
 	 */
@@ -184,7 +184,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the product reviews' page columns when a filter is applied.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_columns()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_columns()
 	 *
 	 * @return void
 	 */
@@ -210,7 +210,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the primary column name.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_primary_column_name()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_primary_column_name()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method does not exist.
@@ -224,7 +224,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::cb()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::cb()
 	 *
 	 * @dataProvider data_provider_test_column_cb()
 	 * @param bool   $current_user_can_edit Whether the current user has the capability to edit this review.
@@ -273,7 +273,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests the output of the review type column.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_type()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::column_type()
 	 * @dataProvider data_provider_test_column_type()
 	 *
 	 * @param string $comment_type The comment type (usually review or comment).
@@ -312,7 +312,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can generate the column rating HTML output.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_rating()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::column_rating()
 	 * @dataProvider data_provider_test_column_rating()
 	 *
 	 * @param string $meta_value The comment meta value for rating.
@@ -356,7 +356,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can output the author information.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_author()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::column_author()
 	 * @dataProvider data_provider_column_author
 	 *
 	 * @param bool $show_avatars          Value for the `show_avatars` option.
@@ -412,7 +412,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the item author URL.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_item_author_url()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_item_author_url()
 	 * @dataProvider data_provider_test_get_item_author_url
 	 *
 	 * @param string $comment_author_url The comment author URL.
@@ -452,7 +452,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get a review author url for display.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_item_author_url_for_display()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_item_author_url_for_display()
 	 * @dataProvider data_provider_test_get_item_author_url_for_display()
 	 *
 	 * @param string $author_url The author URL.
@@ -485,7 +485,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can output the review or reply date column.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_date()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::column_date()
 	 * @dataProvider data_provider_test_column_date
 	 *
 	 * @param bool $has_product   Whether the review is for a valid product object.
@@ -540,7 +540,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that it will output the product information for the corresponding review column.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_response()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::column_response()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method does not exist.
@@ -573,7 +573,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can output the review or reply content.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_comment()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::column_comment()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method does not exist.
@@ -620,7 +620,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the in reply to review text message for the review content column.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_in_reply_to_review_text()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_in_reply_to_review_text()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method does not exist.
@@ -654,7 +654,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the bulk actions for the product reviews page.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_bulk_actions()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_bulk_actions()
 	 * @dataProvider data_provider_get_bulk_actions
 	 *
 	 * @param string $current_comment_status Currently set status.
@@ -728,7 +728,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can set the product to filter reviews by.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::set_review_product()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::set_review_product()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method or the property do not exist.
@@ -763,7 +763,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can set the review status for the current request.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::set_review_status()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::set_review_status()
 	 * @dataProvider data_provider_set_review_status
 	 *
 	 * @param string|null $request_status          Status that's in the request.
@@ -799,7 +799,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can set the review type when preparing items.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::set_review_type()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::set_review_type()
 	 * @dataProvider data_provider_set_review_type
 	 *
 	 * @param string|null $review_type          Review type.
@@ -838,7 +838,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the sortable columns for the reviews table.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_sortable_columns()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_sortable_columns()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method doesn't exist.
@@ -863,7 +863,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the sort arguments for the current request.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_sort_arguments()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_sort_arguments()
 	 * @dataProvider data_provider_get_sort_arguments
 	 *
 	 * @param string|null $orderby       The orderby value that's set in the request.
@@ -963,7 +963,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the comment type argument for the current request.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_filter_type_arguments()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_filter_type_arguments()
 	 * @dataProvider data_provider_get_filter_type_arguments
 	 *
 	 * @param string|null $review_type  The requested review type.
@@ -1000,7 +1000,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can set the filter rating for the current request.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_filter_rating_arguments()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_filter_rating_arguments()
 	 *
 	 * @return void
 	 * @throws ReflectionException If reflected method or property don't exist.
@@ -1041,7 +1041,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the post ID argument for the current request.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_filter_product_arguments()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_filter_product_arguments()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method or the property don't exist.
@@ -1068,7 +1068,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the status arguments based on the current request.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_status_arguments()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_status_arguments()
 	 * @dataProvider provider_get_status_arguments
 	 *
 	 * @param string $status        Current status for the request.
@@ -1099,7 +1099,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers       \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_search_arguments()
+	 * @covers       \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_search_arguments()
 	 * @dataProvider provider_get_search_arguments
 	 *
 	 * @param mixed $search_value  Current search value in the request.
@@ -1127,7 +1127,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can output the text for when no reviews are found.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::no_items()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::no_items()
 	 * @dataProvider data_provider_no_items
 	 *
 	 * @param string $status   Filtered status.
@@ -1156,7 +1156,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can render the extra controls for the product reviews page.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::extra_tablenav()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::extra_tablenav()
 	 * @dataProvider data_provider_test_extra_tablenav()
 	 *
 	 * @param string   $position                  Position (top or bottom).
@@ -1377,7 +1377,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can output a filter by review type dropdown element.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::review_type_dropdown()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::review_type_dropdown()
 	 * @dataProvider data_provider_test_review_type_dropdown
 	 *
 	 * @param string $chosen_type The chosen review type to filter for.
@@ -1416,7 +1416,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can output a filter dropdown for review ratings.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::review_rating_dropdown()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::review_rating_dropdown()
 	 * @dataProvider data_provider_test_review_rating_dropdown
 	 *
 	 * @param int $chosen_rating The rating to filter reviews for.
@@ -1453,7 +1453,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can output the default column content and trigger an action hook for custom columns.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::column_default()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::column_default()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method doesn't exist.
@@ -1482,7 +1482,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that it will trigger a filter hook for columns.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::filter_column_output()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::filter_column_output()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method doesn't exist.
@@ -1509,7 +1509,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can output a product search field for the product in context.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::product_search()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::product_search()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method is not defined.
@@ -1534,7 +1534,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the reviews' status filter.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_status_filters()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_status_filters()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method doesn't exist.
@@ -1599,7 +1599,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get a view URL for the product reviews page.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_view_url()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_view_url()
 	 * @dataProvider provider_get_view_url
 	 *
 	 * @param string $comment_type Current type filter.
@@ -1650,7 +1650,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can convert the status to a query value.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::convert_status_to_query_value()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::convert_status_to_query_value()
 	 * @dataProvider provider_convert_status_string_to_comment_approved
 	 *
 	 * @param string $status              Status to pass in to the method.
@@ -1680,7 +1680,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the product reviews count.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_review_count()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_review_count()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method doesn't exist.
@@ -1758,7 +1758,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the product reviews page views.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_views()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_views()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method doesn't exist.
@@ -1784,7 +1784,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_offset_arguments()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_offset_arguments()
 	 * @dataProvider provider_get_offset_arguments
 	 *
 	 * @param mixed    $request_start_value `$_REQUEST['start']` value.
@@ -1820,7 +1820,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that `offset` and `number` values are always set to `0`, and that `count` is added to the array.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_total_comments_arguments()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_total_comments_arguments()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method doesn't exist.
@@ -1852,7 +1852,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	/**
 	 * This is only testing the default value as we don't have a "current user".
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::get_per_page()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::get_per_page()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method doesn't exist.
@@ -1866,7 +1866,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ReviewsListTable::comments_bubble()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::comments_bubble()
 	 * @dataProvider provider_comments_bubble
 	 *
 	 * @param int    $approved_review_count Number of approved reviews on the product.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Automattic\WooCommerce\Tests\Internal\Admin;
+namespace Automattic\WooCommerce\Tests\Internal\Admin\ProductReviews;
 
-use Automattic\WooCommerce\Internal\Admin\Reviews;
-use Automattic\WooCommerce\Internal\Admin\ReviewsListTable;
+use Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews;
+use Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable;
 use Generator;
 use ReflectionClass;
 use ReflectionException;
@@ -13,7 +13,7 @@ use WP_Comment;
 /**
  * Tests for the admin reviews handler.
  *
- * @covers \Automattic\WooCommerce\Internal\Admin\Reviews
+ * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews
  */
 class ReviewsTest extends WC_Unit_Test_Case {
 
@@ -42,7 +42,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the class instance.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::get_instance()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::get_instance()
 	 *
 	 * @return void
 	 */
@@ -53,7 +53,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can get the capability to view the reviews page.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::get_capability()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::get_capability()
 	 *
 	 * @return void
 	 */
@@ -73,9 +73,9 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Tests that `load_reviews_screen()` creates an instance of {@see ReviewsListTable}.
+	 * Tests that `load_reviews_screen()` creates an instance of {@see \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable}.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::load_reviews_screen()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::load_reviews_screen()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method or the property is not found.
@@ -95,13 +95,13 @@ class ReviewsTest extends WC_Unit_Test_Case {
 
 		$reviews->load_reviews_screen();
 
-		$this->assertInstanceOf( ReviewsListTable::class, $list_table_property->getValue( $reviews ) );
+		$this->assertInstanceOf( \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::class, $list_table_property->getValue( $reviews ) );
 	}
 
 	/**
 	 * Tests that can get the pending comment count bubble.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::get_pending_count_bubble()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::get_pending_count_bubble()
 	 * @dataProvider data_provider_get_pending_count_bubble
 	 *
 	 * @param int    $number_pending Number of pending product reviews.
@@ -176,7 +176,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that it will override the parent file and the submenu file globals when editing a review.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::edit_review_parent_file()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::edit_review_parent_file()
 	 *
 	 * @return void
 	 */
@@ -196,7 +196,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that it will override the headline text when editing or moderating a review or reply.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::edit_comments_screen_text()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::edit_comments_screen_text()
 	 * @dataProvider data_provider_edit_comments_screen_text
 	 *
 	 * @param string $translated_text Translated text.
@@ -242,7 +242,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that can output the reviews list table and filter it.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::render_reviews_list_table()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::render_reviews_list_table()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the property doesn't exist.
@@ -251,7 +251,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 		$GLOBALS['hook_suffix'] = 'product_page_product-reviews'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		$reviews = Reviews::get_instance();
-		$list_table = new ReviewsListTable( [ 'screen' => 'product_page_product-reviews' ] );
+		$list_table = new \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable( [ 'screen' => 'product_page_product-reviews' ] );
 
 		$property = ( new ReflectionClass( $reviews ) )->getProperty( 'reviews_list_table' );
 		$property->setAccessible( true );
@@ -281,7 +281,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that the reviews page is properly identified.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::is_reviews_page()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::is_reviews_page()
 	 * @dataProvider provider_is_reviews_page
 	 *
 	 * @param mixed $new_current_screen The value of the global $pageview var.
@@ -330,7 +330,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that the admin notice messages are properly returned.
 	 *
-	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::get_bulk_action_notice_messages()
+	 * @covers       \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::get_bulk_action_notice_messages()
 	 * @dataProvider provider_get_bulk_action_notice_messages
 	 *
 	 * @param string[] $statuses        The wp comment statuses after a bulk operation.
@@ -458,7 +458,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	/**
 	 * Tests that a notice message will result in a valid HTML return.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::maybe_display_reviews_bulk_action_notice()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::maybe_display_reviews_bulk_action_notice()
 	 * @dataProvider provider_maybe_display_reviews_bulk_action_notice
 	 *
 	 * @param array  $messages        The action notice messages.
@@ -510,7 +510,7 @@ test2</p></div>',
 	/**
 	 * Tests that the display method is called only for the reviews page.
 	 *
-	 * @covers       \Automattic\WooCommerce\Internal\Admin\Reviews::display_notices()
+	 * @covers       \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::display_notices()
 	 * @dataProvider provider_display_notices
 	 *
 	 * @param bool $is_reviews_page                Whether the current page is the reviews page or not.
@@ -551,7 +551,7 @@ test2</p></div>',
 	/**
 	 * Tests scenarios that should return false.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::is_review_or_reply()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::is_review_or_reply()
 	 * @dataProvider provider_is_review_or_reply
 	 *
 	 * @param WP_Comment|array|null $object   Object to pass in to the method.
@@ -577,7 +577,7 @@ test2</p></div>',
 	/**
 	 * Tests different cases that require factories.
 	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\Reviews::is_review_or_reply()
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::is_review_or_reply()
 	 *
 	 * @return void
 	 * @throws ReflectionException If the method doesn't exist.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
@@ -95,7 +95,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 
 		$reviews->load_reviews_screen();
 
-		$this->assertInstanceOf( \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::class, $list_table_property->getValue( $reviews ) );
+		$this->assertInstanceOf( ReviewsListTable::class, $list_table_property->getValue( $reviews ) );
 	}
 
 	/**
@@ -251,7 +251,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 		$GLOBALS['hook_suffix'] = 'product_page_product-reviews'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		$reviews = Reviews::get_instance();
-		$list_table = new \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable( [ 'screen' => 'product_page_product-reviews' ] );
+		$list_table = new ReviewsListTable( [ 'screen' => 'product_page_product-reviews' ] );
 
 		$property = ( new ReflectionClass( $reviews ) )->getProperty( 'reviews_list_table' );
 		$property->setAccessible( true );


### PR DESCRIPTION
## Summary

Moves the new classes to their own namespace.

### Story [MWC 5819](https://jira.godaddy.com/browse/MWC-5819)

Ref: https://github.com/woocommerce/woocommerce/pull/32763#pullrequestreview-968898718

## QA

- [ ] Code reviews
- ~[ ] Unit tests pass~ (will be addressed separately)