### PR TITLE
Update since tags to 6.7.0

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -174,7 +174,7 @@ class WC_Admin_Notices {
 			/**
 			 * Filter the capability required to dismiss a given notice.
 			 *
-			 * @since 6.6.0
+			 * @since 6.7.0
 			 *
 			 * @param string $default_capability The default required capability.
 			 * @param string $notice_name The notice name.

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
@@ -106,7 +106,7 @@ class Reviews {
 		 *
 		 * This is aligned to {@see \wc_rest_check_product_reviews_permissions()}
 		 *
-		 * @since 6.6.0
+		 * @since 6.7.0
 		 *
 		 * @param string $capability The capability (defaults to `moderate_comments` for viewing and `edit_products` for editing).
 		 * @param string $context    The context for which the capability is needed.
@@ -191,7 +191,7 @@ class Reviews {
 		/**
 		 * Filters whether the object is a review or a reply to a review.
 		 *
-		 * @since 6.6.0
+		 * @since 6.7.0
 		 *
 		 * @param bool             $is_review_or_reply Whether the object in context is a review or a reply to a review.
 		 * @param WP_Comment|mixed $object             The object in context.
@@ -645,7 +645,7 @@ class Reviews {
 		/**
 		 * Filters the contents of the product reviews list table output.
 		 *
-		 * @since 6.6.0
+		 * @since 6.7.0
 		 *
 		 * @param string           $output             The HTML output of the list table.
 		 * @param ReviewsListTable $reviews_list_table The reviews list table instance.

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -613,7 +613,7 @@ class ReviewsListTable extends WP_List_Table {
 		/**
 		 * Filters the table columns.
 		 *
-		 * @since 6.6.0
+		 * @since 6.7.0
 		 *
 		 * @param array $columns
 		 */
@@ -1227,7 +1227,7 @@ class ReviewsListTable extends WP_List_Table {
 		 *
 		 * This action can be used to render custom columns that have been added.
 		 *
-		 * @since 6.6.0
+		 * @since 6.7.0
 		 *
 		 * @param WP_Comment $item The review or reply being rendered.
 		 */
@@ -1249,7 +1249,7 @@ class ReviewsListTable extends WP_List_Table {
 		/**
 		 * Filters the output of a column.
 		 *
-		 * @since 6.6.0
+		 * @since 6.7.0
 		 *
 		 * @param string     $output The column output.
 		 * @param WP_Comment $item   The product review being rendered.


### PR DESCRIPTION
## Story: [MWC-6004](https://jira.godaddy.com/browse/MWC-6004)

This updates the since tags to `6.7.0` as per [this comment](https://github.com/woocommerce/woocommerce/pull/32763#discussion_r877553528).

## QA

- [x] Code review
- [x] Tests pass (I think the sniffer failing is normal since I touched a legacy file; it's complaining about surrounding code in that file that isn't ours)