### PR TITLE
Fix Empty Trash/Spam Buttons

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
@@ -632,6 +632,7 @@ class Reviews {
 
 				<input type="hidden" name="page" value="<?php echo esc_attr( $page ); ?>" />
 				<input type="hidden" name="post_type" value="product" />
+				<input type="hidden" name="pagegen_timestamp" value="<?php echo esc_attr( current_time( 'mysql', true ) ); ?>" />
 
 				<?php $this->reviews_list_table->search_box( __( 'Search Reviews', 'woocommerce' ), 'reviews' ); ?>
 

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -687,7 +687,9 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Returns the current action select in bulk actions menu
+	 * Returns the current action select in bulk actions menu.
+	 *
+	 * This is overridden in order to support `delete_all` for use in {@see ReviewsListTable::process_bulk_action()}
 	 *
 	 * @return string
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -687,6 +687,19 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Returns the current action select in bulk actions menu
+	 *
+	 * @return string
+	 */
+	public function current_action() {
+		if ( isset( $_REQUEST['delete_all'] ) || isset( $_REQUEST['delete_all2'] ) ) {
+			return 'delete_all';
+		}
+
+		return parent::current_action();
+	}
+
+	/**
 	 * Processes the bulk actions.
 	 *
 	 * @return void

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -691,7 +691,9 @@ class ReviewsListTable extends WP_List_Table {
 	 *
 	 * This is overridden in order to support `delete_all` for use in {@see ReviewsListTable::process_bulk_action()}
 	 *
-	 * @return string
+	 * {@see WP_Comments_List_Table::current_action()} for reference.
+	 *
+	 * @return string|false
 	 */
 	public function current_action() {
 		if ( isset( $_REQUEST['delete_all'] ) || isset( $_REQUEST['delete_all2'] ) ) {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
@@ -1955,4 +1955,34 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		];
 	}
 
+	/**
+	 * @testdox `current_action` is expected to return `delete_all` if certain query args are present in the request.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsListTable::current_action()
+	 * @dataProvider provider_current_action
+	 *
+	 * @param bool        $delete_all_isset   If `delete_all` isset.
+	 * @param bool        $delete_all_2_isset If `delete_all2` isset.
+	 * @param string|bool $expected           Expected result of the method.
+	 * @return void
+	 */
+	public function test_current_action( bool $delete_all_isset, bool $delete_all_2_isset, $expected ) {
+		if ( $delete_all_isset ) {
+			$_REQUEST['delete_all'] = 'Empty Trash';
+		}
+		if ( $delete_all_2_isset ) {
+			$_REQUEST['delete_all2'] = 'Empty Trash';
+		}
+
+		$this->assertSame( $expected, $this->get_reviews_list_table()->current_action() );
+	}
+
+	/** @see test_current_action */
+	public function provider_current_action(): Generator {
+		yield 'delete all isset' => [ true, false, 'delete_all' ];
+		yield 'delete all 2 isset' => [ false, true, 'delete_all' ];
+		yield 'both deletes are set' => [ true, true, 'delete_all' ];
+		yield 'neither deletes are set' => [ false, false, false ];
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
@@ -1969,9 +1969,13 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	public function test_current_action( bool $delete_all_isset, bool $delete_all_2_isset, $expected ) {
 		if ( $delete_all_isset ) {
 			$_REQUEST['delete_all'] = 'Empty Trash';
+		} else {
+			unset( $_REQUEST['delete_all'] );
 		}
 		if ( $delete_all_2_isset ) {
 			$_REQUEST['delete_all2'] = 'Empty Trash';
+		} else {
+			unset( $_REQUEST['delete_all2'] );
 		}
 
 		$this->assertSame( $expected, $this->get_reviews_list_table()->current_action() );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
@@ -277,6 +277,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( '<form id="reviews-filter" method="get">', $output );
 		$this->assertStringContainsString( '<input type="hidden" name="page" value="' . Reviews::MENU_SLUG . '" />', $output );
 		$this->assertStringContainsString( '<input type="hidden" name="post_type" value="product" />', $output );
+		$this->assertStringContainsString( '<input type="hidden" name="pagegen_timestamp" value="', $output );
 		$this->assertStringEndsWith( 'custom additional content', $output );
 
 		remove_all_filters( 'woocommerce_product_reviews_list_table' );


### PR DESCRIPTION
## Overview

This fixes the "Empty Trash" and "Empty Spam" buttons to make sure they actually do their jobs.

## Issue: [MWC-6148](https://jira.godaddy.com/browse/MWC-6148)

## QA

- [ ] Code review
- [ ] Tests pass

### User Testing

1. Have at least one review or review reply in the trash.
2. Click on the "Trash" status.
3. Click the "Empty Trash" button.
    - [ ] Item is successfully deleted.
    - [ ] You see an admin notice indicating the operation was successful.
4. Have at least one review or review reply in spam.
5. Click on the "Spam" status.
6. Click the "Empty Spam" button.
    - [ ] Item is successfully deleted.
    - [ ] You see an admin notice indicating the operation was successful.