### PR TITLE
Negative filter search results should not hide the top extra tablenav elements

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -1279,14 +1279,9 @@ class ReviewsListTable extends WP_List_Table {
 			$this->review_rating_dropdown( $this->current_reviews_rating );
 			$this->product_search( $this->current_product_for_reviews );
 
-			$output = ob_get_clean();
+			echo ob_get_clean(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-			if ( ! empty( $output ) && $this->has_items() ) {
-
-				echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-
-				submit_button( __( 'Filter', 'woocommerce' ), '', 'filter_action', false, [ 'id' => 'post-query-submit' ] );
-			}
+			submit_button( __( 'Filter', 'woocommerce' ), '', 'filter_action', false, [ 'id' => 'post-query-submit' ] );
 		}
 
 		if ( ( 'spam' === $comment_status || 'trash' === $comment_status ) && $this->has_items() && $this->current_user_can_moderate_reviews ) {

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -1275,6 +1275,8 @@ class ReviewsListTable extends WP_List_Table {
 
 			ob_start();
 
+			echo '<input type="hidden" name="comment_status" value="' . esc_attr( $comment_status ?? 'all' ) . '" />';
+
 			$this->review_type_dropdown( $comment_type );
 			$this->review_rating_dropdown( $this->current_reviews_rating );
 			$this->product_search( $this->current_product_for_reviews );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
@@ -1222,7 +1222,6 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			'expected_elements' => [],
 			'expected_end' => '</div>',
 			'not_expected_elements' => [
-				'<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter"',
 				'<input type="hidden" id="_destroy_nonce" name="_destroy_nonce"',
 				'<input type="hidden" name="_wp_http_referer"',
 				'<input type="submit" name="delete_all" id="delete_all" class="button apply"',
@@ -1238,7 +1237,6 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			'expected_elements' => [],
 			'expected_end' => '</div>',
 			'not_expected_elements' => [
-				'<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter"',
 				'<input type="hidden" id="_destroy_nonce" name="_destroy_nonce"',
 				'<input type="hidden" name="_wp_http_referer"',
 				'<input type="submit" name="delete_all" id="delete_all" class="button apply"',


### PR DESCRIPTION
## Summary

This PR ensures that:

* When no results are produced by a search filter, the top extra tablenav elements do not disappear
* When filtering results while viewing reviews by status, the returned results should consider the current status

Note that it should be ok to hide bulk actions when there are no results, since no bulk actions can be taken. This is coherent with other list pages behavior, including comments.

## Story [MWC-6149](https://jira.godaddy.com/browse/MWC-6149)

## QA

1. Have reviews with different star ratings and with different statuses
1. Make sure you don't have reviews with a chosen star rating (e.g. 1)
1. Go to `Products > Reviews` in admin
    - [x] All reviews should be displayed accordingly
1. Filter reviews by any star rating 2-5
    - [x] Reviews are listed accordingly
1. Filter reviews by 1 star rating
    - [x] No results are produced
    - [x] The _extra_ tablenav elements (ie no bulk actions) are still visible
1. Filter reviews while showing reviews of a specific status (e.g. trash, spam, etc.)
    - [x] The reviews are filtered while maintaining the same status view
   