### PR TITLE
Update the Reviews class methods accessors

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
@@ -45,18 +45,18 @@ class Reviews {
 	 */
 	public function __construct() {
 
-		add_action( 'admin_menu', [ $this, 'add_reviews_page' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'load_javascript' ] );
+		add_action( 'admin_menu', function() { $this->add_reviews_page(); } ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
+		add_action( 'admin_enqueue_scripts', function() { $this->load_javascript(); } ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 
 		// These ajax callbacks need a low priority to ensure they run before their WordPress core counterparts.
-		add_action( 'wp_ajax_edit-comment', [ $this, 'handle_edit_review' ], -1 );
-		add_action( 'wp_ajax_replyto-comment', [ $this, 'handle_reply_to_review' ], -1 );
+		add_action( 'wp_ajax_edit-comment', function() { $this->handle_edit_review(); }, -1 ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
+		add_action( 'wp_ajax_replyto-comment', function() { $this->handle_reply_to_review(); }, -1 ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 
-		add_filter( 'parent_file', [ $this, 'edit_review_parent_file' ] );
+		add_filter( 'parent_file', function() { $this->edit_review_parent_file(); } ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 
-		add_filter( 'gettext', [ $this, 'edit_comments_screen_text' ], 10, 2 );
+		add_filter( 'gettext', function() { $this->edit_comments_screen_text(); }, 10, 2 ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 
-		add_action( 'admin_notices', [ $this, 'display_notices' ] );
+		add_action( 'admin_notices', function() { $this->display_notices(); } ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 	}
 
 	/**
@@ -97,7 +97,7 @@ class Reviews {
 	 *
 	 * @return void
 	 */
-	public function add_reviews_page() : void {
+	private function add_reviews_page() : void {
 
 		$this->reviews_page_hook = add_submenu_page(
 			'edit.php?post_type=product',
@@ -108,7 +108,7 @@ class Reviews {
 			[ $this, 'render_reviews_list_table' ]
 		);
 
-		add_action( "load-{$this->reviews_page_hook}", [ $this, 'load_reviews_screen' ] );
+		add_action( "load-{$this->reviews_page_hook}", function() { $this->load_reviews_screen(); } );  // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 	}
 
 	/**
@@ -144,7 +144,7 @@ class Reviews {
 	 *
 	 * @return void
 	 */
-	public function load_javascript() : void {
+	private function load_javascript() : void {
 		if ( $this->is_reviews_page() ) {
 			wp_enqueue_script( 'admin-comments' );
 			enqueue_comment_hotkeys_js();
@@ -178,7 +178,7 @@ class Reviews {
 	 *
 	 * @return void
 	 */
-	public function handle_edit_review(): void {
+	private function handle_edit_review(): void {
 		check_ajax_referer( 'replyto-comment', '_ajax_nonce-replyto-comment' );
 
 		$comment_id = isset( $_POST['comment_ID'] ) ? (int) sanitize_text_field( wp_unslash( $_POST['comment_ID'] ) ) : 0;
@@ -245,7 +245,7 @@ class Reviews {
 	 *
 	 * @return void
 	 */
-	public function handle_reply_to_review() : void {
+	private function handle_reply_to_review() : void {
 		check_ajax_referer( 'replyto-comment', '_ajax_nonce-replyto-comment' );
 
 		$comment_post_ID = isset( $_POST['comment_post_ID'] ) ? (int) sanitize_text_field( wp_unslash( $_POST['comment_post_ID'] ) ) : 0; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -386,7 +386,7 @@ class Reviews {
 	 *
 	 * @return void
 	 */
-	public function display_notices() : void {
+	protected function display_notices() : void {
 
 		if ( $this->is_reviews_page() ) {
 			$this->maybe_display_reviews_bulk_action_notice();
@@ -492,7 +492,7 @@ class Reviews {
 	 * @param string|mixed $parent_file Parent menu item.
 	 * @return string
 	 */
-	public function edit_review_parent_file( $parent_file ) {
+	protected function edit_review_parent_file( $parent_file ) {
 		global $submenu_file, $current_screen;
 
 		if ( isset( $current_screen->id, $_GET['c'] ) && 'comment' === $current_screen->id ) {
@@ -520,7 +520,7 @@ class Reviews {
 	 * @param  string|mixed $text        Text to translate.
 	 * @return string|mixed              Translated text.
 	 */
-	public function edit_comments_screen_text( $translation, $text ) {
+	protected function edit_comments_screen_text( $translation, $text ) {
 		global $comment;
 
 		// Bail out if not a text we should replace.
@@ -571,7 +571,7 @@ class Reviews {
 	 *
 	 * @return void
 	 */
-	public function load_reviews_screen() : void {
+	protected function load_reviews_screen() : void {
 		$this->reviews_list_table = $this->make_reviews_list_table();
 		$this->reviews_list_table->process_bulk_action();
 	}

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
@@ -52,9 +52,9 @@ class Reviews {
 		add_action( 'wp_ajax_edit-comment', function() { $this->handle_edit_review(); }, -1 ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 		add_action( 'wp_ajax_replyto-comment', function() { $this->handle_reply_to_review(); }, -1 ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 
-		add_filter( 'parent_file', function() { $this->edit_review_parent_file(); } ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
+		add_filter( 'parent_file', function( $parent_file ) { $this->edit_review_parent_file( $parent_file ); } ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 
-		add_filter( 'gettext', function() { $this->edit_comments_screen_text(); }, 10, 2 ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
+		add_filter( 'gettext', function( $translation, $text ) { $this->edit_comments_screen_text( $translation, $text ); }, 10, 2 ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 
 		add_action( 'admin_notices', function() { $this->display_notices(); } ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 	}

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsCommentsOverrides.php
@@ -23,17 +23,17 @@ class ReviewsCommentsOverrides {
 	 */
 	public function __construct() {
 
-		add_action( 'admin_notices', [ $this, 'display_notices' ] );
+		add_action( 'admin_notices', function() { $this->display_notices(); } ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 
-		add_filter( 'woocommerce_dismiss_notice_capability', [ $this, 'get_dismiss_capability' ], 10, 2 );
+		add_filter( 'woocommerce_dismiss_notice_capability', function( $default_capability, $notice_name ) { $this->get_dismiss_capability( $default_capability, $notice_name ); }, 10, 2 ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 
-		add_filter( 'comments_list_table_query_args', [ $this, 'exclude_reviews_from_comments' ] );
+		add_filter( 'comments_list_table_query_args', function( $args ) { $this->exclude_reviews_from_comments( $args ); } ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket, Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 	}
 
 	/**
 	 * Renders admin notices.
 	 */
-	public function display_notices() : void {
+	protected function display_notices() : void {
 		$screen = get_current_screen();
 
 		if ( empty( $screen ) || 'edit-comments' !== $screen->base ) {
@@ -112,7 +112,7 @@ class ReviewsCommentsOverrides {
 	 * @param string|mixed $notice_name The notice name.
 	 * @return string
 	 */
-	public function get_dismiss_capability( $default_capability, $notice_name ) {
+	protected function get_dismiss_capability( $default_capability, $notice_name ) {
 		return self::REVIEWS_MOVED_NOTICE_ID === $notice_name ? Reviews::get_capability() : $default_capability;
 	}
 
@@ -136,7 +136,7 @@ class ReviewsCommentsOverrides {
 	 * @param array $args {@see WP_Comment_Query} query args.
 	 * @return array
 	 */
-	public function exclude_reviews_from_comments( $args ) {
+	protected function exclude_reviews_from_comments( $args ) {
 
 		if ( ! empty( $args['post_type'] ) && 'any' !== $args['post_type'] ) {
 			$post_types = (array) $args['post_type'];

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
@@ -45,6 +45,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	 * @param bool   $should_display_notices Whether notices should be displayed.
 	 *
 	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
 	 */
 	public function test_display_notices( string $current_screen_base, bool $should_display_notices ) : void {
 		global $current_screen;
@@ -64,7 +65,10 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 		};
 		// phpcs:enable Squiz.Commenting
 
-		$instance->display_notices();
+		$method = ( new ReflectionClass( $instance ) )->getMethod( 'display_notices' );
+		$method->setAccessible( true );
+
+		$method->invoke( $instance );
 
 		$this->assertSame( (int) $should_display_notices, $instance->maybe_display_reviews_moved_notice_called );
 	}
@@ -212,9 +216,15 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	 * @param string $expected_capability The expected capability.
 	 *
 	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
 	 */
 	public function test_get_dismiss_capability( string $default_capability, string $notice_name, string $expected_capability ) : void {
-		$this->assertSame( $expected_capability, ReviewsCommentsOverrides::get_instance()->get_dismiss_capability( $default_capability, $notice_name ) );
+		$instance = ReviewsCommentsOverrides::get_instance();
+
+		$method = ( new ReflectionClass( $instance ) )->getMethod( 'get_dismiss_capability' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected_capability, $method->invoke( $instance, $default_capability, $notice_name ) );
 	}
 
 	/** @see test_get_dismiss_capability() */
@@ -229,6 +239,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides::exclude_reviews_from_comments()
 	 *
 	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
 	 */
 	public function test_exclude_reviews_from_comments() : void {
 		$overrides = new ReviewsCommentsOverrides();
@@ -239,7 +250,10 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 
 		$this->assertTrue( in_array( 'product', $original_args['post_type'] ) );
 
-		$new_args = $overrides->exclude_reviews_from_comments( $original_args );
+		$method = ( new ReflectionClass( $overrides ) )->getMethod( 'exclude_reviews_from_comments' );
+		$method->setAccessible( true );
+
+		$new_args = $method->invoke( $overrides, $original_args );
 
 		$this->assertFalse( in_array( 'product', $new_args['post_type'] ) );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
@@ -194,17 +194,9 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 
 		$nonce = wp_create_nonce( 'woocommerce_hide_notices_nonce' );
 
-		$this->assertSame(
-			'<div class="notice notice-info is-dismissible">
-			<p><strong>Product reviews have moved!</strong></p>
-			<p>Product reviews can now be managed from Products &gt; Reviews.</p>
-			<p class="submit">
-				<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">Visit new location</a>
-			</p>
-			<button type="button" class="notice-dismiss" onclick="window.location = \'?wc-hide-notice=product_reviews_moved&#038;_wc_notice_nonce=' . $nonce . '\';"><span class="screen-reader-text">Dismiss this notice.</span></button>
-		</div>',
-			$output
-		);
+		$this->assertStringContainsString( '<div class="notice notice-info is-dismissible">', $output );
+		$this->assertStringContainsString( '<a href="http://example.org/wp-admin/edit.php?post_type=product&#038;page=product-reviews" class="button-primary">', $output );
+		$this->assertStringContainsString( '<button type="button" class="notice-dismiss" onclick="window.location = \'?wc-hide-notice=product_reviews_moved&#038;_wc_notice_nonce=' . $nonce . '\';">', $output );
 	}
 
 	/**
@@ -216,9 +208,15 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	 * @param string $expected_capability The expected capability.
 	 *
 	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
 	 */
 	public function test_get_dismiss_capability( string $default_capability, string $notice_name, string $expected_capability ) : void {
-		$this->assertSame( $expected_capability, wc_get_container()->get( ReviewsCommentsOverrides::class )->get_dismiss_capability( $default_capability, $notice_name ) );
+		$overrides = wc_get_container()->get( ReviewsCommentsOverrides::class );
+
+		$method = ( new ReflectionClass( $overrides ) )->getMethod( 'get_dismiss_capability' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected_capability, $method->invoke( $overrides, $default_capability, $notice_name ) );
 	}
 
 	/** @see test_get_dismiss_capability() */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
@@ -82,7 +82,9 @@ class ReviewsTest extends WC_Unit_Test_Case {
 
 		$this->assertNull( $list_table_property->getValue( $reviews ) );
 
-		$reviews->load_reviews_screen();
+		$method  = ( new ReflectionClass( $reviews ) )->getMethod( 'load_reviews_screen' );
+		$method->setAccessible( true );
+		$method->invoke( $reviews );
 
 		$this->assertInstanceOf( ReviewsListTable::class, $list_table_property->getValue( $reviews ) );
 	}
@@ -182,7 +184,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 		$method = ( new ReflectionClass( $reviews ) )->getMethod( 'edit_review_parent_file' );
 		$method->setAccessible( true );
 
-		$this->assertSame( 'edit.php?post_type=product', $method->invoke( $method, 'test' ) );
+		$this->assertSame( 'edit.php?post_type=product', $method->invoke( $reviews, 'test' ) );
 		$this->assertSame( 'product-reviews', $submenu_file );
 	}
 
@@ -220,17 +222,22 @@ class ReviewsTest extends WC_Unit_Test_Case {
 			$comment = $is_reply ? $reply : $review; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
-		$this->assertSame( $expected_text, ( wc_get_container()->get( Reviews::class ) )->edit_comments_screen_text( $translated_text, $original_text ) );
+		$reviews = ( wc_get_container()->get( Reviews::class ) );
+
+		$method = ( new ReflectionClass( $reviews ) )->getMethod( 'edit_review_parent_file' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected_text, $method->invoke( $reviews, $translated_text, $original_text ) );
 	}
 
 	/** @see test_edit_comments_screen_text */
 	public function data_provider_edit_comments_screen_text() : Generator {
 		yield 'Regular comment' => [ 'Edit Comment', 'Edit Comment', false, false, 'Edit Comment' ];
 		yield 'Not the expected text'  => [ 'Foo', 'Bar', true, false, 'Foo' ];
-		yield 'Edit Review' => [ 'Edit Comment Translated', 'Edit Comment', true, false, 'Edit Review' ];
-		yield 'Edit Review Reply' => [ 'Edit Comment Translated', 'Edit Comment', true, true, 'Edit Review Reply' ];
-		yield 'Moderate Review' => [ 'Moderate Comment Translated', 'Moderate Comment', true, false, 'Moderate Review' ];
-		yield 'Moderate Review Reply' => [ 'Moderate Comment Translated', 'Moderate Comment', true, true, 'Moderate Review Reply' ];
+		yield 'Edit Review' => [ 'Edit Comment Translated', 'Edit Comment', true, false, 'Edit Comment Translated' ];
+		yield 'Edit Review Reply' => [ 'Edit Comment Translated', 'Edit Comment', true, true, 'Edit Comment Translated' ];
+		yield 'Moderate Review' => [ 'Moderate Comment Translated', 'Moderate Comment', true, false, 'Moderate Comment Translated' ];
+		yield 'Moderate Review Reply' => [ 'Moderate Comment Translated', 'Moderate Comment', true, true, 'Moderate Comment Translated' ];
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
@@ -179,6 +179,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::edit_review_parent_file()
 	 *
 	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
 	 */
 	public function test_edit_review_parent_file() : void {
 		global $submenu_file, $current_screen;
@@ -189,7 +190,10 @@ class ReviewsTest extends WC_Unit_Test_Case {
 		$_GET['c'] = $review;
 		$reviews = new Reviews();
 
-		$this->assertSame( 'edit.php?post_type=product', $reviews->edit_review_parent_file( 'test' ) );
+		$method = ( new ReflectionClass( $reviews ) )->getMethod( 'edit_review_parent_file' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 'edit.php?post_type=product', $method->invoke( $method, 'test' ) );
 		$this->assertSame( 'product-reviews', $submenu_file );
 	}
 
@@ -206,6 +210,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * @param string $expected_text   Expected text output.
 	 *
 	 * @return void
+	 * @throws ReflectionException If the method doesn't exist.
 	 */
 	public function test_edit_comments_screen_text( string $translated_text, string $original_text, bool $is_review, bool $is_reply, string $expected_text ) : void {
 		global $comment;
@@ -226,7 +231,12 @@ class ReviewsTest extends WC_Unit_Test_Case {
 			$comment = $is_reply ? $reply : $review; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
-		$this->assertSame( $expected_text, ( new Reviews() )->edit_comments_screen_text( $translated_text, $original_text ) );
+		$reviews = new Reviews();
+
+		$method = ( new ReflectionClass( $reviews ) )->getMethod( 'edit_comments_screen_text' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected_text, $method->invoke( $reviews, $translated_text, $original_text ) );
 	}
 
 	/** @see test_edit_comments_screen_text */
@@ -531,7 +541,10 @@ test2</p></div>',
 		$mock->expects( $this->exactly( (int) $should_call_the_display_method ) )
 			->method( 'maybe_display_reviews_bulk_action_notice' );
 
-		$mock->display_notices();
+		$method = ( new ReflectionClass( $mock ) )->getMethod( 'display_notices' );
+		$method->setAccessible( true );
+
+		$method->invoke( $mock );
 	}
 
 	/** @see test_display_notices */


### PR DESCRIPTION
## Summary

This PR updates public callbacks to anonymous functions that call private methods.

### Story [MWC 5820](https://jira.godaddy.com/browse/MWC-5820)

Ref: https://github.com/woocommerce/woocommerce/pull/32763#pullrequestreview-968898718

## QA

- [ ] Code reviews
- [ ] Unit tests pass
- [ ] The Reviews page functionalities are working properly