### PR TITLE
Update Reviews::is_review_or_reply() and make filterable

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
@@ -138,7 +138,7 @@ class Reviews {
 	 */
 	protected function is_review_or_reply( $object ) : bool {
 
-		$is_review_or_reply = $object instanceof WP_Comment && ( ( 'review' === $object->comment_type || 'comment' === $object->comment_type ) && 'product' === get_post_type( $object->comment_post_ID ) );
+		$is_review_or_reply = $object instanceof WP_Comment && in_array( $object->comment_type, [ 'review', 'comment' ], true ) && 'product' === get_post_type( $object->comment_post_ID );
 
 		/**
 		 * Filters whether the object is a review or a reply to a review.

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
@@ -133,15 +133,22 @@ class Reviews {
 	/**
 	 * Determines if the object is a review or a reply to a review.
 	 *
-	 * @param WP_Comment|array|null $object Object to check.
+	 * @param WP_Comment|mixed $object Object to check.
 	 * @return bool
 	 */
 	protected function is_review_or_reply( $object ) : bool {
-		if ( ! $object instanceof WP_Comment ) {
-			return false;
-		}
 
-		return 'review' === $object->comment_type || 'product' === get_post_type( $object->comment_post_ID );
+		$is_review_or_reply = $object instanceof WP_Comment && ( ( 'review' === $object->comment_type || 'comment' === $object->comment_type ) && 'product' === get_post_type( $object->comment_post_ID ) );
+
+		/**
+		 * Filters whether the object is a review or a reply to a review.
+		 *
+		 * @since 6.6.0
+		 *
+		 * @param bool             $is_review_or_reply Whether the object in context is a review or a reply to a review.
+		 * @param WP_Comment|mixed $object             The object in context.
+		 */
+		return (bool) apply_filters( 'woocommerce_product_reviews_is_product_review_or_reply', $is_review_or_reply, $object );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
@@ -614,7 +614,7 @@ test2</p></div>',
 
 		add_filter( 'woocommerce_product_reviews_is_product_review_or_reply', $callback );
 
-		$this->assertEquals( $method->invoke( $reviews, new stdClass() ) );
+		$this->assertTrue( $method->invoke( $reviews, new stdClass() ) );
 
 		remove_filter( 'woocommerce_product_reviews_is_product_review_or_reply', $callback );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable;
 use Generator;
 use ReflectionClass;
 use ReflectionException;
+use stdClass;
 use WC_Unit_Test_Case;
 use WP_Comment;
 
@@ -606,6 +607,16 @@ test2</p></div>',
 			]
 		);
 		$this->assertTrue( $method->invoke( $reviews, $review_reply ) );
+
+		$callback = function() {
+			return true;
+		};
+
+		add_filter( 'woocommerce_product_reviews_is_product_review_or_reply', $callback );
+
+		$this->assertEquals( $method->invoke( $reviews, new stdClass() ) );
+
+		remove_filter( 'woocommerce_product_reviews_is_product_review_or_reply', $callback );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Updates the `Reviews::is_review_or_reply()` method as [advised from feedback](https://github.com/woocommerce/woocommerce/pull/32763/files/9a5895fe339b42acfba580a6adbda1377661ace4#r872509319) and makes the result filterable.

## QA

- [x] Code review
- [x] Unit tests pass
