### PR TITLE
Move singleton structure to container approach

### DIFF
--- a/plugins/woocommerce/src/Container.php
+++ b/plugins/woocommerce/src/Container.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\Orders
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\OptionSanitizerServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\ProductAttributesLookupServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\ProductDownloadsServiceProvider;
+use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\ProductReviewsServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\ProxiesServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\RestockRefundedItemsAdjusterServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\UtilsClassesServiceProvider;
@@ -47,6 +48,7 @@ final class Container implements \Psr\Container\ContainerInterface {
 		OrdersDataStoreServiceProvider::class,
 		ProductAttributesLookupServiceProvider::class,
 		ProductDownloadsServiceProvider::class,
+		ProductReviewsServiceProvider::class,
 		ProxiesServiceProvider::class,
 		RestockRefundedItemsAdjusterServiceProvider::class,
 		UtilsClassesServiceProvider::class,

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -68,8 +68,9 @@ class Loader {
 		Translations::get_instance();
 		WCAdminUser::get_instance();
 		Settings::get_instance();
-		Reviews::get_instance();
-		ReviewsCommentsOverrides::get_instance();
+
+		wc_get_container()->get( Reviews::class );
+		wc_get_container()->get( ReviewsCommentsOverrides::class );
 
 		add_filter( 'admin_body_class', array( __CLASS__, 'add_admin_body_classes' ) );
 		add_filter( 'admin_title', array( __CLASS__, 'update_admin_title' ) );

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
@@ -20,13 +20,6 @@ class Reviews {
 	const MENU_SLUG = 'product-reviews';
 
 	/**
-	 * Class instance.
-	 *
-	 * @var Reviews|null instance
-	 */
-	protected static $instance;
-
-	/**
 	 * Reviews page hook name.
 	 *
 	 * @var string|null
@@ -57,20 +50,6 @@ class Reviews {
 		add_filter( 'gettext', [ $this, 'edit_comments_screen_text' ], 10, 2 );
 
 		add_action( 'admin_notices', [ $this, 'display_notices' ] );
-	}
-
-	/**
-	 * Gets the class instance.
-	 *
-	 * @return Reviews instance
-	 */
-	public static function get_instance() : Reviews {
-
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsCommentsOverrides.php
@@ -110,20 +110,6 @@ class ReviewsCommentsOverrides {
 	}
 
 	/**
-	 * Gets the class instance.
-	 *
-	 * @return ReviewsCommentsOverrides instance
-	 */
-	public static function get_instance() : ReviewsCommentsOverrides {
-
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
-	}
-
-	/**
 	 * Excludes product reviews from showing in the comments page.
 	 *
 	 * @param array $args {@see WP_Comment_Query} query args.

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsCommentsOverrides.php
@@ -12,13 +12,6 @@ class ReviewsCommentsOverrides {
 	const REVIEWS_MOVED_NOTICE_ID = 'product_reviews_moved';
 
 	/**
-	 * Class instance.
-	 *
-	 * @var ReviewsCommentsOverrides|null instance
-	 */
-	protected static $instance;
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/ProductReviewsServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/ProductReviewsServiceProvider.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * OrdersDataStoreServiceProvider class file.
+ */
+
+namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
+
+use Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews;
+use Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides;
+use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
+
+/**
+ * Service provider for the classes in the Internal\Admin\ProductReviews namespace.
+ */
+class ProductReviewsServiceProvider extends AbstractServiceProvider {
+
+	/**
+	 * The classes/interfaces that are serviced by this service provider.
+	 *
+	 * @var array
+	 */
+	protected $provides = array(
+		Reviews::class,
+		ReviewsCommentsOverrides::class,
+	);
+
+	/**
+	 * Register the classes.
+	 */
+	public function register() {
+		$this->share( Reviews::class );
+		$this->share( ReviewsCommentsOverrides::class );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
@@ -159,7 +159,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 		$method = $reflection->getMethod( 'should_display_reviews_moved_notice' );
 		$method->setAccessible( true );
 
-		$should_display_notice = $method->invoke( ReviewsCommentsOverrides::get_instance() );
+		$should_display_notice = $method->invoke( wc_get_container()->get( ReviewsCommentsOverrides::class ) );
 
 		$this->assertSame( $expected, $should_display_notice );
 	}
@@ -214,7 +214,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_get_dismiss_capability( string $default_capability, string $notice_name, string $expected_capability ) : void {
-		$this->assertSame( $expected_capability, ReviewsCommentsOverrides::get_instance()->get_dismiss_capability( $default_capability, $notice_name ) );
+		$this->assertSame( $expected_capability, wc_get_container()->get( ReviewsCommentsOverrides::class )->get_dismiss_capability( $default_capability, $notice_name ) );
 	}
 
 	/** @see test_get_dismiss_capability() */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
@@ -178,7 +178,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	 * @throws ReflectionException Thrown when the method does not exist.
 	 */
 	public function test_display_reviews_moved_notice() : void {
-		$overrides = new ReviewsCommentsOverrides();
+		$overrides = wc_get_container()->get( ReviewsCommentsOverrides::class );
 		$method = ( new ReflectionClass( $overrides ) )->getMethod( 'display_reviews_moved_notice' );
 		$method->setAccessible( true );
 
@@ -231,7 +231,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_exclude_reviews_from_comments() : void {
-		$overrides = new ReviewsCommentsOverrides();
+		$overrides = wc_get_container()->get( ReviewsCommentsOverrides::class );
 
 		$original_args = [
 			'post_type' => [ 'product' ],

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
@@ -239,7 +239,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	public function test_render_reviews_list_table() : void {
 		$GLOBALS['hook_suffix'] = 'product_page_product-reviews'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
-		$reviews = Reviews::get_instance();
+		$reviews = wc_get_container()->get( Reviews::class );
 		$list_table = new ReviewsListTable( [ 'screen' => 'product_page_product-reviews' ] );
 
 		$property = ( new ReflectionClass( $reviews ) )->getProperty( 'reviews_list_table' );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
@@ -40,17 +40,6 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Tests that can get the class instance.
-	 *
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::get_instance()
-	 *
-	 * @return void
-	 */
-	public function test_get_instance() : void {
-		$this->assertInstanceOf( Reviews::class, Reviews::get_instance() );
-	}
-
-	/**
 	 * Tests that can get the capability to view the reviews page.
 	 *
 	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::get_capability()
@@ -81,7 +70,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 * @throws ReflectionException If the method or the property is not found.
 	 */
 	public function test_load_reviews_screen() : void {
-		$reviews = new Reviews();
+		$reviews = wc_get_container()->get( Reviews::class );
 
 		// This has to be manually set, otherwise instantiating ReviewsListTable will throw an undefined index error.
 		$hook_property = ( new ReflectionClass( $reviews ) )->getProperty( 'reviews_page_hook' );
@@ -154,7 +143,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 			);
 		}
 
-		$reviews = new Reviews();
+		$reviews = wc_get_container()->get( Reviews::class );
 		$method  = ( new ReflectionClass( $reviews ) )->getMethod( 'get_pending_count_bubble' );
 		$method->setAccessible( true );
 
@@ -187,7 +176,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 		$review = $this->factory()->comment->create( [ 'comment_post_ID' => $product ] );
 		$current_screen = (object) [ 'id' => 'comment' ]; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$_GET['c'] = $review;
-		$reviews = new Reviews();
+		$reviews = wc_get_container()->get( Reviews::class );
 
 		$this->assertSame( 'edit.php?post_type=product', $reviews->edit_review_parent_file( 'test' ) );
 		$this->assertSame( 'product-reviews', $submenu_file );
@@ -226,7 +215,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 			$comment = $is_reply ? $reply : $review; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
-		$this->assertSame( $expected_text, ( new Reviews() )->edit_comments_screen_text( $translated_text, $original_text ) );
+		$this->assertSame( $expected_text, ( wc_get_container()->get( Reviews::class ) )->edit_comments_screen_text( $translated_text, $original_text ) );
 	}
 
 	/** @see test_edit_comments_screen_text */
@@ -294,7 +283,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 
 		$current_screen = $new_current_screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
-		$reviews = new Reviews();
+		$reviews = wc_get_container()->get( Reviews::class );
 
 		$this->assertSame( $expected_result, $reviews->is_reviews_page() );
 	}
@@ -342,7 +331,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	 */
 	public function test_get_bulk_action_notice_messages( array $statuses, int $count, array $expected_result ) : void {
 
-		$reviews = new Reviews();
+		$reviews = wc_get_container()->get( Reviews::class );
 
 		$method = ( new ReflectionClass( $reviews ) )->getMethod( 'get_bulk_action_notice_messages' );
 		$method->setAccessible( true );
@@ -561,7 +550,7 @@ test2</p></div>',
 	 * @throws ReflectionException If the method doesn't exist.
 	 */
 	public function test_is_not_review_or_reply( $object, bool $expected ) : void {
-		$reviews = new Reviews();
+		$reviews = wc_get_container()->get( Reviews::class );
 		$method  = ( new ReflectionClass( $reviews ) )->getMethod( 'is_review_or_reply' );
 		$method->setAccessible( true );
 
@@ -583,7 +572,7 @@ test2</p></div>',
 	 * @throws ReflectionException If the method doesn't exist.
 	 */
 	public function test_is_review_or_reply_with_comment_object() : void {
-		$reviews = new Reviews();
+		$reviews = wc_get_container()->get( Reviews::class );
 		$method  = ( new ReflectionClass( $reviews ) )->getMethod( 'is_review_or_reply' );
 		$method->setAccessible( true );
 


### PR DESCRIPTION
## Summary

Adds and registers the `ProductReviewsServiceProvider` to instantiate the `Reviews` and `ReviewCommentsOverrides` classes using the DI container.

### Story [MWC-5821](https://jira.godaddy.com/browse/MWC-5821)

## Details

I have chosen to keep the `ReviewsListTable` instantiation inside the `Reviews` class because it needs the reviews page hook as a constructor argument. 

Also, the [review comment](https://github.com/woocommerce/woocommerce/pull/32763#discussion_r870044320) only asked us to change it for the `Reviews` and `ReviewsCommentsOverrides`. 

The code sniff errors in the `Loader` class are not introduced in this PR and are totally unrelated to our changes, and I did not feel comfortable updating it.

## QA

- [x] Code reviews
- [x] Unit tests pass
- [x] The Product Reviews page loads correctly and the table is displayed
- [x] The ReviewsCommentsOverrides loads correctly (product reviews are not displayed in the Comments page)