### PR TITLE
Update Reviews::get_capability() to align with REST API

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
@@ -63,12 +63,14 @@ class Reviews {
 		/**
 		 * Filters whether the current user can manage product reviews.
 		 *
+		 * This is aligned to {@see \wc_rest_check_product_reviews_permissions()}
+		 *
 		 * @since 6.6.0
 		 *
-		 * @param string $capability The capability (defaults to `moderate_comments`).
+		 * @param string $capability The capability (defaults to `moderate_comments` for viewing and `edit_products` for editing).
 		 * @param string $context    The context for which the capability is needed.
 		 */
-		return (string) apply_filters( 'woocommerce_product_reviews_page_capability', 'moderate_comments', $context );
+		return (string) apply_filters( 'woocommerce_product_reviews_page_capability', 'view' === $context ? 'moderate_comments' : 'edit_products', $context );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
@@ -49,6 +49,8 @@ class ReviewsTest extends WC_Unit_Test_Case {
 	public function test_get_view_page_capability() : void {
 
 		$this->assertEquals( 'moderate_comments', Reviews::get_capability() );
+		$this->assertEquals( 'moderate_comments', Reviews::get_capability( 'view' ) );
+		$this->assertEquals( 'edit_products', Reviews::get_capability( 'moderate' ) );
 
 		$callback = function() {
 			return 'manage_woocommerce';


### PR DESCRIPTION
## Summary

Updates `Reviews::get_capability` to align the viewing and editing reviews capabilities check to those of the WC REST API.

## Issue: [MWC-5852](https://jira.godaddy.com/browse/MWC-5852)

## QA

- [x] Code review
- [x] Unit tests pass

### User testing

- [x] Administrators and WooCommerce shop managers can edit view and edit reviews
- [x] Try creating a user role that is able to see the reviews page but has no `edit_products` ability: they should not be able to edit a review. You can use the [User Roles Editor](https://wordpress.org/plugins/user-role-editor/) for this.