### PR TITLE
Add update routine to purge comments count cache in 6.7.0

### DIFF
--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -209,6 +209,9 @@ class WC_Install {
 		'6.5.1' => array(
 			'wc_update_651_approved_download_directories',
 		),
+		'6.7.0' => array(
+			'wc_update_670_purge_comments_count_cache',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2435,7 +2435,7 @@ function wc_update_651_approved_download_directories() {
  * Purges the comments count cache after 6.7.0 split reviews from the comments page.
  */
 function wc_update_670_purge_comments_count_cache() {
-	if (! is_callable('WC_Comments::delete_comments_count_cache')) {
+	if ( ! is_callable( 'WC_Comments::delete_comments_count_cache' ) ) {
 		return;
 	}
 

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2430,3 +2430,14 @@ function wc_update_651_approved_download_directories() {
 	$directory_sync->init_hooks();
 	$directory_sync->init_feature( true, false );
 }
+
+/**
+ * Purges the comments count cache after 6.7.0 split reviews from the comments page.
+ */
+function wc_update_670_purge_comments_count_cache() {
+	if (! is_callable('WC_Comments::delete_comments_count_cache')) {
+		return;
+	}
+
+	WC_Comments::delete_comments_count_cache();
+}


### PR DESCRIPTION
## Summary

Introduces an upgrade routine in WooCommerce targeting v6.7.0 to clear the comments (count) cache.

### Story: [MWC-6230](https://jira.godaddy.com/browse/MWC-6230)

## Details

See https://github.com/woocommerce/woocommerce/pull/32763#pullrequestreview-992465060

## QA

- [ ] Code review