### PR TITLE
Add the ReviewsUtil class

### DIFF
--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -8,6 +8,8 @@
  * @version 2.3.0
  */
 
+use Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsUtil;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -37,7 +39,7 @@ class WC_Comments {
 		add_filter( 'comment_feed_where', array( __CLASS__, 'exclude_webhook_comments_from_feed_where' ) );
 
 		// Exclude product reviews.
-		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_product_reviews' ), 10, 1 );
+		add_filter( 'comments_clauses', array( ReviewsUtil::class, 'comments_clauses_without_product_reviews' ), 10, 1 );
 
 		// Count comments.
 		add_filter( 'wp_count_comments', array( __CLASS__, 'wp_count_comments' ), 10, 2 );
@@ -75,23 +77,6 @@ class WC_Comments {
 			$open = false;
 		}
 		return $open;
-	}
-
-	/**
-	 * Removes product reviews from the edit-comments page to fix the "Mine" tab counter.
-	 *
-	 * @param  array|mixed $clauses A compacted array of comment query clauses.
-	 * @return array|mixed
-	 */
-	public static function exclude_product_reviews( $clauses ) {
-		global $wpdb, $current_screen;
-
-		if ( isset( $current_screen->base ) && 'edit-comments' === $current_screen->base ) {
-			$clauses['join']  .= " LEFT JOIN {$wpdb->posts} AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID ";
-			$clauses['where'] .= ( $clauses['where'] ? ' AND ' : '' ) . " wp_posts_to_exclude_reviews.post_type NOT IN ('product') ";
-		}
-
-		return $clauses;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsUtil.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsUtil.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin\ProductReviews;
+
+/**
+ * An utility to handle comments that are product reviews.
+ */
+class ReviewsUtil {
+	/**
+	 * Removes product reviews from the edit-comments page to fix the "Mine" tab counter.
+	 *
+	 * @param  array|mixed $clauses A compacted array of comment query clauses.
+	 * @return array|mixed
+	 */
+	public static function comments_clauses_without_product_reviews( $clauses ) {
+		global $wpdb, $current_screen;
+
+		if ( isset( $current_screen->base ) && 'edit-comments' === $current_screen->base ) {
+			$clauses['join']  .= " LEFT JOIN {$wpdb->posts} AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID ";
+			$clauses['where'] .= ( $clauses['where'] ? ' AND ' : '' ) . " wp_posts_to_exclude_reviews.post_type NOT IN ('product') ";
+		}
+
+		return $clauses;
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsUtil.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsUtil.php
@@ -3,9 +3,10 @@
 namespace Automattic\WooCommerce\Internal\Admin\ProductReviews;
 
 /**
- * An utility to handle comments that are product reviews.
+ * A utility class for handling comments that are product reviews.
  */
 class ReviewsUtil {
+
 	/**
 	 * Removes product reviews from the edit-comments page to fix the "Mine" tab counter.
 	 *

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsUtilTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\ProductReviews;
+
+use Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsUtil;
+use Generator;
+use WC_Unit_Test_Case;
+
+/**
+ * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsUtil()
+ */
+class ReviewsUtilTest extends WC_Unit_Test_Case {
+	/**
+	 * Sets the global vars before each test.
+	 */
+	public function setUp() : void {
+		global $wpdb, $current_screen;
+
+		$this->old_wpdb = $wpdb;
+		$this->old_current_screen = $current_screen;
+
+		parent::setUp();
+	}
+
+	/**
+	 * Restores the global vars after each test.
+	 */
+	public function tearDown() : void {
+		global $wpdb, $current_screen;
+
+		$wpdb = $this->old_wpdb; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$current_screen = $this->old_current_screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsUtil::comments_clauses_without_product_reviews()
+	 *
+	 * @dataProvider provider_can_get_comments_clauses_without_product_reviews
+	 *
+	 * @param string $current_screen_value the current screen value.
+	 * @param string $where_value the current WHERE clause value.
+	 * @param string $expected_join the expected JOIN value.
+	 * @param string $expected_where the expected WHERE value.
+	 */
+	public function test_can_get_comments_clauses_without_product_reviews( $current_screen_value, $where_value, $expected_join, $expected_where ) : void {
+		global $wpdb, $current_screen;
+
+		$wpdb = (object) [ 'posts' => 'test_table' ]; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$current_screen = (object) [ 'base' => $current_screen_value ]; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$clauses = ReviewsUtil::comments_clauses_without_product_reviews(
+			[
+				'join' => '',
+				'where' => $where_value,
+			]
+		);
+
+		$this->assertArrayHasKey( 'join', $clauses );
+		$this->assertArrayHasKey( 'where', $clauses );
+		$this->assertSame( $expected_join, $clauses['join'] );
+		$this->assertSame( $expected_where, $clauses['where'] );
+	}
+
+	/** @see test_can_get_comments_clauses_without_product_reviews */
+	public function provider_can_get_comments_clauses_without_product_reviews() : Generator {
+
+		$join = ' LEFT JOIN test_table AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID ';
+		$where = ' wp_posts_to_exclude_reviews.post_type NOT IN (\'product\') ';
+
+		yield 'Current screen is not edit comments' => [
+			'current_screen_value' => 'test-page',
+			'where_value' => '',
+			'expected_join' => '',
+			'expected_where' => '',
+		];
+
+		yield 'Where is empty' => [
+			'current_screen_value' => 'edit-comments',
+			'where_value' => '',
+			'expected_join' => $join,
+			'expected_where' => $where,
+		];
+
+		yield 'Where is not empty' => [
+			'current_screen_value' => 'edit-comments',
+			'where_value' => 'WHERE 1=1',
+			'expected_join' => $join,
+			'expected_where' => 'WHERE 1=1 AND ' . $where,
+		];
+	}
+
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsUtilTest.php
@@ -10,6 +10,7 @@ use WC_Unit_Test_Case;
  * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsUtil()
  */
 class ReviewsUtilTest extends WC_Unit_Test_Case {
+
 	/**
 	 * Sets the global vars before each test.
 	 */
@@ -35,16 +36,17 @@ class ReviewsUtilTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsUtil::comments_clauses_without_product_reviews()
+	 * Tests that can get the comment clauses excluding product reviews.
 	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsUtil::comments_clauses_without_product_reviews()
 	 * @dataProvider provider_can_get_comments_clauses_without_product_reviews
 	 *
-	 * @param string $current_screen_value the current screen value.
-	 * @param string $where_value the current WHERE clause value.
-	 * @param string $expected_join the expected JOIN value.
-	 * @param string $expected_where the expected WHERE value.
+	 * @param string $current_screen_value The current screen value.
+	 * @param string $where_value          The current WHERE clause value.
+	 * @param string $expected_join        The expected JOIN value.
+	 * @param string $expected_where       The expected WHERE value.
 	 */
-	public function test_can_get_comments_clauses_without_product_reviews( $current_screen_value, $where_value, $expected_join, $expected_where ) : void {
+	public function test_can_get_comments_clauses_without_product_reviews( string $current_screen_value, string $where_value, string $expected_join, string $expected_where ) : void {
 		global $wpdb, $current_screen;
 
 		$wpdb = (object) [ 'posts' => 'test_table' ]; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited


### PR DESCRIPTION
# Summary

This PR address [this request](https://github.com/woocommerce/woocommerce/pull/32763#discussion_r870030840).

### Story: [MWC 5822](https://jira.godaddy.com/browse/MWC-5822)

## QA

- [x] Code review
- [x] Unit tests pass

### User testing

1. Have at least a product and a blog post on your store
1. Post a few product reviews and a few post comments
    * Use an anonymous user so they will be pending approval
1. Go to `wp-admin`
    - [x] The comments bubble shows the number of pending **post comments**
1. Go to the Comments page
    - [x] The tabs over the comments table reflect the proper amounts (comments count only, not considering review amounts)
1. Go to a product page with reviews
    - [x] The reviews are shown